### PR TITLE
Account Currency edit restriction

### DIFF
--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -25,6 +25,7 @@ import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
 
 import android.util.Log;
+import android.support.annotation.NonNull;
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.*;
@@ -1322,4 +1323,26 @@ public class AccountsDbAdapter extends DatabaseAdapter {
         return mDb.delete(AccountEntry.TABLE_NAME, null, null);
 	}
 
+    public int getTransactionMaxSplitNum(@NonNull String accountUID) {
+        Cursor cursor = mDb.query("trans_extra_info",
+                new String[]{"MAX(trans_split_count)"},
+                "trans_acct_t_uid IN ( SELECT DISTINCT " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_UID +
+                        " FROM trans_split_acct WHERE " + AccountEntry.TABLE_NAME + "_" + AccountEntry.COLUMN_UID +
+                        " = ? )",
+                new String[]{accountUID},
+                null,
+                null,
+                null
+                );
+        try {
+            if (cursor.moveToFirst()) {
+                return (int)cursor.getLong(0);
+            } else {
+                return 0;
+            }
+        }
+        finally {
+            cursor.close();
+        }
+    }
 }

--- a/app/src/org/gnucash/android/db/DatabaseAdapter.java
+++ b/app/src/org/gnucash/android/db/DatabaseAdapter.java
@@ -164,7 +164,7 @@ public abstract class DatabaseAdapter {
                 SplitEntry.COLUMN_AMOUNT + " ELSE - " + SplitEntry.TABLE_NAME + "_" +
                 SplitEntry.COLUMN_AMOUNT + " END ) AS trans_acct_balance , COUNT ( DISTINCT " +
                 AccountEntry.TABLE_NAME + "_" + AccountEntry.COLUMN_CURRENCY +
-                " ) AS trans_currency_count FROM trans_split_acct " +
+                " ) AS trans_currency_count , COUNT (*) AS trans_split_count FROM trans_split_acct " +
                 " GROUP BY " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_UID
         );
     }

--- a/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -27,6 +27,8 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.text.TextUtils;
@@ -350,6 +352,11 @@ public class AccountFormFragment extends SherlockFragment {
 
         String currencyCode = account.getCurrency().getCurrencyCode();
         setSelectedCurrency(currencyCode);
+
+        if (mAccountsDbAdapter.getTransactionMaxSplitNum(mAccount.getUID()) > 1)
+        {
+            mCurrencySpinner.setEnabled(false);
+        }
 
         mNameEditText.setText(account.getName());
 


### PR DESCRIPTION
Account currency edit restriction discussed in #220 . Disable modification of currency for accounts that have at least one transaction with two or more splits.
