### PR TITLE
Android Studio gets error if same string is defined more than once

### DIFF
--- a/app/res/values-el/strings.xml
+++ b/app/res/values-el/strings.xml
@@ -285,7 +285,6 @@
 	<string name="toast_ofx_exported_to">Αρχείο OFX εξήχθη σε:\n</string>
 	<string name="title_export_email">Εξαγωγή GnuCash OFX</string>
 	<string name="description_export_email">Εξαγωγή GnuCash OFX προς </string>
-	<string name="header_transaction_settings">Συναλλαγές</string>
 	<string name="header_transaction_settings">Κινήσεις</string>
 	<string name="title_transaction_preferences">Προτιμήσεις Κινήσεων</string>
 	<string name="title_account_preferences">Προτιμήσεις Λογαριασμών</string>


### PR DESCRIPTION
Introduced in commit 3616eff03f81de2b1ff271de810388f446bcde0e

I assume "Κινήσεις" is more correct than "Συναλλαγές" as it's in a later commit.
