### PR TITLE
Speeding up Account balance calculation

### DIFF
--- a/app/src/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -52,11 +52,14 @@ public class AccountBalanceTask extends AsyncTask<Long, Void, Money> {
 
         Money balance = Money.getZeroInstance();
         try {
-            balance = accountsDbAdapter.getAccountBalance(params[0]);
+            balance = accountsDbAdapter.getAccountBalance(accountsDbAdapter.getAccountUID(params[0]));
         } catch (IllegalArgumentException ex){
             //sometimes a load computation has been started and the data set changes.
             //the account ID may no longer exist. So we catch that exception here and do nothing
             Log.e(LOG_TAG, "Error computing account balance: " + ex);
+        } catch (Exception ex) {
+            Log.e(LOG_TAG, "Error computing account balance: " + ex);
+            ex.printStackTrace();
         }
         return balance;
     }


### PR DESCRIPTION
Calculate account balance using SQL query. Now account balance calculation is much faster. I used to have to wait quite a few seconds for the balance to come up in my big book. Now it take only a second or two. Tested with my multi-currency book and the balance shown is the same as the original approach. Didn't test when recurrence transactions are involved.

Created a new entry function taking GUID as parameter instead of rowIdx.

Now the balance is calculated in this way:
1. get the all related accounts, i.e. all descendent account of the current account whose currency is the same the parent account. 
2. Use SQL query to get the balance. The SQL statement is something like :
  `SELECT TOTAL ( CASE WHEN splits.type = 'DEBIT' THEN splits.amount ELSE - splits.amount END ) FROM splits, transactions WHERE splits.account_uid in ( accounts_list ) AND splits.transaction_uid = transactions.uid AND transaction.recurrence_period = 0`
3. adjust he returned value with the parent account's type. 

Possible draw backs may be that floating point calculation and floating point number are used in step 2, which is always bad when money is involved. However, double precision should be precise enough for this task with proper rounding, when no number more than 10e12 is involved. Don't know if any currency would need that large number. Ultimate solution would be only using integers in the database, but that will need major rewrite of the code.
