### PR TITLE
Double-entry accounting positive and negative debits and credits

### DIFF
--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -526,7 +526,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
                 balance = balance.add(subBalance);
             }
         }
-        return balance.add(mTransactionsAdapter.getTransactionsSum(accountId));
+        return balance.add(getAccount(accountId).getBalance());
     }
 
     /**

--- a/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
@@ -24,6 +24,7 @@ import android.util.Log;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.model.Transaction;
+import org.gnucash.android.model.Transaction.TransactionType;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -179,9 +180,13 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 		while (c.moveToNext()) {
 			Transaction transaction = buildTransactionInstance(c);
 			String doubleEntryAccountUID = transaction.getDoubleEntryAccountUID();
-			//negate double entry transactions for the transfer account
+			// Negate double entry transactions for the transfer account
 			if (doubleEntryAccountUID != null && doubleEntryAccountUID.equals(accountUID)){
-				transaction.setAmount(transaction.getAmount().negate());
+				if (transaction.getType() == TransactionType.DEBIT) {
+					transaction.setType(TransactionType.CREDIT);
+				} else {
+					transaction.setType(TransactionType.DEBIT);
+				}
 			}
 			transactionsList.add(transaction);
 		}

--- a/app/src/org/gnucash/android/model/Account.java
+++ b/app/src/org/gnucash/android/model/Account.java
@@ -369,10 +369,23 @@ public class Account {
 	 * @return {@link Money} aggregate amount of all transactions in account.
 	 */
 	public Money getBalance(){
-		//TODO: Consider double entry transactions
 		Money balance = new Money(new BigDecimal(0), this.mCurrency);
 		for (Transaction transaction : mTransactionsList) {
-			balance = balance.add(transaction.getAmount());
+			boolean isDebitAccount = getAccountType().hasDebitNormalBalance();
+			boolean isDebitTransaction = transaction.getType() == TransactionType.DEBIT;
+			if (isDebitAccount) {
+				if (isDebitTransaction) {
+					balance = balance.add(transaction.getAmount());
+				} else {
+					balance = balance.subtract(transaction.getAmount());
+				}
+			} else {
+				if (isDebitTransaction) {
+					balance = balance.subtract(transaction.getAmount());
+				} else {
+					balance = balance.add(transaction.getAmount());
+				}
+			}
 		}
 		return balance;
 	}

--- a/app/src/org/gnucash/android/model/Transaction.java
+++ b/app/src/org/gnucash/android/model/Transaction.java
@@ -366,7 +366,22 @@ public class Transaction {
 	public void setDoubleEntryAccountUID(String doubleEntryAccountUID) {
 		this.mDoubleEntryAccountUID = doubleEntryAccountUID;
 	}
-	
+
+	/**
+	 * Returns type of this transaction
+	 * @return Type of this transaction
+	 */
+	public TransactionType getType() {
+		return mType;
+	}
+
+	/**
+	 * Sets the type of this transaction
+	 * @param Type of this transaction
+	 */
+	public void setType(TransactionType type) {
+		mType = type;
+	}
 
 	/**
 	 * Returns UID of account to which this transaction belongs


### PR DESCRIPTION
In double-entry accounting, all transactions have a double-entry. If the transaction is a credit, then the double-entry is a debit and vice versa. Also, the transaction amount is positive or negative depending on if the account the transaction is in is a debit account or a credit account. Example: If you create a salary transaction in the income account, that should be a credit which is a positive number. If the double-entry account is a checking account, which is a debit account, it's entry should also be a positive number, not a negative number.
