### PR TITLE
DB code refactor

### DIFF
--- a/app/src/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/org/gnucash/android/app/GnuCashApplication.java
@@ -18,9 +18,16 @@ package org.gnucash.android.app;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import org.gnucash.android.R;
+import org.gnucash.android.db.AccountsDbAdapter;
+import org.gnucash.android.db.DatabaseHelper;
+import org.gnucash.android.db.SplitsDbAdapter;
+import org.gnucash.android.db.TransactionsDbAdapter;
 
 import java.util.Currency;
 import java.util.Locale;
@@ -44,9 +51,45 @@ public class GnuCashApplication extends Application{
 
     private static Context context;
 
+    private static DatabaseHelper mDbHelper;
+
+    private static SQLiteDatabase mDb;
+
+    private static AccountsDbAdapter mAccountsDbAdapter;
+
+    private static TransactionsDbAdapter mTransactionsDbAdapter;
+
+    private static SplitsDbAdapter mSplitsDbAdapter;
+
+    @Override
     public void onCreate(){
         super.onCreate();
         GnuCashApplication.context = getApplicationContext();
+        mDbHelper = new DatabaseHelper(getApplicationContext());
+        try {
+            mDb = mDbHelper.getWritableDatabase();
+        } catch (SQLException e) {
+            Log.e(getClass().getName(), "Error getting database: " + e.getMessage());
+            mDb = mDbHelper.getReadableDatabase();
+        }
+        mSplitsDbAdapter = new SplitsDbAdapter(mDb);
+        mTransactionsDbAdapter = new TransactionsDbAdapter(mDb, mSplitsDbAdapter);
+        mAccountsDbAdapter = new AccountsDbAdapter(mDb, mTransactionsDbAdapter);
+    }
+
+    @NonNull
+    public static AccountsDbAdapter getAccountsDbAdapter() {
+        return mAccountsDbAdapter;
+    }
+
+    @NonNull
+    public static TransactionsDbAdapter getTransactionDbAdapter() {
+        return mTransactionsDbAdapter;
+    }
+
+    @NonNull
+    public static SplitsDbAdapter getSplitsDbAdapter() {
+        return mSplitsDbAdapter;
     }
 
     /**

--- a/app/src/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/org/gnucash/android/app/GnuCashApplication.java
@@ -21,7 +21,6 @@ import android.content.SharedPreferences;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.util.Log;
 import org.gnucash.android.R;
 import org.gnucash.android.db.AccountsDbAdapter;
@@ -77,17 +76,14 @@ public class GnuCashApplication extends Application{
         mAccountsDbAdapter = new AccountsDbAdapter(mDb, mTransactionsDbAdapter);
     }
 
-    @NonNull
     public static AccountsDbAdapter getAccountsDbAdapter() {
         return mAccountsDbAdapter;
     }
 
-    @NonNull
     public static TransactionsDbAdapter getTransactionDbAdapter() {
         return mTransactionsDbAdapter;
     }
 
-    @NonNull
     public static SplitsDbAdapter getSplitsDbAdapter() {
         return mSplitsDbAdapter;
     }

--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -241,7 +241,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
                 ContentValues contentValues = new ContentValues();
                 for (String acctUID : descendantAccountUIDs) {
                     Account acct = mapAccounts.get(acctUID);
-                    if (acct.getParentUID().equals(accountUID)) {
+                    if (accountUID.equals(acct.getParentUID())) {
                         // direct descendant
                         acct.setParentUID(parentAccountUID);
                         if (parentAccountFullName == null || parentAccountFullName.length() == 0) {
@@ -647,6 +647,9 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      */
     @NonNull
     public String createAccountHierarchy(@NonNull String fullName, @NonNull AccountType accountType) {
+        if ("".equals(fullName)) {
+            throw new IllegalArgumentException("fullName cannot be empty");
+        }
         String[] tokens = fullName.trim().split(ACCOUNT_NAME_SEPARATOR);
         String uid = getGnuCashRootAccountUID();
         String parentName = "";
@@ -669,6 +672,8 @@ public class AccountsDbAdapter extends DatabaseAdapter {
         if (accountsList.size() > 0) {
             bulkAddAccounts(accountsList);
         }
+        // if fullName is not empty, loop will be entered and then uid will never be null
+        //noinspection ConstantConditions
         return uid;
     }
 

--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -77,11 +77,23 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 		contentValues.put(AccountEntry.COLUMN_UID,          account.getUID());
 		contentValues.put(AccountEntry.COLUMN_CURRENCY,     account.getCurrency().getCurrencyCode());
         contentValues.put(AccountEntry.COLUMN_PLACEHOLDER,  account.isPlaceholderAccount() ? 1 : 0);
-        contentValues.put(AccountEntry.COLUMN_COLOR_CODE,   account.getColorHexCode());
+        if (account.getColorHexCode() != null) {
+            contentValues.put(AccountEntry.COLUMN_COLOR_CODE, account.getColorHexCode());
+        } else {
+            contentValues.putNull(AccountEntry.COLUMN_COLOR_CODE);
+        }
         contentValues.put(AccountEntry.COLUMN_FAVORITE,     account.isFavorite() ? 1 : 0);
         contentValues.put(AccountEntry.COLUMN_FULL_NAME,    account.getFullName());
-        contentValues.put(AccountEntry.COLUMN_PARENT_ACCOUNT_UID,           account.getParentUID());
-        contentValues.put(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID, account.getDefaultTransferAccountUID());
+        if (account.getParentUID() != null) {
+            contentValues.put(AccountEntry.COLUMN_PARENT_ACCOUNT_UID, account.getParentUID());
+        } else {
+            contentValues.putNull(AccountEntry.COLUMN_PARENT_ACCOUNT_UID);
+        }
+        if (account.getDefaultTransferAccountUID() != null) {
+            contentValues.put(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID, account.getDefaultTransferAccountUID());
+        } else {
+            contentValues.putNull(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID);
+        }
 
         Log.d(TAG, "Replace account to db");
         long rowId =  mDb.replace(AccountEntry.TABLE_NAME, null, contentValues);

--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -22,11 +22,9 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import android.util.Log;
-import android.support.annotation.NonNull;
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.*;
@@ -51,14 +49,13 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	/**
 	 * Transactions database adapter for manipulating transactions associated with accounts
 	 */
-	@NonNull
     private final TransactionsDbAdapter mTransactionsAdapter;
 
     /**
      * Overloaded constructor. Creates an adapter for an already open database
      * @param db SQliteDatabase instance
      */
-    public AccountsDbAdapter(@NonNull SQLiteDatabase db, @NonNull TransactionsDbAdapter transactionsDbAdapter) {
+    public AccountsDbAdapter(SQLiteDatabase db, TransactionsDbAdapter transactionsDbAdapter) {
         super(db);
         mTransactionsAdapter = transactionsDbAdapter;
     }
@@ -70,7 +67,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param account {@link Account} to be inserted to database
 	 * @return Database row ID of the inserted account
 	 */
-	public long addAccount(@NonNull Account account){
+	public long addAccount(Account account){
 		ContentValues contentValues = new ContentValues();
 		contentValues.put(AccountEntry.COLUMN_NAME,         account.getName());
 		contentValues.put(AccountEntry.COLUMN_TYPE,         account.getAccountType().name());
@@ -118,7 +115,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountList {@link Account} to be inserted to database
      * @return number of rows inserted
      */
-    public long bulkAddAccounts(@NonNull List<Account> accountList){
+    public long bulkAddAccounts(List<Account> accountList){
         long nRow = 0;
         try {
             mDb.beginTransaction();
@@ -167,7 +164,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID Unique ID of the record to be marked as exported
      * @return Number of records marked as exported
      */
-    public int markAsExported(@NonNull String accountUID){
+    public int markAsExported(String accountUID){
         ContentValues contentValues = new ContentValues();
         contentValues.put(TransactionEntry.COLUMN_EXPORTED, 1);
         return mDb.update(
@@ -195,7 +192,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param newValue New value to be assigned to the columnKey
      * @return Number of records affected
      */
-    public int updateAllAccounts(@NonNull String columnKey, @Nullable String newValue){
+    public int updateAllAccounts(String columnKey, String newValue){
         ContentValues contentValues = new ContentValues();
         if (newValue == null) {
             contentValues.putNull(columnKey);
@@ -212,7 +209,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param newValue  New value to be assigned to the columnKey
      * @return Number of records affected
      */
-    public int updateAccount(long accountId, @NonNull String columnKey, @Nullable String newValue){
+    public int updateAccount(long accountId, String columnKey, String newValue){
         return updateRecord(AccountEntry.TABLE_NAME, accountId, columnKey, newValue);
     }
 
@@ -306,7 +303,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param newParentUID Unique ID of new parent account
      * @return Number of records which are modified
      */
-    public int reassignParent(@NonNull String oldParentUID, @Nullable String newParentUID){
+    public int reassignParent(String oldParentUID, String newParentUID){
         ContentValues contentValues = new ContentValues();
         if (newParentUID == null)
             contentValues.putNull(AccountEntry.COLUMN_PARENT_ACCOUNT_UID);
@@ -386,8 +383,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param c Cursor pointing to account record in database
 	 * @return {@link Account} object constructed from database record
 	 */
-	@NonNull
-    public Account buildAccountInstance(@NonNull Cursor c){
+    public Account buildAccountInstance(Cursor c){
         Account account = buildSimpleAccountInstance(c);
         account.setTransactions(mTransactionsAdapter.getAllTransactionsForAccount(account.getUID()));
 
@@ -403,8 +399,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param c Cursor pointing to account record in database
      * @return {@link Account} object constructed from database record
      */
-    @NonNull
-    private Account buildSimpleAccountInstance(@NonNull Cursor c) {
+    private Account buildSimpleAccountInstance(Cursor c) {
         Account account = new Account(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_NAME)));
         String uid = c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_UID));
         account.setUID(uid);
@@ -426,8 +421,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param uid Unique Identifier of account whose parent is to be returned. Should not be null
 	 * @return DB record UID of the parent account, null if the account has no parent
 	 */
-	@Nullable
-    public String getParentAccountUID(@NonNull String uid){
+    public String getParentAccountUID(String uid){
 		Cursor cursor = mDb.query(AccountEntry.TABLE_NAME,
 				new String[] {AccountEntry._ID, AccountEntry.COLUMN_PARENT_ACCOUNT_UID},
                 AccountEntry.COLUMN_UID + " = ?",
@@ -452,7 +446,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @return DB record UID of the parent account, null if the account has no parent
      * @see #getParentAccountUID(String)
      */
-    @Nullable
     public String getParentAccountUID(long id){
         return getParentAccountUID(getAccountUID(id));
     }
@@ -462,7 +455,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param rowId Identifier of the account record to be retrieved
 	 * @return {@link Account} object corresponding to database record
 	 */
-	@NonNull
     public Account getAccount(long rowId){
 		Log.v(TAG, "Fetching account with id " + rowId);
 		Cursor c =	fetchRecord(AccountEntry.TABLE_NAME, rowId);
@@ -483,8 +475,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param uid Unique ID of the account to be retrieved
 	 * @return {@link Account} object for unique ID <code>uid</code>
 	 */
-	@NonNull
-    public Account getAccount(@NonNull String uid){
+    public Account getAccount(String uid){
 		return getAccount(getID(uid));
 	}	
 	
@@ -493,7 +484,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountId Database row ID of the account
      * @return String color code of account or null if none
      */
-    @Nullable
     public String getAccountColorCode(long accountId){
         Cursor c = mDb.query(AccountEntry.TABLE_NAME,
                 new String[]{AccountEntry._ID, AccountEntry.COLUMN_COLOR_CODE},
@@ -516,7 +506,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountId Database row ID of the account
      * @return {@link AccountType} of the account
      */
-    @NonNull
     public AccountType getAccountType(long accountId){
         return getAccountType(getAccountUID(accountId));
     }
@@ -526,7 +515,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param accountID Database ID of the account record
 	 * @return Name of the account 
 	 */
-	@NonNull
     public String getName(long accountID) {
 		Cursor c = fetchRecord(AccountEntry.TABLE_NAME, accountID);
         try {
@@ -544,7 +532,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * Returns a list of all account objects in the system
 	 * @return List of {@link Account}s in the database
 	 */
-	@NonNull
     public List<Account> getAllAccounts(){
 		LinkedList<Account> accounts = new LinkedList<Account>();
 		Cursor c = fetchAllRecords();
@@ -563,7 +550,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * No transactions are loaded, just the accounts
      * @return List of {@link Account}s in the database
      */
-    @NonNull
     public List<Account> getSimpleAccountList(){
         LinkedList<Account> accounts = new LinkedList<Account>();
         Cursor c = fetchAccounts(null, null);
@@ -584,8 +570,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * No transactions are loaded, just the accounts
      * @return List of {@link Account}s in the database
      */
-    @NonNull
-    public List<Account> getSimpleAccountList(@Nullable String where, @Nullable String[] whereArgs, @Nullable String orderBy){
+    public List<Account> getSimpleAccountList(String where, String[] whereArgs, String orderBy){
         LinkedList<Account> accounts = new LinkedList<Account>();
         Cursor c = fetchAccounts(where, whereArgs, orderBy);
         try {
@@ -602,7 +587,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * Returns a list of accounts which have transactions that have not been exported yet
 	 * @return List of {@link Account}s with unexported transactions
 	 */
-	@NonNull
     public List<Account> getExportableAccounts(){
         LinkedList<Account> accountsList = new LinkedList<Account>();
         Cursor cursor = mDb.query(
@@ -636,8 +620,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param currency Currency for the imbalance account
      * @return String unique ID of the account
      */
-    @NonNull
-    public String getOrCreateImbalanceAccountUID(@NonNull Currency currency){
+    public String getOrCreateImbalanceAccountUID(Currency currency){
         String imbalanceAccountName = getImbalanceAccountName(currency);
         String uid = findAccountUidByFullName(imbalanceAccountName);
         if (uid == null){
@@ -657,8 +640,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountType Type to assign to all accounts created
      * @return String unique ID of the account at bottom of hierarchy
      */
-    @NonNull
-    public String createAccountHierarchy(@NonNull String fullName, @NonNull AccountType accountType) {
+    public String createAccountHierarchy(String fullName, AccountType accountType) {
         if ("".equals(fullName)) {
             throw new IllegalArgumentException("fullName cannot be empty");
         }
@@ -693,7 +675,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns the unique ID of the opening balance account or creates one if necessary
      * @return String unique ID of the opening balance account
      */
-    @NonNull
     public String getOrCreateOpeningBalanceAccountUID() {
         String openingBalanceAccountName = getOpeningBalanceAccountFullName();
         String uid = findAccountUidByFullName(openingBalanceAccountName);
@@ -708,7 +689,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param fullName Fully qualified name of the account
      * @return String unique ID of the account
      */
-    @Nullable
     public String findAccountUidByFullName(String fullName){
         Cursor c = mDb.query(AccountEntry.TABLE_NAME, new String[]{AccountEntry.COLUMN_UID},
                 AccountEntry.COLUMN_FULL_NAME + "= ?", new String[]{fullName},
@@ -729,7 +709,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * GnuCash ROOT accounts are ignored
 	 * @return {@link Cursor} to all account records
 	 */
-    @NonNull
     @Override
 	public Cursor fetchAllRecords(){
 		Log.v(TAG, "Fetching all accounts from db");
@@ -747,7 +726,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * GnuCash ROOT accounts are ignored
      * @return {@link Cursor} to all account records
      */
-    @NonNull
     public Cursor fetchAllRecordsOrderedByFullName(){
         Log.v(TAG, "Fetching all accounts from db");
         String selection =  AccountEntry.COLUMN_TYPE + " != ?" ;
@@ -759,7 +737,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
                 AccountEntry.COLUMN_FULL_NAME + " ASC");
     }
 
-    @NonNull
     @Override
     public Cursor fetchRecord(long rowId) {
         return fetchRecord(AccountEntry.TABLE_NAME, rowId);
@@ -783,8 +760,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param whereArgs where args
 	 * @return Cursor set of accounts which fulfill <code>where</code>
 	 */
-    @NonNull
-	public Cursor fetchAccounts(@Nullable String where, @Nullable String[] whereArgs) {
+	public Cursor fetchAccounts(String where, String[] whereArgs) {
         Log.v(TAG, "Fetching all accounts from db where " + where);
         return mDb.query(AccountEntry.TABLE_NAME,
                 null, where, whereArgs, null, null,
@@ -799,8 +775,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param orderBy orderBy clause
      * @return Cursor set of accounts which fulfill <code>where</code>
      */
-    @NonNull
-    public Cursor fetchAccounts(@Nullable String where, @Nullable String[] whereArgs, @Nullable String orderBy){
+    public Cursor fetchAccounts(String where, String[] whereArgs, String orderBy){
         Log.v(TAG, "Fetching all accounts from db where " + where + " order by " + orderBy);
         return mDb.query(AccountEntry.TABLE_NAME,
                 null, where, whereArgs, null, null,
@@ -813,8 +788,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param whereArgs where args
      * @return Cursor set of accounts which fulfill <code>where</code>
      */
-    @NonNull
-    public Cursor fetchAccountsOrderedByFullName(@Nullable String where, @Nullable String[] whereArgs) {
+    public Cursor fetchAccountsOrderedByFullName(String where, String[] whereArgs) {
         Log.v(TAG, "Fetching all accounts from db where " + where);
         return mDb.query(AccountEntry.TABLE_NAME,
                 null, where, whereArgs, null, null,
@@ -824,7 +798,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns the balance of an account while taking sub-accounts into consideration
      * @return Account Balance of an account including sub-accounts
      */
-    @NonNull
     public Money getAccountBalance(long accountId){
         Log.d(TAG, "Computing account balance for account ID " + accountId);
         String currencyCode = getCurrencyCode(accountId);
@@ -849,8 +822,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns the balance of an account while taking sub-accounts into consideration
      * @return Account Balance of an account including sub-accounts
      */
-    @NonNull
-    public Money getAccountBalance(@NonNull String accountUID){
+    public Money getAccountBalance(String accountUID){
         Log.d(TAG, "Computing account balance for account ID " + accountUID);
         String currencyCode = mTransactionsAdapter.getCurrencyCode(accountUID);
         boolean hasDebitNormalBalance = getAccountType(accountUID).hasDebitNormalBalance();
@@ -876,8 +848,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param whereArgs  Condition args to filter accounts
      * @return The descendant accounts list.
      */
-    @NonNull
-    public List<String> getDescendantAccountUIDs(@NonNull String accountUID, @Nullable String where, @Nullable String[] whereArgs) {
+    public List<String> getDescendantAccountUIDs(String accountUID, String where, String[] whereArgs) {
         // accountsList will hold accountUID with all descendant accounts.
         // accountsListLevel will hold descendant accounts of the same level
         ArrayList<String> accountsList = new ArrayList<String>();
@@ -915,7 +886,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountId Account ID whose sub-accounts are to be retrieved
      * @return List of IDs for the sub-accounts for account <code>accountId</code>
      */
-    @NonNull
     public List<Long> getSubAccountIds(long accountId){
         List<Long> subAccounts = new ArrayList<Long>();
         String accountUID;
@@ -947,8 +917,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID GUID of the parent account
      * @return {@link Cursor} to the sub accounts data set
      */
-    @NonNull
-    public Cursor fetchSubAccounts(@NonNull String accountUID) {
+    public Cursor fetchSubAccounts(String accountUID) {
         Log.v(TAG, "Fetching sub accounts for account id " + accountUID);
         return mDb.query(AccountEntry.TABLE_NAME,
                 null,
@@ -960,7 +929,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns the top level accounts i.e. accounts with no parent or with the GnuCash ROOT account as parent
      * @return Cursor to the top level accounts
      */
-    @NonNull
     public Cursor fetchTopLevelAccounts() {
         //condition which selects accounts with no parent, whose UID is not ROOT and whose name is not ROOT
         return fetchAccounts("(" + AccountEntry.COLUMN_PARENT_ACCOUNT_UID + " IS NULL OR "
@@ -973,7 +941,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns a cursor to accounts which have recently had transactions added to them
      * @return Cursor to recently used accounts
      */
-    @NonNull
     public Cursor fetchRecentAccounts(int numberOfRecent) {
         return mDb.query(TransactionEntry.TABLE_NAME
                         + " LEFT OUTER JOIN " + SplitEntry.TABLE_NAME + " ON "
@@ -995,7 +962,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Fetches favorite accounts from the database
      * @return Cursor holding set of favorite accounts
      */
-    @NonNull
     public Cursor fetchFavoriteAccounts(){
         Log.v(TAG, "Fetching favorite accounts from db");
         String condition = AccountEntry.COLUMN_FAVORITE + " = 1";
@@ -1013,7 +979,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * <p><b>Note:</b> NULL is an acceptable response, be sure to check for it</p>
      * @return Unique ID of the GnuCash root account.
      */
-    @Nullable
     public String getGnuCashRootAccountUID() {
         Cursor cursor = fetchAccounts(AccountEntry.COLUMN_TYPE + "= ?",
                 new String[]{AccountType.ROOT.name()});
@@ -1033,7 +998,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID String Unique ID (GUID) of the account
      * @return Number of sub accounts
      */
-    public int getSubAccountCount(@NonNull String accountUID){
+    public int getSubAccountCount(String accountUID){
         //TODO: at some point when API level 11 and above only is supported, use DatabaseUtils.queryNumEntries
 
         String queryCount = "SELECT COUNT(*) FROM " + AccountEntry.TABLE_NAME + " WHERE "
@@ -1066,7 +1031,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @return Record ID belonging to account UID
 	 */
     @Override
-	public long getID(@NonNull String accountUID){
+	public long getID(String accountUID){
 		long id = -1;
 		Cursor c = mDb.query(AccountEntry.TABLE_NAME,
 				new String[]{AccountEntry._ID},
@@ -1081,7 +1046,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 		return id;
 	}
 
-    @NonNull
     @Override
     public String getUID(long id) {
         return getAccountUID(id);
@@ -1092,7 +1056,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
 	 * @param id Record ID of the account to be removed
 	 * @return Currency code of the account
 	 */
-    @NonNull
 	public String getCurrencyCode(long id){
 		return mTransactionsAdapter.getCurrencyCode(id);
 	}
@@ -1104,8 +1067,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @throws java.lang.IllegalArgumentException if accountUID does not exist
      * @see #getFullyQualifiedAccountName(String)
      */
-    @NonNull
-    public String getAccountName(@NonNull String accountUID){
+    public String getAccountName(String accountUID){
         Cursor cursor = mDb.query(AccountEntry.TABLE_NAME,
                 new String[]{AccountEntry._ID, AccountEntry.COLUMN_NAME},
                 AccountEntry.COLUMN_UID + " = ?",
@@ -1148,7 +1110,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID Unique ID of account
      * @return Fully qualified (with parent hierarchy) account name
      */
-    @NonNull
     public String getFullyQualifiedAccountName(String accountUID){
         String accountName = getAccountName(accountUID);
         String parentAccountUID = getParentAccountUID(accountUID);
@@ -1167,8 +1128,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID the account to retrieve full name
      * @return full name registered in DB
      */
-    @Nullable
-    public String getAccountFullName(@NonNull String accountUID) {
+    public String getAccountFullName(String accountUID) {
         Cursor cursor = mDb.query(AccountEntry.TABLE_NAME, new String[]{AccountEntry.COLUMN_FULL_NAME},
                 AccountEntry.COLUMN_UID + " = ?", new String[]{accountUID},
                 null, null, null);
@@ -1189,7 +1149,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountId Database record ID of account
      * @return Fully qualified (with parent hierarchy) account name
      */
-    @NonNull
     public String getFullyQualifiedAccountName(long accountId){
         return getFullyQualifiedAccountName(getAccountUID(accountId));
     }
@@ -1199,7 +1158,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param accountUID Unique identifier of the account
      * @return <code>true</code> if the account is a placeholder account, <code>false</code> otherwise
      */
-    public boolean isPlaceholderAccount(@NonNull String accountUID) {
+    public boolean isPlaceholderAccount(String accountUID) {
         Cursor cursor = mDb.query(AccountEntry.TABLE_NAME,
                 new String[]{AccountEntry.COLUMN_PLACEHOLDER},
                 AccountEntry.COLUMN_UID + " = ?",
@@ -1245,7 +1204,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
     /**
      * Updates all opening balances to the current account balances
      */
-    @NonNull
     public List<Transaction> getAllOpeningBalanceTransactions(){
         Cursor cursor = fetchAccounts(null, null);
         List<Transaction> openingTransactions = new ArrayList<Transaction>();
@@ -1286,8 +1244,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * @param currency Currency of the transaction
      * @return Imbalance account name
      */
-    @NonNull
-    public static String getImbalanceAccountName(@NonNull Currency currency){
+    public static String getImbalanceAccountName(Currency currency){
         return GnuCashApplication.getAppContext().getString(R.string.imbalance_account_name) + "-" + currency.getCurrencyCode();
     }
 
@@ -1296,7 +1253,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * For the English locale, it will be "Equity:Opening Balances"
      * @return Fully qualified account name of the opening balances account
      */
-    @NonNull
     public static String getOpeningBalanceAccountFullName(){
         Context context = GnuCashApplication.getAppContext();
         String parentEquity = context.getString(R.string.account_name_equity).trim();
@@ -1312,7 +1268,6 @@ public class AccountsDbAdapter extends DatabaseAdapter {
      * Returns the list of currencies in the database
      * @return List of currencies in the database
      */
-    @NonNull
     public List<Currency> getCurrencies(){
         Cursor cursor = mDb.query(true, AccountEntry.TABLE_NAME, new String[]{AccountEntry.COLUMN_CURRENCY},
                 null, null, null, null, null, null);
@@ -1339,7 +1294,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
         return mDb.delete(AccountEntry.TABLE_NAME, null, null);
 	}
 
-    public int getTransactionMaxSplitNum(@NonNull String accountUID) {
+    public int getTransactionMaxSplitNum(String accountUID) {
         Cursor cursor = mDb.query("trans_extra_info",
                 new String[]{"MAX(trans_split_count)"},
                 "trans_acct_t_uid IN ( SELECT DISTINCT " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_UID +

--- a/app/src/org/gnucash/android/db/DatabaseAdapter.java
+++ b/app/src/org/gnucash/android/db/DatabaseAdapter.java
@@ -19,8 +19,6 @@ package org.gnucash.android.db;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.gnucash.android.db.DatabaseSchema.*;
 import org.gnucash.android.model.AccountType;
@@ -41,14 +39,13 @@ public abstract class DatabaseAdapter {
 	/**
 	 * SQLite database
 	 */
-	@NonNull
     protected final SQLiteDatabase mDb;
 
     /**
      * Opens the database adapter with an existing database
      * @param db SQLiteDatabase object
      */
-    public DatabaseAdapter(@NonNull SQLiteDatabase db) {
+    public DatabaseAdapter(SQLiteDatabase db) {
         this.mDb = db;
         if (!db.isOpen() || db.isReadOnly())
             throw new IllegalArgumentException("Database not open or is read-only. Require writeable database");
@@ -162,8 +159,7 @@ public abstract class DatabaseAdapter {
 	 * @param rowId ID of record to be retrieved
 	 * @return {@link Cursor} to record retrieved
 	 */
-    @NonNull
-	protected Cursor fetchRecord(@NonNull String tableName, long rowId){
+	protected Cursor fetchRecord(String tableName, long rowId){
 		return mDb.query(tableName, null, DatabaseSchema.CommonColumns._ID + "=" + rowId,
 				null, null, null, null);
 	}
@@ -173,8 +169,7 @@ public abstract class DatabaseAdapter {
 	 * @param tableName Name of table in database
 	 * @return {@link Cursor} to all records in table <code>tableName</code>
 	 */
-    @NonNull
-	protected Cursor fetchAllRecords(@NonNull String tableName){
+	protected Cursor fetchAllRecords(String tableName){
 		return mDb.query(tableName, 
         		null, null, null, null, null, null);
 	}
@@ -186,7 +181,7 @@ public abstract class DatabaseAdapter {
 	 * @param rowId ID of record to be deleted
 	 * @return <code>true</code> if deletion was successful, <code>false</code> otherwise
 	 */
-	protected boolean deleteRecord(@NonNull String tableName, long rowId){
+	protected boolean deleteRecord(String tableName, long rowId){
 		return mDb.delete(tableName, DatabaseSchema.CommonColumns._ID + "=" + rowId, null) > 0;
 	}
 
@@ -194,7 +189,7 @@ public abstract class DatabaseAdapter {
      * Deletes all records in the database
      * @return Number of deleted records
      */
-    protected int deleteAllRecords(@NonNull String tableName){
+    protected int deleteAllRecords(String tableName){
         return mDb.delete(tableName, null, null);
     }
 
@@ -203,14 +198,12 @@ public abstract class DatabaseAdapter {
      * @param rowId ID of record to be retrieved
      * @return {@link Cursor} to record retrieved
      */
-    @NonNull
     public abstract Cursor fetchRecord(long rowId);
 
     /**
      * Retrieves all records from database table corresponding to this adapter
      * @return {@link Cursor} to all records in table
      */
-    @NonNull
     public abstract Cursor fetchAllRecords();
 
     /**
@@ -233,8 +226,7 @@ public abstract class DatabaseAdapter {
      * @return Currency code of the account. "" if accountUID
      *      does not exist in DB
      */
-    @NonNull
-    public String getCurrencyCode(@NonNull String accountUID) {
+    public String getCurrencyCode(String accountUID) {
         Cursor cursor = mDb.query(DatabaseSchema.AccountEntry.TABLE_NAME,
                 new String[] {DatabaseSchema.AccountEntry.COLUMN_CURRENCY},
                 DatabaseSchema.AccountEntry.COLUMN_UID + "= ?",
@@ -256,8 +248,7 @@ public abstract class DatabaseAdapter {
      * @return {@link org.gnucash.android.model.AccountType} of the account.
      * @throws java.lang.IllegalArgumentException if accountUID does not exist in DB,
      */
-    @NonNull
-    public AccountType getAccountType(@NonNull String accountUID){
+    public AccountType getAccountType(String accountUID){
         String type = "";
         Cursor c = mDb.query(DatabaseSchema.AccountEntry.TABLE_NAME,
                 new String[]{DatabaseSchema.AccountEntry.COLUMN_TYPE},
@@ -281,7 +272,6 @@ public abstract class DatabaseAdapter {
      * @return String containing UID of account
      * @throws java.lang.IllegalArgumentException if accountRowID does not exist
      */
-    @NonNull
     public String getAccountUID(long accountRowID) {
         Cursor c = mDb.query(DatabaseSchema.AccountEntry.TABLE_NAME,
                 new String[]{DatabaseSchema.AccountEntry.COLUMN_UID},
@@ -304,7 +294,7 @@ public abstract class DatabaseAdapter {
      * @return Database row ID of the account
      * @throws java.lang.IllegalArgumentException if accountUID does not exist
      */
-    public long getAccountID(@NonNull String accountUID){
+    public long getAccountID(String accountUID){
         Cursor c = mDb.query(DatabaseSchema.AccountEntry.TABLE_NAME,
                 new String[]{DatabaseSchema.AccountEntry._ID},
                 DatabaseSchema.AccountEntry.COLUMN_UID + "= ?",
@@ -325,14 +315,13 @@ public abstract class DatabaseAdapter {
      * @param uid GUID of the record
      * @return Long database identifier of the record
      */
-    public abstract long getID(@NonNull String uid);
+    public abstract long getID(String uid);
 
     /**
      * Returns the global unique identifier of the record
      * @param id Database record ID of the entry
      * @return String GUID of the record
      */
-    @NonNull
     public abstract String getUID(long id);
 
     /**
@@ -342,7 +331,7 @@ public abstract class DatabaseAdapter {
      * @param newValue  New value to be assigned to the columnKey
      * @return Number of records affected
      */
-    public int updateRecord(@NonNull String tableName, long recordId, @NonNull String columnKey, @Nullable String newValue) {
+    public int updateRecord(String tableName, long recordId, String columnKey, String newValue) {
         ContentValues contentValues = new ContentValues();
         if (newValue == null) {
             contentValues.putNull(columnKey);

--- a/app/src/org/gnucash/android/db/DatabaseCursorLoader.java
+++ b/app/src/org/gnucash/android/db/DatabaseCursorLoader.java
@@ -140,10 +140,6 @@ public abstract class DatabaseCursorLoader extends AsyncTaskLoader<Cursor> {
      */
 	protected void onReleaseResources(Cursor c) {
 		if (c != null)
-			c.close();		
-		
-		if (mDatabaseAdapter != null){
-			mDatabaseAdapter.close();
-		}
+			c.close();
 	}
 }

--- a/app/src/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/org/gnucash/android/db/MigrationHelper.java
@@ -124,7 +124,7 @@ public class MigrationHelper {
                 + "/gnucash/" + Exporter.buildExportFilename(ExportFormat.GNC_XML));
 
         //we do not use the ExporterAsyncTask here because we want to use an already open db
-        GncXmlExporter exporter = new GncXmlExporter(exportParams);
+        GncXmlExporter exporter = new GncXmlExporter(exportParams, db);
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(exportParams.getTargetFilepath()), "UTF-8"));
         try {

--- a/app/src/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/org/gnucash/android/db/MigrationHelper.java
@@ -124,7 +124,7 @@ public class MigrationHelper {
                 + "/gnucash/" + Exporter.buildExportFilename(ExportFormat.GNC_XML));
 
         //we do not use the ExporterAsyncTask here because we want to use an already open db
-        GncXmlExporter exporter = new GncXmlExporter(exportParams, db);
+        GncXmlExporter exporter = new GncXmlExporter(exportParams);
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(exportParams.getTargetFilepath()), "UTF-8"));
         try {

--- a/app/src/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/SplitsDbAdapter.java
@@ -23,6 +23,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.database.sqlite.SQLiteStatement;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
 import org.gnucash.android.model.AccountType;
@@ -48,11 +49,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
 
     protected static final String TAG = "SplitsDbAdapter";
 
-    public SplitsDbAdapter(Context context){
-        super(context);
-    }
-
-    public SplitsDbAdapter(SQLiteDatabase db) {
+    public SplitsDbAdapter(@NonNull SQLiteDatabase db) {
         super(db);
     }
 
@@ -469,7 +466,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
         Cursor cursor = fetchSplitsForTransaction(transactionUID);
         if (cursor != null){
             if (cursor.getCount() > 0){
-                result &= deleteTransaction(getTransactionID(transactionUID));
+                result = deleteTransaction(getTransactionID(transactionUID));
             }
             cursor.close();
         }

--- a/app/src/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/SplitsDbAdapter.java
@@ -22,8 +22,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import org.gnucash.android.model.AccountType;
@@ -49,7 +47,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
 
     protected static final String TAG = "SplitsDbAdapter";
 
-    public SplitsDbAdapter(@NonNull SQLiteDatabase db) {
+    public SplitsDbAdapter(SQLiteDatabase db) {
         super(db);
     }
 
@@ -59,7 +57,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param split {@link org.gnucash.android.model.Split} to be recorded in DB
      * @return Record ID of the newly saved split
      */
-    public long addSplit(@NonNull Split split){
+    public long addSplit(Split split){
         ContentValues contentValues = new ContentValues();
         contentValues.put(SplitEntry.COLUMN_UID,        split.getUID());
         contentValues.put(SplitEntry.COLUMN_AMOUNT,     split.getAmount().absolute().toPlainString());
@@ -85,7 +83,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param splitList {@link org.gnucash.android.model.Split} to be recorded in DB
      * @return Number of records of the newly saved split
      */
-    public long bulkAddSplits(@NonNull List<Split> splitList) {
+    public long bulkAddSplits(List<Split> splitList) {
         long nRow = 0;
         try {
             mDb.beginTransaction();
@@ -126,8 +124,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param cursor Cursor pointing to transaction record in database
      * @return {@link org.gnucash.android.model.Split} instance
      */
-    @NonNull
-    public Split buildSplitInstance(@NonNull Cursor cursor){
+    public Split buildSplitInstance(Cursor cursor){
         String uid          = cursor.getString(cursor.getColumnIndexOrThrow(SplitEntry.COLUMN_UID));
         String amountString = cursor.getString(cursor.getColumnIndexOrThrow(SplitEntry.COLUMN_AMOUNT));
         String typeName     = cursor.getString(cursor.getColumnIndexOrThrow(SplitEntry.COLUMN_TYPE));
@@ -153,8 +150,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param uid Unique Identifier String of the split transaction
      * @return {@link org.gnucash.android.model.Split} instance
      */
-    @NonNull
-    public Split getSplit(@NonNull String uid){
+    public Split getSplit(String uid){
         return getSplit(getID(uid));
     }
 
@@ -163,7 +159,6 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param id Database record ID of the split
      * @return {@link org.gnucash.android.model.Split} instance
      */
-    @NonNull
     public Split getSplit(long id){
         Cursor cursor = fetchRecord(id);
         try {
@@ -184,8 +179,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param accountUID String unique ID of account
      * @return Balance of the splits for this account
      */
-    @NonNull
-    public Money computeSplitBalance(@NonNull String accountUID) {
+    public Money computeSplitBalance(String accountUID) {
         Cursor cursor = fetchSplitsForAccount(accountUID);
         String currencyCode = getCurrencyCode(accountUID);
         Money splitSum = new Money("0", currencyCode);
@@ -234,8 +228,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param hasDebitNormalBalance Does the final balance has normal debit credit meaning
      * @return Balance of the splits for this account
      */
-    @NonNull
-    public Money computeSplitBalance(@NonNull List<String> accountUIDList, @NonNull String currencyCode, boolean hasDebitNormalBalance){
+    public Money computeSplitBalance(List<String> accountUIDList, String currencyCode, boolean hasDebitNormalBalance){
         //Cursor cursor = fetchSplitsForAccount(accountUID);
         if (accountUIDList.size() == 0){
             return new Money("0", currencyCode);
@@ -271,8 +264,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param transactionUID String unique ID of transaction
      * @return List of {@link org.gnucash.android.model.Split}s
      */
-    @NonNull
-    public List<Split> getSplitsForTransaction(@NonNull String transactionUID){
+    public List<Split> getSplitsForTransaction(String transactionUID){
         Cursor cursor = fetchSplitsForTransaction(transactionUID);
         List<Split> splitList = new ArrayList<Split>();
         try {
@@ -292,7 +284,6 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @see #getSplitsForTransaction(String)
      * @see #getTransactionUID(long)
      */
-    @NonNull
     public List<Split> getSplitsForTransaction(long transactionID){
         return getSplitsForTransaction(getTransactionUID(transactionID));
     }
@@ -303,8 +294,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param accountUID String unique ID of account
      * @return List of splits
      */
-    @NonNull
-    public List<Split> getSplitsForTransactionInAccount(@NonNull String transactionUID, @NonNull String accountUID){
+    public List<Split> getSplitsForTransactionInAccount(String transactionUID, String accountUID){
         Cursor cursor = fetchSplitsForTransactionAndAccount(transactionUID, accountUID);
         List<Split> splitList = new ArrayList<Split>();
         if (cursor != null){
@@ -323,8 +313,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param sortOrder Sort order for the returned records
      * @return Cursor to split records
      */
-    @NonNull
-    public Cursor fetchSplits(@Nullable String where, @Nullable String[] whereArgs, @Nullable String sortOrder){
+    public Cursor fetchSplits(String where, String[] whereArgs, String sortOrder){
         return mDb.query(SplitEntry.TABLE_NAME,
                 null, where, whereArgs, null, null, sortOrder);
     }
@@ -335,7 +324,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @return Database record ID of split
      */
     @Override
-    public long getID(@NonNull String uid){
+    public long getID(String uid){
         Cursor cursor = mDb.query(SplitEntry.TABLE_NAME,
                 new String[] {SplitEntry._ID},
                 SplitEntry.COLUMN_UID + " = ?", new String[]{uid}, null, null, null);
@@ -356,7 +345,6 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param id Database record ID of the split
      * @return String unique identifier of the split
      */
-    @NonNull
     @Override
     public String getUID(long id){
         Cursor cursor = mDb.query(SplitEntry.TABLE_NAME,
@@ -378,8 +366,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param transactionUID Unique idendtifier of the transaction
      * @return Cursor to splits
      */
-    @NonNull
-    public Cursor fetchSplitsForTransaction(@NonNull String transactionUID){
+    public Cursor fetchSplitsForTransaction(String transactionUID){
         Log.v(TAG, "Fetching all splits for transaction UID " + transactionUID);
         return mDb.query(SplitEntry.TABLE_NAME,
                 null, SplitEntry.COLUMN_TRANSACTION_UID + " = ?",
@@ -392,8 +379,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param accountUID String unique ID of account
      * @return Cursor containing splits dataset
      */
-    @NonNull
-    public Cursor fetchSplitsForAccount(@NonNull String accountUID){
+    public Cursor fetchSplitsForAccount(String accountUID){
         Log.d(TAG, "Fetching all splits for account UID " + accountUID);
 
         //This is more complicated than a simple "where account_uid=?" query because
@@ -420,8 +406,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param accountUID String unique ID of account
      * @return Cursor to splits data set
      */
-    @Nullable
-    public Cursor fetchSplitsForTransactionAndAccount(@Nullable String transactionUID, @Nullable String accountUID){
+    public Cursor fetchSplitsForTransactionAndAccount(String transactionUID, String accountUID){
         if (transactionUID == null || accountUID == null)
             return null;
 
@@ -439,7 +424,6 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param transactionId Database record ID of the transaction
      * @return String unique ID of the transaction or null if transaction with the ID cannot be found.
      */
-    @NonNull
     public String getTransactionUID(long transactionId){
         Cursor cursor = mDb.query(TransactionEntry.TABLE_NAME,
                 new String[]{TransactionEntry.COLUMN_UID},
@@ -457,13 +441,11 @@ public class SplitsDbAdapter extends DatabaseAdapter {
         }
     }
 
-    @NonNull
     @Override
     public Cursor fetchRecord(long rowId) {
         return fetchRecord(SplitEntry.TABLE_NAME, rowId);
     }
 
-    @NonNull
     @Override
     public Cursor fetchAllRecords() {
         return fetchAllRecords(SplitEntry.TABLE_NAME);
@@ -496,7 +478,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param uid String unique ID of split
      * @return <code>true</code> if the split was deleted, <code>false</code> otherwise
      */
-    public boolean deleteSplit(@NonNull String uid) {
+    public boolean deleteSplit(String uid) {
         long id = getID(uid);
         return deleteRecord(id);
     }
@@ -506,7 +488,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param transactionUID Unique idendtifier of the transaction
      * @return Database record ID for the transaction
      */
-    public long getTransactionID(@NonNull String transactionUID) {
+    public long getTransactionID(String transactionUID) {
         Cursor c = mDb.query(TransactionEntry.TABLE_NAME,
                 new String[]{TransactionEntry._ID},
                 TransactionEntry.COLUMN_UID + "=?",
@@ -542,7 +524,7 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param accountUID String unique ID of account
      * @return Number of records deleted
      */
-    public int deleteSplitsForTransactionAndAccount(@NonNull String transactionUID, @NonNull String accountUID){
+    public int deleteSplitsForTransactionAndAccount(String transactionUID, String accountUID){
         int deletedCount = mDb.delete(SplitEntry.TABLE_NAME,
                 SplitEntry.COLUMN_TRANSACTION_UID + "= ? AND " + SplitEntry.COLUMN_ACCOUNT_UID + "= ?",
                 new String[]{transactionUID, accountUID});

--- a/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
@@ -25,8 +25,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.database.sqlite.SQLiteStatement;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.gnucash.android.app.GnuCashApplication;
@@ -45,19 +43,17 @@ import java.util.List;
  */
 public class TransactionsDbAdapter extends DatabaseAdapter {
 
-    @NonNull
     private final SplitsDbAdapter mSplitsDbAdapter;
 
     /**
      * Overloaded constructor. Creates adapter for already open db
      * @param db SQlite db instance
      */
-    public TransactionsDbAdapter(@NonNull SQLiteDatabase db, @NonNull SplitsDbAdapter splitsDbAdapter) {
+    public TransactionsDbAdapter(SQLiteDatabase db, SplitsDbAdapter splitsDbAdapter) {
         super(db);
         mSplitsDbAdapter = splitsDbAdapter;
     }
 
-    @NonNull
     public SplitsDbAdapter getSplitDbAdapter() {
         return mSplitsDbAdapter;
     }
@@ -69,7 +65,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param transaction {@link Transaction} to be inserted to database
 	 * @return Database row ID of the inserted transaction
 	 */
-	public long addTransaction(@NonNull Transaction transaction){
+	public long addTransaction(Transaction transaction){
 		ContentValues contentValues = new ContentValues();
 		contentValues.put(TransactionEntry.COLUMN_DESCRIPTION, transaction.getDescription());
 		contentValues.put(TransactionEntry.COLUMN_UID,          transaction.getUID());
@@ -101,7 +97,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param transactionList {@link Transaction} transactions to be inserted to database
      * @return Number of transactions inserted
      */
-    public long bulkAddTransactions(@NonNull List<Transaction> transactionList){
+    public long bulkAddTransactions(List<Transaction> transactionList){
         List<Split> splitList = new ArrayList<Split>(transactionList.size()*3);
         long rowInserted = 0;
         try {
@@ -158,7 +154,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param uid Unique Identifier of transaction to be retrieved
 	 * @return Database row ID of transaction with UID <code>uid</code>
 	 */
-	public long fetchTransactionWithUID(@NonNull String uid){
+	public long fetchTransactionWithUID(String uid){
 		Cursor cursor = mDb.query(TransactionEntry.TABLE_NAME,
 				new String[] {TransactionEntry._ID},
                 TransactionEntry.COLUMN_UID + " = ?",
@@ -180,7 +176,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param rowId Identifier of the transaction record to be retrieved
 	 * @return {@link Transaction} object corresponding to database record
 	 */
-	@NonNull
     public Transaction getTransaction(long rowId) {
         Log.v(TAG, "Fetching transaction with id " + rowId);
         Cursor c = fetchRecord(TransactionEntry.TABLE_NAME, rowId);
@@ -203,8 +198,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @return Cursor holding set of transactions for particular account
      * @throws java.lang.IllegalArgumentException if the accountUID is null
 	 */
-    @NonNull
-	public Cursor fetchAllTransactionsForAccount(@NonNull String accountUID){
+	public Cursor fetchAllTransactionsForAccount(String accountUID){
         if (mDb.getVersion() < DatabaseSchema.SPLITS_DB_VERSION){ //legacy from previous database format
             return mDb.query(TransactionEntry.TABLE_NAME, null,
                     "((" + SplitEntry.COLUMN_ACCOUNT_UID + " = '" + accountUID + "') "
@@ -234,7 +228,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * They are not considered when computing account balances</p>
      * @return Cursor holding set of all recurring transactions
      */
-    @NonNull
     public Cursor fetchAllRecurringTransactions(){
         return mDb.query(TransactionEntry.TABLE_NAME,
                 null,
@@ -249,7 +242,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param accountID ID of the account whose transactions are to be retrieved
 	 * @return Cursor holding set of transactions for particular account
 	 */
-    @NonNull
 	public Cursor fetchAllTransactionsForAccount(long accountID){
 		return fetchAllTransactionsForAccount(getAccountUID(accountID));
 	}
@@ -259,8 +251,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param accountUID UID of account whose transactions are to be retrieved
 	 * @return List of {@link Transaction}s for account with UID <code>accountUID</code>
 	 */
-	@NonNull
-    public List<Transaction> getAllTransactionsForAccount(@NonNull String accountUID){
+    public List<Transaction> getAllTransactionsForAccount(String accountUID){
 		Cursor c = fetchAllTransactionsForAccount(accountUID);
 		ArrayList<Transaction> transactionsList = new ArrayList<Transaction>();
         try {
@@ -277,7 +268,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * Returns all transaction instances in the database.
      * @return List of all transactions
      */
-    @NonNull
     public List<Transaction> getAllTransactions(){
         Cursor cursor = fetchAllRecords();
         List<Transaction> transactions = new ArrayList<Transaction>();
@@ -291,8 +281,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
         return transactions;
     }
 
-    @NonNull
-    public Cursor fetchTransactionsWithSplits(@Nullable String [] columns, @Nullable String where, @Nullable String[] whereArgs, @NonNull String orderBy) {
+    public Cursor fetchTransactionsWithSplits(String [] columns, String where, String[] whereArgs, String orderBy) {
         return mDb.query(TransactionEntry.TABLE_NAME + " , " + SplitEntry.TABLE_NAME +
                         " ON " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_UID +
                         " = " + SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_TRANSACTION_UID,
@@ -300,8 +289,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
                 orderBy);
     }
 
-    @NonNull
-    public Cursor fetchTransactionsWithSplitsWithTransactionAccount(@Nullable String [] columns, @Nullable String where, @Nullable String[] whereArgs, @Nullable String orderBy) {
+    public Cursor fetchTransactionsWithSplitsWithTransactionAccount(String [] columns, String where, String[] whereArgs, String orderBy) {
         // table is :
         // trans_split_acct , trans_extra_info ON trans_extra_info.trans_acct_t_uid = transactions_uid ,
         // accounts AS account1 ON account1.uid = trans_extra_info.trans_acct_a_uid
@@ -342,8 +330,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param c Cursor pointing to transaction record in database
 	 * @return {@link Transaction} object constructed from database record
 	 */
-	@NonNull
-    public Transaction buildTransactionInstance(@NonNull Cursor c){
+    public Transaction buildTransactionInstance(Cursor c){
 		String name   = c.getString(c.getColumnIndexOrThrow(TransactionEntry.COLUMN_DESCRIPTION));
 		Transaction transaction = new Transaction(name);
 		transaction.setUID(c.getString(c.getColumnIndexOrThrow(TransactionEntry.COLUMN_UID)));
@@ -389,7 +376,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @return Currency code of the account with Id <code>accountId</code>
 	 * @see #getCurrencyCode(String)
 	 */
-	@NonNull
     public String getCurrencyCode(long accountId){
 		String accountUID = getAccountUID(accountId);
 		return getCurrencyCode(accountUID);
@@ -402,8 +388,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param accountUID GUID of the account
      * @return {@link org.gnucash.android.model.Money} balance of the transaction for that account
      */
-    @NonNull
-    public Money getBalance(@NonNull String transactionUID, @NonNull String accountUID){
+    public Money getBalance(String transactionUID, String accountUID){
         List<Split> splitList = mSplitsDbAdapter.getSplitsForTransactionInAccount(
                 transactionUID, accountUID);
 
@@ -415,7 +400,6 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param transactionId Database record ID of transaction
      * @return String unique identifier of the transaction
      */
-    @NonNull
     @Override
     public String getUID(long transactionId) {
         Cursor c = mDb.query(TransactionEntry.TABLE_NAME,
@@ -450,7 +434,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param uid String unique ID of transaction
 	 * @return <code>true</code> if deletion was successful, <code>false</code> otherwise
 	 */
-	public boolean deleteTransaction(@NonNull String uid){
+	public boolean deleteTransaction(String uid){
         return deleteRecord(getID(uid));
 	}
 	
@@ -470,7 +454,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
 	 * @param dstAccountUID GUID of the account to which the transaction will be assigned
 	 * @return Number of transactions splits affected
 	 */
-	public int moveTransaction(@NonNull String transactionUID, @NonNull String srcAccountUID, @NonNull String dstAccountUID){
+	public int moveTransaction(String transactionUID, String srcAccountUID, String dstAccountUID){
 		Log.i(TAG, "Moving transaction ID " + transactionUID
                 + " splits from " + srcAccountUID + " to account " + dstAccountUID);
 
@@ -513,7 +497,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @return Database record ID for the transaction
      */
     @Override
-    public long getID(@NonNull String transactionUID){
+    public long getID(String transactionUID){
         Cursor c = mDb.query(TransactionEntry.TABLE_NAME,
                 new String[]{TransactionEntry._ID},
                 TransactionEntry.COLUMN_UID + "='" + transactionUID + "'",
@@ -529,13 +513,11 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
         }
     }
 
-    @NonNull
     @Override
     public Cursor fetchAllRecords() {
         return fetchAllRecords(TransactionEntry.TABLE_NAME);
     }
 
-    @NonNull
     @Override
     public Cursor fetchRecord(long rowId) {
         return fetchRecord(TransactionEntry.TABLE_NAME, rowId);
@@ -547,8 +529,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param prefix Starting characters of the transaction name
      * @return Cursor to the data set containing all matching transactions
      */
-    @NonNull
-    public Cursor fetchTransactionsStartingWith(@NonNull String prefix){
+    public Cursor fetchTransactionsStartingWith(String prefix){
         return mDb.query(TransactionEntry.TABLE_NAME,
                 new String[]{TransactionEntry._ID, TransactionEntry.COLUMN_DESCRIPTION},
                 TransactionEntry.COLUMN_DESCRIPTION + " LIKE '" + prefix + "%'",
@@ -563,11 +544,11 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param newValue  New value to be assigned to the columnKey
      * @return Number of records affected
      */
-    public int updateTransaction(@NonNull String transactionUID, @NonNull String columnKey, @Nullable String newValue){
+    public int updateTransaction(String transactionUID, String columnKey, String newValue){
         return updateRecord(TransactionEntry.TABLE_NAME, getID(transactionUID), columnKey, newValue);
     }
 
-    public int updateTransaction(@NonNull ContentValues contentValues, @Nullable String whereClause, @Nullable String[] whereArgs){
+    public int updateTransaction(ContentValues contentValues, String whereClause, String[] whereArgs){
         return mDb.update(TransactionEntry.TABLE_NAME, contentValues, whereClause, whereArgs);
     }
 
@@ -576,7 +557,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * The interval period is packaged within the transaction
      * @param recurringTransaction Transaction which is to be recurring
      */
-    public void scheduleTransaction(@NonNull Transaction recurringTransaction) {
+    public void scheduleTransaction(Transaction recurringTransaction) {
         long recurrencePeriodMillis = recurringTransaction.getRecurrencePeriod();
         long firstRunMillis = System.currentTimeMillis() + recurrencePeriodMillis;
         long recurringTransactionId = addTransaction(recurringTransaction);
@@ -593,12 +574,11 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
      * @param transactionUID GUID of the transaction
      * @return Retrieves a transaction from the database
      */
-    @NonNull
-    public Transaction getTransaction(@NonNull String transactionUID) {
+    public Transaction getTransaction(String transactionUID) {
         return getTransaction(getID(transactionUID));
     }
 
-    public int getNumCurrencies(@NonNull String transactionUID) {
+    public int getNumCurrencies(String transactionUID) {
         Cursor cursor = mDb.query("trans_extra_info",
                 new String[]{"trans_currency_count"},
                 "trans_acct_t_uid=?",

--- a/app/src/org/gnucash/android/export/ExportDialogFragment.java
+++ b/app/src/org/gnucash/android/export/ExportDialogFragment.java
@@ -151,7 +151,8 @@ public class ExportDialogFragment extends DialogFragment {
 	 */
 	private void bindViews(){		
 		View v = getView();
-		mDestinationSpinner = (Spinner) v.findViewById(R.id.spinner_export_destination);
+        assert v != null;
+        mDestinationSpinner = (Spinner) v.findViewById(R.id.spinner_export_destination);
 		ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(getActivity(),
 		        R.array.export_destinations, android.R.layout.simple_spinner_item);		
 		adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);		

--- a/app/src/org/gnucash/android/export/Exporter.java
+++ b/app/src/org/gnucash/android/export/Exporter.java
@@ -20,10 +20,13 @@ package org.gnucash.android.export;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Environment;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
+import org.gnucash.android.db.SplitsDbAdapter;
+import org.gnucash.android.db.TransactionsDbAdapter;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -58,13 +61,26 @@ public abstract class Exporter {
      * Adapter for retrieving accounts to export
      * Subclasses should close this object when they are done with exporting
      */
+    @NonNull
     protected AccountsDbAdapter mAccountsDbAdapter;
+    @NonNull
+    protected TransactionsDbAdapter mTransactionsDbAdapter;
+    @NonNull
+    protected SplitsDbAdapter mSplitsDbAdapter;
     protected Context mContext;
 
-    public Exporter(ExportParams params){
+    public Exporter(ExportParams params, @Nullable SQLiteDatabase db) {
         this.mParameters = params;
         mContext = GnuCashApplication.getAppContext();
-        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+        if (db == null) {
+            mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+            mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
+            mSplitsDbAdapter = GnuCashApplication.getSplitsDbAdapter();
+        } else {
+            mSplitsDbAdapter = new SplitsDbAdapter(db);
+            mTransactionsDbAdapter = new TransactionsDbAdapter(db, mSplitsDbAdapter);
+            mAccountsDbAdapter = new AccountsDbAdapter(db, mTransactionsDbAdapter);
+        }
     }
 
     /**

--- a/app/src/org/gnucash/android/export/Exporter.java
+++ b/app/src/org/gnucash/android/export/Exporter.java
@@ -62,18 +62,7 @@ public abstract class Exporter {
     public Exporter(ExportParams params){
         this.mParameters = params;
         mContext = GnuCashApplication.getAppContext();
-        mAccountsDbAdapter = new AccountsDbAdapter(mContext);
-    }
-
-    /**
-     * Overloaded constructor, provided the database object to use
-     * @param params Export parameters
-     * @param db Database from which to export (should be initialized and open)
-     */
-    public Exporter(ExportParams params, SQLiteDatabase db){
-        this.mParameters = params;
-        mAccountsDbAdapter = new AccountsDbAdapter(db);
-        mContext = GnuCashApplication.getAppContext();
+        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
     }
 
     /**

--- a/app/src/org/gnucash/android/export/Exporter.java
+++ b/app/src/org/gnucash/android/export/Exporter.java
@@ -20,6 +20,8 @@ package org.gnucash.android.export;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Environment;
+import android.support.annotation.Nullable;
+
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 
@@ -103,6 +105,7 @@ public abstract class Exporter {
      * @return Last modified file from backup folder
      * @see #BACKUP_FOLDER_PATH
      */
+    @Nullable
     public static File getMostRecentBackupFile(){
         File backupFolder = new File(BACKUP_FOLDER_PATH);
         if (!backupFolder.exists())

--- a/app/src/org/gnucash/android/export/Exporter.java
+++ b/app/src/org/gnucash/android/export/Exporter.java
@@ -20,8 +20,6 @@ package org.gnucash.android.export;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Environment;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
@@ -61,15 +59,12 @@ public abstract class Exporter {
      * Adapter for retrieving accounts to export
      * Subclasses should close this object when they are done with exporting
      */
-    @NonNull
     protected AccountsDbAdapter mAccountsDbAdapter;
-    @NonNull
     protected TransactionsDbAdapter mTransactionsDbAdapter;
-    @NonNull
     protected SplitsDbAdapter mSplitsDbAdapter;
     protected Context mContext;
 
-    public Exporter(ExportParams params, @Nullable SQLiteDatabase db) {
+    public Exporter(ExportParams params, SQLiteDatabase db) {
         this.mParameters = params;
         mContext = GnuCashApplication.getAppContext();
         if (db == null) {
@@ -121,7 +116,6 @@ public abstract class Exporter {
      * @return Last modified file from backup folder
      * @see #BACKUP_FOLDER_PATH
      */
-    @Nullable
     public static File getMostRecentBackupFile(){
         File backupFolder = new File(BACKUP_FOLDER_PATH);
         if (!backupFolder.exists())

--- a/app/src/org/gnucash/android/export/ExporterAsyncTask.java
+++ b/app/src/org/gnucash/android/export/ExporterAsyncTask.java
@@ -257,8 +257,7 @@ public class ExporterAsyncTask extends AsyncTask<ExportParams, Void, Boolean> {
             } finally {
                 if (inChannel != null)
                     inChannel.close();
-                if (outChannel != null)
-                    outChannel.close();
+                outChannel.close();
             }
         }
     }

--- a/app/src/org/gnucash/android/export/ofx/OfxExporter.java
+++ b/app/src/org/gnucash/android/export/ofx/OfxExporter.java
@@ -22,10 +22,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.List;
 
-import android.database.sqlite.SQLiteDatabase;
 import android.preference.PreferenceManager;
 import org.gnucash.android.R;
-import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.export.ExportParams;
 import org.gnucash.android.export.Exporter;
 import org.gnucash.android.model.Account;
@@ -59,7 +57,7 @@ public class OfxExporter extends Exporter{
 	 * Builds an XML representation of the {@link Account}s and {@link Transaction}s in the database
 	 */
 	public OfxExporter(ExportParams params) {
-        super(params);
+        super(params, null);
 	}
 
     /**
@@ -80,7 +78,7 @@ public class OfxExporter extends Exporter{
 		
 		parent.appendChild(bankmsgs);		
 		
-		AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+		AccountsDbAdapter accountsDbAdapter = mAccountsDbAdapter;
 		for (Account account : mAccountsList) {		
 			if (account.getTransactionCount() == 0)
 				continue; 

--- a/app/src/org/gnucash/android/export/ofx/OfxExporter.java
+++ b/app/src/org/gnucash/android/export/ofx/OfxExporter.java
@@ -25,6 +25,7 @@ import java.util.List;
 import android.database.sqlite.SQLiteDatabase;
 import android.preference.PreferenceManager;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.export.ExportParams;
 import org.gnucash.android.export.Exporter;
 import org.gnucash.android.model.Account;
@@ -62,15 +63,6 @@ public class OfxExporter extends Exporter{
 	}
 
     /**
-     * Initializes the OFX exporter with a specific database to export from
-     * @param params Export parameters/options
-     * @param db SQLite database object (should be already open)
-     */
-    public OfxExporter(ExportParams params, SQLiteDatabase db){
-        super(params, db);
-    }
-
-    /**
 	 * Converts all expenses into OFX XML format and adds them to the XML document
 	 * @param doc DOM document of the OFX expenses.
 	 * @param parent Parent node for all expenses in report
@@ -88,7 +80,7 @@ public class OfxExporter extends Exporter{
 		
 		parent.appendChild(bankmsgs);		
 		
-		AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(mContext);
+		AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 		for (Account account : mAccountsList) {		
 			if (account.getTransactionCount() == 0)
 				continue; 
@@ -100,13 +92,11 @@ public class OfxExporter extends Exporter{
 			accountsDbAdapter.markAsExported(account.getUID());
 			
 		}
-		accountsDbAdapter.close();
 	}
 
     public String generateExport() throws ExporterException {
         mAccountsList = mParameters.shouldExportAllTransactions() ?
                 mAccountsDbAdapter.getAllAccounts() : mAccountsDbAdapter.getExportableAccounts();
-        mAccountsDbAdapter.close();
 
         DocumentBuilderFactory docFactory = DocumentBuilderFactory
                 .newInstance();

--- a/app/src/org/gnucash/android/export/qif/QifExporter.java
+++ b/app/src/org/gnucash/android/export/qif/QifExporter.java
@@ -45,14 +45,10 @@ public class QifExporter extends Exporter{
         super(params);
     }
 
-    public QifExporter(ExportParams params,  SQLiteDatabase db){
-        super(params, db);
-    }
-
     @Override
     public void generateExport(Writer writer) throws ExporterException {
         final String newLine = "\n";
-        TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(GnuCashApplication.getAppContext());
+        TransactionsDbAdapter transactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
         try {
             Cursor cursor = transactionsDbAdapter.fetchTransactionsWithSplitsWithTransactionAccount(
                     new String[]{
@@ -173,9 +169,6 @@ public class QifExporter extends Exporter{
         catch (IOException e)
         {
             throw new ExporterException(mParameters, e);
-        }
-        finally {
-            transactionsDbAdapter.close();
         }
     }
 }

--- a/app/src/org/gnucash/android/export/qif/QifExporter.java
+++ b/app/src/org/gnucash/android/export/qif/QifExporter.java
@@ -18,16 +18,13 @@ package org.gnucash.android.export.qif;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 
-import org.gnucash.android.app.GnuCashApplication;
 import static org.gnucash.android.db.DatabaseSchema.*;
 
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.db.TransactionsDbAdapter;
 import org.gnucash.android.export.ExportParams;
 import org.gnucash.android.export.Exporter;
-import org.gnucash.android.model.Account;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -42,13 +39,13 @@ import java.util.Currency;
  */
 public class QifExporter extends Exporter{
     public QifExporter(ExportParams params){
-        super(params);
+        super(params, null);
     }
 
     @Override
     public void generateExport(Writer writer) throws ExporterException {
         final String newLine = "\n";
-        TransactionsDbAdapter transactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
+        TransactionsDbAdapter transactionsDbAdapter = mTransactionsDbAdapter;
         try {
             Cursor cursor = transactionsDbAdapter.fetchTransactionsWithSplitsWithTransactionAccount(
                     new String[]{

--- a/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -21,6 +21,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.DatabaseSchema;
 import static org.gnucash.android.db.DatabaseSchema.*;
 import org.gnucash.android.db.TransactionsDbAdapter;
@@ -62,18 +63,7 @@ public class GncXmlExporter extends Exporter{
 
     public GncXmlExporter(ExportParams params){
         super(params);
-        mTransactionsDbAdapter = new TransactionsDbAdapter(mContext);
-    }
-
-    /**
-     * Overloaded constructor.
-     * <p>This method is used mainly by the {@link org.gnucash.android.db.DatabaseHelper} for database migrations</p>
-     * @param params Export parameters
-     * @param db SQLite database from which to export
-     */
-    public GncXmlExporter(ExportParams params, SQLiteDatabase db){
-        super(params, db);
-        mTransactionsDbAdapter = new TransactionsDbAdapter(db);
+        mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
     }
 
     private void exportSlots(XmlSerializer xmlSerializer,
@@ -491,8 +481,6 @@ public class GncXmlExporter extends Exporter{
         }
 
         document.appendChild(rootElement);
-        mAccountsDbAdapter.close();
-        mTransactionsDbAdapter.close();
 
         StringWriter stringWriter = new StringWriter();
         try {

--- a/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -18,12 +18,12 @@
 package org.gnucash.android.export.xml;
 
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
-import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.DatabaseSchema;
 import static org.gnucash.android.db.DatabaseSchema.*;
-import org.gnucash.android.db.TransactionsDbAdapter;
+
 import org.gnucash.android.export.ExportFormat;
 import org.gnucash.android.export.ExportParams;
 import org.gnucash.android.export.Exporter;
@@ -58,11 +58,12 @@ import java.util.zip.GZIPOutputStream;
  */
 public class GncXmlExporter extends Exporter{
 
-    private TransactionsDbAdapter mTransactionsDbAdapter;
+    public GncXmlExporter(ExportParams params) {
+        super(params, null);
+    }
 
-    public GncXmlExporter(ExportParams params){
-        super(params);
-        mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
+    public GncXmlExporter(ExportParams params, SQLiteDatabase db) {
+        super(params, db);
     }
 
     private void exportSlots(XmlSerializer xmlSerializer,

--- a/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -18,7 +18,6 @@
 package org.gnucash.android.export.xml;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 import org.gnucash.android.app.GnuCashApplication;
@@ -184,7 +183,7 @@ public class GncXmlExporter extends Exporter{
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_TYPE + " AS split_type",
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_AMOUNT + " AS split_amount",
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_ACCOUNT_UID + " AS split_acct_uid"
-                }, null,
+                }, null, null,
                 TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_RECURRENCE_PERIOD + " ASC , " +
                         TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " ASC , " +
                         TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_UID + " ASC ");
@@ -454,19 +453,20 @@ public class GncXmlExporter extends Exporter{
         bookNode.appendChild(transactionCountNode);
 
         String rootAccountUID = mAccountsDbAdapter.getGnuCashRootAccountUID();
-        Account rootAccount = mAccountsDbAdapter.getAccount(rootAccountUID);
-        if (rootAccount != null){
+        if (rootAccountUID != null) {
+            Account rootAccount = mAccountsDbAdapter.getAccount(rootAccountUID);
             rootAccount.toGncXml(document, bookNode);
         }
         Cursor accountsCursor = mAccountsDbAdapter.fetchAllRecordsOrderedByFullName();
 
         //create accounts hierarchically by ordering by full name
-        if (accountsCursor != null){
-            while (accountsCursor.moveToNext()){
+        try {
+            while (accountsCursor.moveToNext()) {
                 long id = accountsCursor.getLong(accountsCursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry._ID));
                 Account account = mAccountsDbAdapter.getAccount(id);
                 account.toGncXml(document, bookNode);
             }
+        } finally {
             accountsCursor.close();
         }
 

--- a/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -472,11 +472,12 @@ public class GncXmlExporter extends Exporter{
 
         //more memory efficient approach than loading all transactions into memory first
         Cursor transactionsCursor = mTransactionsDbAdapter.fetchAllRecords();
-        if (transactionsCursor != null){
-            while (transactionsCursor.moveToNext()){
+        try {
+            while (transactionsCursor.moveToNext()) {
                 Transaction transaction = mTransactionsDbAdapter.buildTransactionInstance(transactionsCursor);
                 transaction.toGncXml(document, bookNode);
             }
+        } finally {
             transactionsCursor.close();
         }
 

--- a/app/src/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/org/gnucash/android/importer/GncXmlHandler.java
@@ -19,8 +19,6 @@ package org.gnucash.android.importer;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.SplitsDbAdapter;
@@ -123,11 +121,11 @@ public class GncXmlHandler extends DefaultHandler {
         init(bulk, null);
     }
 
-    public GncXmlHandler(boolean bulk, @NonNull SQLiteDatabase db) {
+    public GncXmlHandler(boolean bulk, SQLiteDatabase db) {
         init(bulk, db);
     }
 
-    private void init(boolean bulk, @Nullable SQLiteDatabase db) {
+    private void init(boolean bulk, SQLiteDatabase db) {
         if (db == null) {
             mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
             mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();

--- a/app/src/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/org/gnucash/android/importer/GncXmlHandler.java
@@ -123,8 +123,8 @@ public class GncXmlHandler extends DefaultHandler {
 
     private void init(Context context, boolean bulk) {
         mContext = context;
-        mAccountsDbAdapter = new AccountsDbAdapter(mContext);
-        mTransactionsDbAdapter = new TransactionsDbAdapter(mContext);
+        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+        mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
         mContent = new StringBuilder();
         mBulk = bulk;
         if (bulk) {
@@ -133,15 +133,8 @@ public class GncXmlHandler extends DefaultHandler {
         }
     }
 
-    /**
-     * Instantiates handler to parse XML into already open db
-     * @param db SQLite Database
-     */
-    public GncXmlHandler(SQLiteDatabase db){
-        mContext = GnuCashApplication.getAppContext();
-        mAccountsDbAdapter = new AccountsDbAdapter(db);
-        mTransactionsDbAdapter = new TransactionsDbAdapter(db);
-        mContent = new StringBuilder();
+    public GncXmlHandler(){
+        init(GnuCashApplication.getAppContext(), false);
     }
 
     @Override
@@ -402,7 +395,5 @@ public class GncXmlHandler extends DefaultHandler {
             long endTime = System.nanoTime();
             Log.d("Handler:", String.format(" bulk insert time: %d", endTime - startTime));
         }
-        mAccountsDbAdapter.close();
-        mTransactionsDbAdapter.close();
     }
 }

--- a/app/src/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/org/gnucash/android/importer/GncXmlHandler.java
@@ -19,8 +19,11 @@ package org.gnucash.android.importer;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.db.SplitsDbAdapter;
 import org.gnucash.android.db.TransactionsDbAdapter;
 import org.gnucash.android.export.xml.GncXmlHelper;
 import org.gnucash.android.model.*;
@@ -110,31 +113,34 @@ public class GncXmlHandler extends DefaultHandler {
     boolean mInDefaultTransferAccount = false;
     boolean mInExported         = false;
 
-    private Context mContext;
     private TransactionsDbAdapter mTransactionsDbAdapter;
 
-    public GncXmlHandler(Context context) {
-        init(context, false);
+    public GncXmlHandler() {
+        init(false, null);
     }
 
-    public GncXmlHandler(Context context, boolean bulk) {
-        init(context, bulk);
+    public GncXmlHandler(boolean bulk) {
+        init(bulk, null);
     }
 
-    private void init(Context context, boolean bulk) {
-        mContext = context;
-        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
-        mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
+    public GncXmlHandler(boolean bulk, @NonNull SQLiteDatabase db) {
+        init(bulk, db);
+    }
+
+    private void init(boolean bulk, @Nullable SQLiteDatabase db) {
+        if (db == null) {
+            mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+            mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
+        } else {
+            mTransactionsDbAdapter = new TransactionsDbAdapter(db, new SplitsDbAdapter(db));
+            mAccountsDbAdapter = new AccountsDbAdapter(db, mTransactionsDbAdapter);
+        }
         mContent = new StringBuilder();
         mBulk = bulk;
         if (bulk) {
             mAccountList = new ArrayList<Account>();
             mTransactionList = new ArrayList<Transaction>();
         }
-    }
-
-    public GncXmlHandler(){
-        init(GnuCashApplication.getAppContext(), false);
     }
 
     @Override

--- a/app/src/org/gnucash/android/importer/GncXmlImporter.java
+++ b/app/src/org/gnucash/android/importer/GncXmlImporter.java
@@ -18,8 +18,6 @@ package org.gnucash.android.importer;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -48,7 +46,7 @@ public class GncXmlImporter {
      * @param db SQLite Database
      * @param gncXmlInputStream Input stream of GnuCash XML
      */
-    public static void parse(@NonNull SQLiteDatabase db, InputStream gncXmlInputStream) throws Exception {
+    public static void parse(SQLiteDatabase db, InputStream gncXmlInputStream) throws Exception {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         SAXParser sp = spf.newSAXParser();
         XMLReader xr = sp.getXMLReader();

--- a/app/src/org/gnucash/android/importer/GncXmlImporter.java
+++ b/app/src/org/gnucash/android/importer/GncXmlImporter.java
@@ -55,7 +55,7 @@ public class GncXmlImporter {
 
         /** Create handler to handle XML Tags ( extends DefaultHandler ) */
 
-        GncXmlHandler handler = new GncXmlHandler(db);
+        GncXmlHandler handler = new GncXmlHandler();
         xr.setContentHandler(handler);
         xr.parse(new InputSource(bos));
     }

--- a/app/src/org/gnucash/android/importer/GncXmlImporter.java
+++ b/app/src/org/gnucash/android/importer/GncXmlImporter.java
@@ -18,6 +18,8 @@ package org.gnucash.android.importer;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -46,7 +48,7 @@ public class GncXmlImporter {
      * @param db SQLite Database
      * @param gncXmlInputStream Input stream of GnuCash XML
      */
-    public static void parse(SQLiteDatabase db, InputStream gncXmlInputStream) throws Exception {
+    public static void parse(@NonNull SQLiteDatabase db, InputStream gncXmlInputStream) throws Exception {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         SAXParser sp = spf.newSAXParser();
         XMLReader xr = sp.getXMLReader();
@@ -55,7 +57,8 @@ public class GncXmlImporter {
 
         /** Create handler to handle XML Tags ( extends DefaultHandler ) */
 
-        GncXmlHandler handler = new GncXmlHandler();
+        GncXmlHandler handler = new GncXmlHandler(false, db);
+
         xr.setContentHandler(handler);
         xr.parse(new InputSource(bos));
     }
@@ -82,7 +85,7 @@ public class GncXmlImporter {
 
         //TODO: Set an error handler which can log errors
 
-        GncXmlHandler handler = new GncXmlHandler(context, true);
+        GncXmlHandler handler = new GncXmlHandler(true);
         xr.setContentHandler(handler);
         long startTime = System.nanoTime();
         xr.parse(new InputSource(bos));

--- a/app/src/org/gnucash/android/importer/ImportAsyncTask.java
+++ b/app/src/org/gnucash/android/importer/ImportAsyncTask.java
@@ -20,6 +20,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.Toast;
 import org.gnucash.android.R;
@@ -41,7 +42,7 @@ public class ImportAsyncTask extends AsyncTask<InputStream, Void, Boolean> {
         this.context = context;
     }
 
-    public ImportAsyncTask(Activity context, TaskDelegate delegate){
+    public ImportAsyncTask(Activity context, @Nullable TaskDelegate delegate){
         this.context = context;
         this.mDelegate = delegate;
     }

--- a/app/src/org/gnucash/android/importer/ImportAsyncTask.java
+++ b/app/src/org/gnucash/android/importer/ImportAsyncTask.java
@@ -20,7 +20,6 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.Toast;
 import org.gnucash.android.R;
@@ -42,7 +41,7 @@ public class ImportAsyncTask extends AsyncTask<InputStream, Void, Boolean> {
         this.context = context;
     }
 
-    public ImportAsyncTask(Activity context, @Nullable TaskDelegate delegate){
+    public ImportAsyncTask(Activity context, TaskDelegate delegate){
         this.context = context;
         this.mDelegate = delegate;
     }

--- a/app/src/org/gnucash/android/model/Account.java
+++ b/app/src/org/gnucash/android/model/Account.java
@@ -16,8 +16,6 @@
 
 package org.gnucash.android.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.gnucash.android.export.ofx.OfxHelper;
 import org.gnucash.android.export.xml.GncXmlHelper;
@@ -73,20 +71,17 @@ public class Account {
 	 * Unique Identifier of the account
 	 * It is generated when the account is created and can be set a posteriori as well
 	 */
-    @NonNull
 	private String mUID;
 	
 	/**
 	 * Name of this account
 	 */
-    @NonNull
 	private String mName;
 
     /**
      * Fully qualified name of this account including the parent hierarchy.
      * On instantiation of an account, the full name is set to the name by default
      */
-    @NonNull
     private String mFullName;
 
 	/**
@@ -98,26 +93,22 @@ public class Account {
 	 * Type of account
 	 * Defaults to {@link AccountType#CASH}
 	 */
-    @NonNull
 	private AccountType mAccountType = AccountType.CASH;
 	
 	/**
 	 * List of transactions in this account
 	 */
-    @NonNull
 	private List<Transaction> mTransactionsList = new ArrayList<Transaction>();
 
 	/**
 	 * Account UID of the parent account. Can be null
 	 */
-    @Nullable
 	private String mParentAccountUID;
 
     /**
      * Save UID of a default account for transfers.
      * All transactions in this account will by default be transfers to the other account
      */
-    @Nullable
     private String mDefaultTransferAccountUID;
 
     /**
@@ -129,7 +120,6 @@ public class Account {
     /**
      * Account color field in hex format #rrggbb
      */
-    @Nullable
     private String mColorCode;
 
     /**
@@ -153,7 +143,7 @@ public class Account {
 	 * Creates a new account with the default currency and a generated unique ID
 	 * @param name Name of the account
 	 */
-	public Account(@NonNull String name) {
+	public Account(String name) {
 		setName(name);
         this.mFullName  = mName;
 		this.mUID       = generateUID();
@@ -165,7 +155,7 @@ public class Account {
 	 * @param name Name of the account
 	 * @param currency {@link Currency} to be used by transactions in this account
 	 */
-	public Account(@NonNull String name, @NonNull Currency currency){
+	public Account(String name, Currency currency){
 		setName(name);
         this.mFullName  = mName;
 		this.mUID       = generateUID();
@@ -176,7 +166,7 @@ public class Account {
 	 * Sets the name of the account
 	 * @param name String name of the account
 	 */
-	public void setName(@NonNull String name) {
+	public void setName(String name) {
 		this.mName = name.trim();
 	}
 
@@ -184,7 +174,6 @@ public class Account {
 	 * Returns the name of the account
 	 * @return String containing name of the account
 	 */
-    @NonNull
 	public String getName() {
 		return mName;
 	}
@@ -194,7 +183,6 @@ public class Account {
      * The full name is the full account hierarchy name
      * @return Fully qualified name of the account
      */
-    @NonNull
     public String getFullName() {
         return mFullName;
     }
@@ -203,7 +191,7 @@ public class Account {
      * Sets the fully qualified name of the account
      * @param fullName Fully qualified account name
      */
-    public void setFullName(@NonNull String fullName) {
+    public void setFullName(String fullName) {
         this.mFullName = fullName;
     }
 
@@ -212,7 +200,6 @@ public class Account {
 	 * This represents the ACCTID in the exported OFX and should have a maximum of 22 alphanumeric characters
 	 * @return Generated Unique ID string
 	 */
-    @NonNull
 	protected String generateUID(){
 		String uuid = UUID.randomUUID().toString();
 		
@@ -233,7 +220,6 @@ public class Account {
 	 * Returns the unique ID of this account
 	 * @return String containing unique ID for the account
 	 */
-    @NonNull
 	public String getUID(){
 		return mUID;
 	}
@@ -242,7 +228,7 @@ public class Account {
 	 * Sets the unique identifier of this acocunt
 	 * @param uid Unique identifier to be set
 	 */
-	public void setUID(@NonNull String uid){
+	public void setUID(String uid){
 		this.mUID = uid;
 	}
 	
@@ -250,7 +236,6 @@ public class Account {
 	 * Get the type of account
 	 * @return {@link AccountType} type of account
 	 */
-    @NonNull
 	public AccountType getAccountType() {
 		return mAccountType;
 	}
@@ -260,7 +245,7 @@ public class Account {
 	 * @param mAccountType Type of account
 	 * @see AccountType
 	 */
-	public void setAccountType(@NonNull AccountType mAccountType) {
+	public void setAccountType(AccountType mAccountType) {
 		this.mAccountType = mAccountType;
 	}
 
@@ -268,7 +253,7 @@ public class Account {
 	 * Adds a transaction to this account
 	 * @param transaction {@link Transaction} to be added to the account
 	 */
-	public void addTransaction(@NonNull Transaction transaction){
+	public void addTransaction(Transaction transaction){
 		transaction.setCurrencyCode(mCurrency.getCurrencyCode());
 		mTransactionsList.add(transaction);
 	}
@@ -280,7 +265,7 @@ public class Account {
 	 * and currency of the account respectively
 	 * @param transactionsList List of {@link Transaction}s to be set.
 	 */
-	public void setTransactions(@NonNull List<Transaction> transactionsList){
+	public void setTransactions(List<Transaction> transactionsList){
 		this.mTransactionsList = transactionsList;
 	}
 		
@@ -288,7 +273,7 @@ public class Account {
 	 * Removes <code>transaction</code> from this account
 	 * @param transaction {@link Transaction} to be removed from account
 	 */
-	public void removeTransaction(@NonNull Transaction transaction){
+	public void removeTransaction(Transaction transaction){
 		mTransactionsList.remove(transaction);
 	}
 	
@@ -296,7 +281,6 @@ public class Account {
 	 * Returns a list of transactions for this account
 	 * @return Array list of transactions for the account
 	 */
-    @NonNull
 	public List<Transaction> getTransactions(){
 		return mTransactionsList;
 	}
@@ -327,7 +311,6 @@ public class Account {
 	 * It takes into account debit and credit amounts, it does not however consider sub-accounts
 	 * @return {@link Money} aggregate amount of all transactions in account.
 	 */
-    @NonNull
 	public Money getBalance(){
 		Money balance = Money.createZeroInstance(mCurrency.getCurrencyCode());
         for (Transaction transaction : mTransactionsList) {
@@ -340,7 +323,6 @@ public class Account {
      * Returns the color code of the account in the format #rrggbb
      * @return Color code of the account
      */
-    @Nullable
     public String getColorHexCode() {
         return mColorCode;
     }
@@ -350,7 +332,7 @@ public class Account {
      * @param colorCode Color code to be set in the format #rrggbb or #rgb
      * @throws java.lang.IllegalArgumentException if the color code is not properly formatted
      */
-    public void setColorCode(@Nullable String colorCode) {
+    public void setColorCode(String colorCode) {
         if (colorCode == null)
             return;
 
@@ -379,7 +361,6 @@ public class Account {
     /**
 	 * @return the mCurrency
 	 */
-    @NonNull
 	public Currency getCurrency() {
 		return mCurrency;
 	}
@@ -388,7 +369,7 @@ public class Account {
 	 * Sets the currency to be used by this account
 	 * @param mCurrency the mCurrency to set
 	 */
-	public void setCurrency(@NonNull Currency mCurrency) {
+	public void setCurrency(Currency mCurrency) {
 		this.mCurrency = mCurrency;
 		//TODO: Maybe at some time t, this method should convert all 
 		//transaction values to the corresponding value in the new currency
@@ -398,7 +379,7 @@ public class Account {
 	 * Sets the Unique Account Identifier of the parent account
 	 * @param parentUID String Unique ID of parent account
 	 */
-	public void setParentUID(@Nullable String parentUID){
+	public void setParentUID(String parentUID){
 		mParentAccountUID = parentUID;
 	}
 	
@@ -406,7 +387,6 @@ public class Account {
 	 * Returns the Unique Account Identifier of the parent account
 	 * @return String Unique ID of parent account
 	 */
-    @Nullable
 	public String getParentUID() {
 		return mParentAccountUID;
 	}
@@ -432,7 +412,6 @@ public class Account {
      * Return the unique ID of accounts to which to default transfer transactions to
      * @return Unique ID string of default transfer account
      */
-    @Nullable
     public String getDefaultTransferAccountUID() {
         return mDefaultTransferAccountUID;
     }
@@ -441,7 +420,7 @@ public class Account {
      * Set the unique ID of account which is the default transfer target
      * @param defaultTransferAccountUID Unique ID string of default transfer account
      */
-    public void setDefaultTransferAccountUID(@Nullable String defaultTransferAccountUID) {
+    public void setDefaultTransferAccountUID(String defaultTransferAccountUID) {
         this.mDefaultTransferAccountUID = defaultTransferAccountUID;
     }
 
@@ -454,8 +433,7 @@ public class Account {
 	 * @see AccountType
 	 * @see OfxAccountType
 	 */
-	@NonNull
-    public static OfxAccountType convertToOfxAccountType(@NonNull AccountType accountType){
+    public static OfxAccountType convertToOfxAccountType(AccountType accountType){
 		switch (accountType) {
 		case CREDIT:
 		case LIABILITY:
@@ -488,7 +466,7 @@ public class Account {
 	 * @param doc XML DOM document for the OFX data
 	 * @param parent Parent node to which to add this account's transactions in XML
 	 */
-	public void toOfx(@NonNull Document doc, @NonNull Element parent, boolean exportAllTransactions){
+	public void toOfx(Document doc, Element parent, boolean exportAllTransactions){
 		Element currency = doc.createElement(OfxHelper.TAG_CURRENCY_DEF);
 		currency.appendChild(doc.createTextNode(mCurrency.getCurrencyCode()));						
 		
@@ -567,7 +545,7 @@ public class Account {
      * @param rootNode {@link org.w3c.dom.Element} node to which to attach the XML
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(@NonNull Document doc, @NonNull Element rootNode) {
+    public void toGncXml(Document doc, Element rootNode) {
         Element nameNode = doc.createElement(GncXmlHelper.TAG_NAME);
         nameNode.appendChild(doc.createTextNode(mName));
 

--- a/app/src/org/gnucash/android/model/Account.java
+++ b/app/src/org/gnucash/android/model/Account.java
@@ -16,6 +16,9 @@
 
 package org.gnucash.android.model;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import org.gnucash.android.export.ofx.OfxHelper;
 import org.gnucash.android.export.xml.GncXmlHelper;
 import org.w3c.dom.Document;
@@ -70,17 +73,20 @@ public class Account {
 	 * Unique Identifier of the account
 	 * It is generated when the account is created and can be set a posteriori as well
 	 */
+    @NonNull
 	private String mUID;
 	
 	/**
 	 * Name of this account
 	 */
+    @NonNull
 	private String mName;
 
     /**
      * Fully qualified name of this account including the parent hierarchy.
      * On instantiation of an account, the full name is set to the name by default
      */
+    @NonNull
     private String mFullName;
 
 	/**
@@ -92,22 +98,26 @@ public class Account {
 	 * Type of account
 	 * Defaults to {@link AccountType#CASH}
 	 */
+    @NonNull
 	private AccountType mAccountType = AccountType.CASH;
 	
 	/**
 	 * List of transactions in this account
 	 */
+    @NonNull
 	private List<Transaction> mTransactionsList = new ArrayList<Transaction>();
 
 	/**
 	 * Account UID of the parent account. Can be null
 	 */
+    @Nullable
 	private String mParentAccountUID;
 
     /**
      * Save UID of a default account for transfers.
      * All transactions in this account will by default be transfers to the other account
      */
+    @Nullable
     private String mDefaultTransferAccountUID;
 
     /**
@@ -119,6 +129,7 @@ public class Account {
     /**
      * Account color field in hex format #rrggbb
      */
+    @Nullable
     private String mColorCode;
 
     /**
@@ -142,7 +153,7 @@ public class Account {
 	 * Creates a new account with the default currency and a generated unique ID
 	 * @param name Name of the account
 	 */
-	public Account(String name) {
+	public Account(@NonNull String name) {
 		setName(name);
         this.mFullName  = mName;
 		this.mUID       = generateUID();
@@ -154,7 +165,7 @@ public class Account {
 	 * @param name Name of the account
 	 * @param currency {@link Currency} to be used by transactions in this account
 	 */
-	public Account(String name, Currency currency){
+	public Account(@NonNull String name, @NonNull Currency currency){
 		setName(name);
         this.mFullName  = mName;
 		this.mUID       = generateUID();
@@ -165,7 +176,7 @@ public class Account {
 	 * Sets the name of the account
 	 * @param name String name of the account
 	 */
-	public void setName(String name) {
+	public void setName(@NonNull String name) {
 		this.mName = name.trim();
 	}
 
@@ -173,6 +184,7 @@ public class Account {
 	 * Returns the name of the account
 	 * @return String containing name of the account
 	 */
+    @NonNull
 	public String getName() {
 		return mName;
 	}
@@ -182,6 +194,7 @@ public class Account {
      * The full name is the full account hierarchy name
      * @return Fully qualified name of the account
      */
+    @NonNull
     public String getFullName() {
         return mFullName;
     }
@@ -190,7 +203,7 @@ public class Account {
      * Sets the fully qualified name of the account
      * @param fullName Fully qualified account name
      */
-    public void setFullName(String fullName) {
+    public void setFullName(@NonNull String fullName) {
         this.mFullName = fullName;
     }
 
@@ -199,10 +212,11 @@ public class Account {
 	 * This represents the ACCTID in the exported OFX and should have a maximum of 22 alphanumeric characters
 	 * @return Generated Unique ID string
 	 */
+    @NonNull
 	protected String generateUID(){
 		String uuid = UUID.randomUUID().toString();
 		
-		if (mName == null || mName.length() == 0){
+		if (mName.length() == 0){
 			//if we do not have a name, return pure random
 			return uuid.substring(0, 22);
 		}
@@ -219,6 +233,7 @@ public class Account {
 	 * Returns the unique ID of this account
 	 * @return String containing unique ID for the account
 	 */
+    @NonNull
 	public String getUID(){
 		return mUID;
 	}
@@ -227,7 +242,7 @@ public class Account {
 	 * Sets the unique identifier of this acocunt
 	 * @param uid Unique identifier to be set
 	 */
-	public void setUID(String uid){
+	public void setUID(@NonNull String uid){
 		this.mUID = uid;
 	}
 	
@@ -235,6 +250,7 @@ public class Account {
 	 * Get the type of account
 	 * @return {@link AccountType} type of account
 	 */
+    @NonNull
 	public AccountType getAccountType() {
 		return mAccountType;
 	}
@@ -244,7 +260,7 @@ public class Account {
 	 * @param mAccountType Type of account
 	 * @see AccountType
 	 */
-	public void setAccountType(AccountType mAccountType) {
+	public void setAccountType(@NonNull AccountType mAccountType) {
 		this.mAccountType = mAccountType;
 	}
 
@@ -252,7 +268,7 @@ public class Account {
 	 * Adds a transaction to this account
 	 * @param transaction {@link Transaction} to be added to the account
 	 */
-	public void addTransaction(Transaction transaction){
+	public void addTransaction(@NonNull Transaction transaction){
 		transaction.setCurrencyCode(mCurrency.getCurrencyCode());
 		mTransactionsList.add(transaction);
 	}
@@ -264,7 +280,7 @@ public class Account {
 	 * and currency of the account respectively
 	 * @param transactionsList List of {@link Transaction}s to be set.
 	 */
-	public void setTransactions(List<Transaction> transactionsList){
+	public void setTransactions(@NonNull List<Transaction> transactionsList){
 		this.mTransactionsList = transactionsList;
 	}
 		
@@ -272,7 +288,7 @@ public class Account {
 	 * Removes <code>transaction</code> from this account
 	 * @param transaction {@link Transaction} to be removed from account
 	 */
-	public void removeTransaction(Transaction transaction){
+	public void removeTransaction(@NonNull Transaction transaction){
 		mTransactionsList.remove(transaction);
 	}
 	
@@ -280,6 +296,7 @@ public class Account {
 	 * Returns a list of transactions for this account
 	 * @return Array list of transactions for the account
 	 */
+    @NonNull
 	public List<Transaction> getTransactions(){
 		return mTransactionsList;
 	}
@@ -310,6 +327,7 @@ public class Account {
 	 * It takes into account debit and credit amounts, it does not however consider sub-accounts
 	 * @return {@link Money} aggregate amount of all transactions in account.
 	 */
+    @NonNull
 	public Money getBalance(){
 		Money balance = Money.createZeroInstance(mCurrency.getCurrencyCode());
         for (Transaction transaction : mTransactionsList) {
@@ -322,6 +340,7 @@ public class Account {
      * Returns the color code of the account in the format #rrggbb
      * @return Color code of the account
      */
+    @Nullable
     public String getColorHexCode() {
         return mColorCode;
     }
@@ -331,7 +350,7 @@ public class Account {
      * @param colorCode Color code to be set in the format #rrggbb or #rgb
      * @throws java.lang.IllegalArgumentException if the color code is not properly formatted
      */
-    public void setColorCode(String colorCode) {
+    public void setColorCode(@Nullable String colorCode) {
         if (colorCode == null)
             return;
 
@@ -360,6 +379,7 @@ public class Account {
     /**
 	 * @return the mCurrency
 	 */
+    @NonNull
 	public Currency getCurrency() {
 		return mCurrency;
 	}
@@ -368,7 +388,7 @@ public class Account {
 	 * Sets the currency to be used by this account
 	 * @param mCurrency the mCurrency to set
 	 */
-	public void setCurrency(Currency mCurrency) {		
+	public void setCurrency(@NonNull Currency mCurrency) {
 		this.mCurrency = mCurrency;
 		//TODO: Maybe at some time t, this method should convert all 
 		//transaction values to the corresponding value in the new currency
@@ -378,7 +398,7 @@ public class Account {
 	 * Sets the Unique Account Identifier of the parent account
 	 * @param parentUID String Unique ID of parent account
 	 */
-	public void setParentUID(String parentUID){
+	public void setParentUID(@Nullable String parentUID){
 		mParentAccountUID = parentUID;
 	}
 	
@@ -386,9 +406,9 @@ public class Account {
 	 * Returns the Unique Account Identifier of the parent account
 	 * @return String Unique ID of parent account
 	 */
+    @Nullable
 	public String getParentUID() {
 		return mParentAccountUID;
-		
 	}
 
     /**
@@ -412,6 +432,7 @@ public class Account {
      * Return the unique ID of accounts to which to default transfer transactions to
      * @return Unique ID string of default transfer account
      */
+    @Nullable
     public String getDefaultTransferAccountUID() {
         return mDefaultTransferAccountUID;
     }
@@ -420,7 +441,7 @@ public class Account {
      * Set the unique ID of account which is the default transfer target
      * @param defaultTransferAccountUID Unique ID string of default transfer account
      */
-    public void setDefaultTransferAccountUID(String defaultTransferAccountUID) {
+    public void setDefaultTransferAccountUID(@Nullable String defaultTransferAccountUID) {
         this.mDefaultTransferAccountUID = defaultTransferAccountUID;
     }
 
@@ -433,7 +454,8 @@ public class Account {
 	 * @see AccountType
 	 * @see OfxAccountType
 	 */
-	public static OfxAccountType convertToOfxAccountType(AccountType accountType){
+	@NonNull
+    public static OfxAccountType convertToOfxAccountType(@NonNull AccountType accountType){
 		switch (accountType) {
 		case CREDIT:
 		case LIABILITY:
@@ -466,7 +488,7 @@ public class Account {
 	 * @param doc XML DOM document for the OFX data
 	 * @param parent Parent node to which to add this account's transactions in XML
 	 */
-	public void toOfx(Document doc, Element parent, boolean exportAllTransactions){
+	public void toOfx(@NonNull Document doc, @NonNull Element parent, boolean exportAllTransactions){
 		Element currency = doc.createElement(OfxHelper.TAG_CURRENCY_DEF);
 		currency.appendChild(doc.createTextNode(mCurrency.getCurrencyCode()));						
 		
@@ -545,7 +567,7 @@ public class Account {
      * @param rootNode {@link org.w3c.dom.Element} node to which to attach the XML
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(Document doc, Element rootNode) {
+    public void toGncXml(@NonNull Document doc, @NonNull Element rootNode) {
         Element nameNode = doc.createElement(GncXmlHelper.TAG_NAME);
         nameNode.appendChild(doc.createTextNode(mName));
 

--- a/app/src/org/gnucash/android/model/Money.java
+++ b/app/src/org/gnucash/android/model/Money.java
@@ -16,8 +16,6 @@
 
 package org.gnucash.android.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -46,13 +44,11 @@ public final class Money implements Comparable<Money>{
 	/**
 	 * Currency of the account
 	 */
-    @NonNull
 	private Currency mCurrency;
 	
 	/**
 	 * Amount value held by this object
 	 */
-    @NonNull
 	private BigDecimal mAmount;
 	
 	/**
@@ -71,7 +67,6 @@ public final class Money implements Comparable<Money>{
 	 * Rounding mode to be applied when performing operations
 	 * Defaults to {@link #DEFAULT_ROUNDING_MODE}
 	 */
-    @NonNull
 	protected RoundingMode ROUNDING_MODE = DEFAULT_ROUNDING_MODE;
 	
 	/**
@@ -97,7 +92,6 @@ public final class Money implements Comparable<Money>{
      * Returns a Money instance initialized to the local currency and value 0
      * @return Money instance of value 0 in locale currency
      */
-    @NonNull
     public static Money getZeroInstance(){
         return sDefaultZero;
     }
@@ -115,7 +109,7 @@ public final class Money implements Comparable<Money>{
 	 * @param amount {@link BigDecimal} value of the money instance
 	 * @param currency {@link Currency} associated with the <code>amount</code>
 	 */
-	public Money(@NonNull BigDecimal amount, @NonNull Currency currency){
+	public Money(BigDecimal amount, Currency currency){
 		this.mAmount = amount;
 		this.mCurrency = currency;
 	}
@@ -126,7 +120,7 @@ public final class Money implements Comparable<Money>{
 	 * @param amount Numrical value of the Money
 	 * @param currencyCode Currency code as specified by ISO 4217
 	 */
-	public Money(@NonNull String amount, @NonNull String currencyCode){
+	public Money(String amount, String currencyCode){
 		setAmount(amount);
 		setCurrency(Currency.getInstance(currencyCode));
 	}
@@ -138,7 +132,7 @@ public final class Money implements Comparable<Money>{
 	 * @param currency {@link Currency} associated with the <code>amount</code>
 	 * @param context {@link MathContext} specifying rounding mode during operations
 	 */
-	public Money(@NonNull BigDecimal amount, @NonNull Currency currency, @NonNull MathContext context){
+	public Money(BigDecimal amount, Currency currency, MathContext context){
 		setAmount(amount);
 		setCurrency(currency);
 		ROUNDING_MODE = context.getRoundingMode();
@@ -150,7 +144,7 @@ public final class Money implements Comparable<Money>{
 	 * Initializes the currency to that specified by {@link Money#DEFAULT_CURRENCY_CODE}
 	 * @param amount Value associated with this Money object
 	 */
-	public Money(@NonNull String amount){
+	public Money(String amount){
 		init();
 		setAmount(parseToDecimal(amount));
 	}
@@ -160,7 +154,7 @@ public final class Money implements Comparable<Money>{
 	 * Initializes the currency to that specified by {@link Money#DEFAULT_CURRENCY_CODE}
 	 * @param amount Value associated with this Money object
 	 */
-	public Money(@NonNull BigDecimal amount){
+	public Money(BigDecimal amount){
 		init();
 		setAmount(amount);
 	}
@@ -170,7 +164,7 @@ public final class Money implements Comparable<Money>{
      * Creates a new Money object which is a clone of <code>money</code>
      * @param money Money instance to be cloned
      */
-    public Money(@NonNull Money money){
+    public Money(Money money){
         setAmount(money.asBigDecimal());
         setCurrency(money.getCurrency());
     }
@@ -180,8 +174,7 @@ public final class Money implements Comparable<Money>{
      * @param currencyCode Currency to use for this money instance
      * @return Money object with value 0 and currency <code>currencyCode</code>
      */
-    @NonNull
-    public static Money createZeroInstance(@NonNull String currencyCode){
+    public static Money createZeroInstance(String currencyCode){
         return new Money("0", currencyCode);
     }
 
@@ -198,7 +191,6 @@ public final class Money implements Comparable<Money>{
 	 * Returns the currency of the money object
 	 * @return {@link Currency} of the money value
 	 */
-    @NonNull
 	public Currency getCurrency() {
 		return mCurrency;
 	}
@@ -209,8 +201,7 @@ public final class Money implements Comparable<Money>{
 	 * @param currency {@link Currency} to assign to new <code>Money</code> object
 	 * @return {@link Money} object with same value as current object, but with new <code>currency</code>
 	 */
-	@NonNull
-    public Money withCurrency(@NonNull Currency currency){
+    public Money withCurrency(Currency currency){
 		return new Money(mAmount, currency);
 	}
 	
@@ -221,7 +212,7 @@ public final class Money implements Comparable<Money>{
 	 * Money objects are immutable and hence this method should not be called out of a constructor
 	 * @param currency {@link Currency} to assign to the Money object  
 	 */
-	private void setCurrency(@NonNull Currency currency) {
+	private void setCurrency(Currency currency) {
 		//TODO: Consider doing a conversion of the value as well in the future
 		this.mCurrency = currency;
 	}
@@ -230,7 +221,6 @@ public final class Money implements Comparable<Money>{
 	 * Returns the amount represented by this Money object
 	 * @return {@link BigDecimal} valure of amount in object
 	 */
-    @NonNull
 	public BigDecimal asBigDecimal() {
 		return mAmount;
 	}
@@ -258,8 +248,7 @@ public final class Money implements Comparable<Money>{
 	 * @param locale Locale to use when formatting the object
 	 * @return String containing formatted Money representation
 	 */
-	@NonNull
-    public String formattedString(@NonNull Locale locale){
+    public String formattedString(Locale locale){
 		NumberFormat formatter = NumberFormat.getInstance(locale);
 		formatter.setMinimumFractionDigits(DECIMAL_PLACES);
 		formatter.setMaximumFractionDigits(DECIMAL_PLACES);
@@ -270,7 +259,6 @@ public final class Money implements Comparable<Money>{
      * Equivalent to calling formattedString(Locale.getDefault())
      * @return String formatted Money representation in default locale
      */
-    @NonNull
     public String formattedString(){
         return formattedString(Locale.getDefault());
     }
@@ -280,7 +268,6 @@ public final class Money implements Comparable<Money>{
 	 * The original <code>Money</code> object remains unchanged.
 	 * @return Negated <code>Money</code> object
 	 */
-	@NonNull
     public Money negate(){
 		return new Money(mAmount.negate(), mCurrency);
 	}
@@ -289,7 +276,7 @@ public final class Money implements Comparable<Money>{
 	 * Sets the amount value of this <code>Money</code> object
 	 * @param amount {@link BigDecimal} amount to be set
 	 */
-	private void setAmount(@NonNull BigDecimal amount) {
+	private void setAmount(BigDecimal amount) {
 		mAmount = amount.setScale(DECIMAL_PLACES, ROUNDING_MODE);
 	}
 	
@@ -298,7 +285,7 @@ public final class Money implements Comparable<Money>{
 	 * The <code>amount</code> is parsed by the {@link BigDecimal} constructor
 	 * @param amount {@link String} amount to be set
 	 */
-	private void setAmount(@NonNull String amount){
+	private void setAmount(String amount){
 		setAmount(parseToDecimal(amount));
 	}	
 	
@@ -310,8 +297,7 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the sum of this object and <code>money</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	@NonNull
-    public Money add(@NonNull Money addend){
+    public Money add(Money addend){
 		if (!mCurrency.equals(addend.mCurrency))
 			throw new IllegalArgumentException("Only Money with same currency can be added");
 		
@@ -327,8 +313,7 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the difference of this object and <code>subtrahend</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	@NonNull
-    public Money subtract(@NonNull Money subtrahend){
+    public Money subtract(Money subtrahend){
 		if (!mCurrency.equals(subtrahend.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -344,8 +329,7 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the quotient of this object and <code>divisor</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	@NonNull
-    public Money divide(@NonNull Money divisor){
+    public Money divide(Money divisor){
 		if (!mCurrency.equals(divisor.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -359,7 +343,6 @@ public final class Money implements Comparable<Money>{
 	 * @param divisor Second operand in the addition.
 	 * @return Money object whose value is the quotient of this object and <code>divisor</code>
 	 */
-	@NonNull
     public Money divide(int divisor){
 		Money moneyDiv = new Money(new BigDecimal(divisor), mCurrency);
 		return divide(moneyDiv);
@@ -373,8 +356,7 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the product of this object and <code>money</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	@NonNull
-    public Money multiply(@NonNull Money money){
+    public Money multiply(Money money){
 		if (!mCurrency.equals(money.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -388,7 +370,6 @@ public final class Money implements Comparable<Money>{
 	 * @param multiplier Factor to multiply the amount by.
 	 * @return Money object whose value is the product of this objects values and <code>multiplier</code>
 	 */
-	@NonNull
     public Money multiply(int multiplier){
 		Money moneyFactor = new Money(new BigDecimal(multiplier), mCurrency);
 		return multiply(moneyFactor);
@@ -406,7 +387,6 @@ public final class Money implements Comparable<Money>{
 	 * Returns the string representation of the amount (without currency) of the Money object
 	 * @return String representation of the amount (without currency) of the Money object
 	 */
-    @NonNull
 	public String toPlainString(){
 		return mAmount.setScale(DECIMAL_PLACES, ROUNDING_MODE).toPlainString();
 	}
@@ -416,7 +396,6 @@ public final class Money implements Comparable<Money>{
 	 * to the default locale
 	 * @return String representation of the amount formatted with default locale
 	 */
-	@NonNull
     @Override
 	public String toString() {
 		return formattedString(Locale.getDefault());
@@ -437,7 +416,7 @@ public final class Money implements Comparable<Money>{
 	 * @return <code>true</code> if the objects are equal, <code>false</code> otherwise
 	 */
 	@Override
-	public boolean equals(@Nullable Object obj) {
+	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
@@ -453,7 +432,7 @@ public final class Money implements Comparable<Money>{
 	}
 
 	@Override
-	public int compareTo(@NonNull Money another) {
+	public int compareTo(Money another) {
 		if (!mCurrency.equals(another.mCurrency))
 			throw new IllegalArgumentException("Cannot compare different currencies yet");
 		return mAmount.compareTo(another.mAmount);
@@ -464,8 +443,7 @@ public final class Money implements Comparable<Money>{
 	 * @param amountString Formatted String amount
 	 * @return String amount formatted in the default locale
 	 */
-	@NonNull
-    public static BigDecimal parseToDecimal(@NonNull String amountString){
+    public static BigDecimal parseToDecimal(String amountString){
 		char separator = new DecimalFormatSymbols(Locale.US).getGroupingSeparator();
 		amountString = amountString.replace(Character.toString(separator), "");
 		NumberFormat formatter = NumberFormat.getInstance(Locale.US);		
@@ -485,7 +463,6 @@ public final class Money implements Comparable<Money>{
      * Returns a new instance of {@link Money} object with the absolute value of the current object
      * @return Money object with absolute value of this instance
      */
-    @NonNull
     public Money absolute() {
         return new Money(mAmount.abs(), mCurrency);
     }

--- a/app/src/org/gnucash/android/model/Money.java
+++ b/app/src/org/gnucash/android/model/Money.java
@@ -16,6 +16,9 @@
 
 package org.gnucash.android.model;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
@@ -43,11 +46,13 @@ public final class Money implements Comparable<Money>{
 	/**
 	 * Currency of the account
 	 */
+    @NonNull
 	private Currency mCurrency;
 	
 	/**
 	 * Amount value held by this object
 	 */
+    @NonNull
 	private BigDecimal mAmount;
 	
 	/**
@@ -66,6 +71,7 @@ public final class Money implements Comparable<Money>{
 	 * Rounding mode to be applied when performing operations
 	 * Defaults to {@link #DEFAULT_ROUNDING_MODE}
 	 */
+    @NonNull
 	protected RoundingMode ROUNDING_MODE = DEFAULT_ROUNDING_MODE;
 	
 	/**
@@ -91,6 +97,7 @@ public final class Money implements Comparable<Money>{
      * Returns a Money instance initialized to the local currency and value 0
      * @return Money instance of value 0 in locale currency
      */
+    @NonNull
     public static Money getZeroInstance(){
         return sDefaultZero;
     }
@@ -108,7 +115,7 @@ public final class Money implements Comparable<Money>{
 	 * @param amount {@link BigDecimal} value of the money instance
 	 * @param currency {@link Currency} associated with the <code>amount</code>
 	 */
-	public Money(BigDecimal amount, Currency currency){		
+	public Money(@NonNull BigDecimal amount, @NonNull Currency currency){
 		this.mAmount = amount;
 		this.mCurrency = currency;
 	}
@@ -119,7 +126,7 @@ public final class Money implements Comparable<Money>{
 	 * @param amount Numrical value of the Money
 	 * @param currencyCode Currency code as specified by ISO 4217
 	 */
-	public Money(String amount, String currencyCode){
+	public Money(@NonNull String amount, @NonNull String currencyCode){
 		setAmount(amount);
 		setCurrency(Currency.getInstance(currencyCode));
 	}
@@ -131,7 +138,7 @@ public final class Money implements Comparable<Money>{
 	 * @param currency {@link Currency} associated with the <code>amount</code>
 	 * @param context {@link MathContext} specifying rounding mode during operations
 	 */
-	public Money(BigDecimal amount, Currency currency, MathContext context){
+	public Money(@NonNull BigDecimal amount, @NonNull Currency currency, @NonNull MathContext context){
 		setAmount(amount);
 		setCurrency(currency);
 		ROUNDING_MODE = context.getRoundingMode();
@@ -143,7 +150,7 @@ public final class Money implements Comparable<Money>{
 	 * Initializes the currency to that specified by {@link Money#DEFAULT_CURRENCY_CODE}
 	 * @param amount Value associated with this Money object
 	 */
-	public Money(String amount){
+	public Money(@NonNull String amount){
 		init();
 		setAmount(parseToDecimal(amount));
 	}
@@ -153,7 +160,7 @@ public final class Money implements Comparable<Money>{
 	 * Initializes the currency to that specified by {@link Money#DEFAULT_CURRENCY_CODE}
 	 * @param amount Value associated with this Money object
 	 */
-	public Money(BigDecimal amount){
+	public Money(@NonNull BigDecimal amount){
 		init();
 		setAmount(amount);
 	}
@@ -163,7 +170,7 @@ public final class Money implements Comparable<Money>{
      * Creates a new Money object which is a clone of <code>money</code>
      * @param money Money instance to be cloned
      */
-    public Money(Money money){
+    public Money(@NonNull Money money){
         setAmount(money.asBigDecimal());
         setCurrency(money.getCurrency());
     }
@@ -173,7 +180,8 @@ public final class Money implements Comparable<Money>{
      * @param currencyCode Currency to use for this money instance
      * @return Money object with value 0 and currency <code>currencyCode</code>
      */
-    public static Money createZeroInstance(String currencyCode){
+    @NonNull
+    public static Money createZeroInstance(@NonNull String currencyCode){
         return new Money("0", currencyCode);
     }
 
@@ -181,7 +189,7 @@ public final class Money implements Comparable<Money>{
 	 * Initializes the amount and currency to their default values
 	 * @see {@link Money#DEFAULT_CURRENCY_CODE}, {@link #DEFAULT_ROUNDING_MODE}, {@link #DEFAULT_DECIMAL_PLACES}
 	 */
-	private void init(){
+	private void init() {
 		mCurrency = Currency.getInstance(Money.DEFAULT_CURRENCY_CODE);
 		mAmount = new BigDecimal(0).setScale(DEFAULT_DECIMAL_PLACES, DEFAULT_ROUNDING_MODE);
 	}
@@ -190,6 +198,7 @@ public final class Money implements Comparable<Money>{
 	 * Returns the currency of the money object
 	 * @return {@link Currency} of the money value
 	 */
+    @NonNull
 	public Currency getCurrency() {
 		return mCurrency;
 	}
@@ -200,7 +209,8 @@ public final class Money implements Comparable<Money>{
 	 * @param currency {@link Currency} to assign to new <code>Money</code> object
 	 * @return {@link Money} object with same value as current object, but with new <code>currency</code>
 	 */
-	public Money withCurrency(Currency currency){
+	@NonNull
+    public Money withCurrency(@NonNull Currency currency){
 		return new Money(mAmount, currency);
 	}
 	
@@ -211,7 +221,7 @@ public final class Money implements Comparable<Money>{
 	 * Money objects are immutable and hence this method should not be called out of a constructor
 	 * @param currency {@link Currency} to assign to the Money object  
 	 */
-	private void setCurrency(Currency currency) {
+	private void setCurrency(@NonNull Currency currency) {
 		//TODO: Consider doing a conversion of the value as well in the future
 		this.mCurrency = currency;
 	}
@@ -220,6 +230,7 @@ public final class Money implements Comparable<Money>{
 	 * Returns the amount represented by this Money object
 	 * @return {@link BigDecimal} valure of amount in object
 	 */
+    @NonNull
 	public BigDecimal asBigDecimal() {
 		return mAmount;
 	}
@@ -247,7 +258,8 @@ public final class Money implements Comparable<Money>{
 	 * @param locale Locale to use when formatting the object
 	 * @return String containing formatted Money representation
 	 */
-	public String formattedString(Locale locale){
+	@NonNull
+    public String formattedString(@NonNull Locale locale){
 		NumberFormat formatter = NumberFormat.getInstance(locale);
 		formatter.setMinimumFractionDigits(DECIMAL_PLACES);
 		formatter.setMaximumFractionDigits(DECIMAL_PLACES);
@@ -258,6 +270,7 @@ public final class Money implements Comparable<Money>{
      * Equivalent to calling formattedString(Locale.getDefault())
      * @return String formatted Money representation in default locale
      */
+    @NonNull
     public String formattedString(){
         return formattedString(Locale.getDefault());
     }
@@ -267,7 +280,8 @@ public final class Money implements Comparable<Money>{
 	 * The original <code>Money</code> object remains unchanged.
 	 * @return Negated <code>Money</code> object
 	 */
-	public Money negate(){
+	@NonNull
+    public Money negate(){
 		return new Money(mAmount.negate(), mCurrency);
 	}
 	
@@ -275,7 +289,7 @@ public final class Money implements Comparable<Money>{
 	 * Sets the amount value of this <code>Money</code> object
 	 * @param amount {@link BigDecimal} amount to be set
 	 */
-	private void setAmount(BigDecimal amount) {	
+	private void setAmount(@NonNull BigDecimal amount) {
 		mAmount = amount.setScale(DECIMAL_PLACES, ROUNDING_MODE);
 	}
 	
@@ -284,7 +298,7 @@ public final class Money implements Comparable<Money>{
 	 * The <code>amount</code> is parsed by the {@link BigDecimal} constructor
 	 * @param amount {@link String} amount to be set
 	 */
-	private void setAmount(String amount){
+	private void setAmount(@NonNull String amount){
 		setAmount(parseToDecimal(amount));
 	}	
 	
@@ -296,7 +310,8 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the sum of this object and <code>money</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	public Money add(Money addend){
+	@NonNull
+    public Money add(@NonNull Money addend){
 		if (!mCurrency.equals(addend.mCurrency))
 			throw new IllegalArgumentException("Only Money with same currency can be added");
 		
@@ -312,7 +327,8 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the difference of this object and <code>subtrahend</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	public Money subtract(Money subtrahend){
+	@NonNull
+    public Money subtract(@NonNull Money subtrahend){
 		if (!mCurrency.equals(subtrahend.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -328,7 +344,8 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the quotient of this object and <code>divisor</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	public Money divide(Money divisor){
+	@NonNull
+    public Money divide(@NonNull Money divisor){
 		if (!mCurrency.equals(divisor.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -342,7 +359,8 @@ public final class Money implements Comparable<Money>{
 	 * @param divisor Second operand in the addition.
 	 * @return Money object whose value is the quotient of this object and <code>divisor</code>
 	 */
-	public Money divide(int divisor){
+	@NonNull
+    public Money divide(int divisor){
 		Money moneyDiv = new Money(new BigDecimal(divisor), mCurrency);
 		return divide(moneyDiv);
 	}
@@ -355,7 +373,8 @@ public final class Money implements Comparable<Money>{
 	 * @return Money object whose value is the product of this object and <code>money</code>
 	 * @throws IllegalArgumentException if the <code>Money</code> objects to be added have different Currencies
 	 */
-	public Money multiply(Money money){
+	@NonNull
+    public Money multiply(@NonNull Money money){
 		if (!mCurrency.equals(money.mCurrency))
 			throw new IllegalArgumentException("Operation can only be performed on money with same currency");
 		
@@ -369,7 +388,8 @@ public final class Money implements Comparable<Money>{
 	 * @param multiplier Factor to multiply the amount by.
 	 * @return Money object whose value is the product of this objects values and <code>multiplier</code>
 	 */
-	public Money multiply(int multiplier){
+	@NonNull
+    public Money multiply(int multiplier){
 		Money moneyFactor = new Money(new BigDecimal(multiplier), mCurrency);
 		return multiply(moneyFactor);
 	}
@@ -386,6 +406,7 @@ public final class Money implements Comparable<Money>{
 	 * Returns the string representation of the amount (without currency) of the Money object
 	 * @return String representation of the amount (without currency) of the Money object
 	 */
+    @NonNull
 	public String toPlainString(){
 		return mAmount.setScale(DECIMAL_PLACES, ROUNDING_MODE).toPlainString();
 	}
@@ -395,7 +416,8 @@ public final class Money implements Comparable<Money>{
 	 * to the default locale
 	 * @return String representation of the amount formatted with default locale
 	 */
-	@Override
+	@NonNull
+    @Override
 	public String toString() {
 		return formattedString(Locale.getDefault());
 	}
@@ -404,9 +426,8 @@ public final class Money implements Comparable<Money>{
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((mAmount == null) ? 0 : mAmount.hashCode());
-		result = prime * result
-				+ ((mCurrency == null) ? 0 : mCurrency.hashCode());
+		result = prime * result + (mAmount.hashCode());
+		result = prime * result + (mCurrency.hashCode());
 		return result;
 	}
 
@@ -416,7 +437,7 @@ public final class Money implements Comparable<Money>{
 	 * @return <code>true</code> if the objects are equal, <code>false</code> otherwise
 	 */
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
@@ -424,21 +445,15 @@ public final class Money implements Comparable<Money>{
 		if (getClass() != obj.getClass())
 			return false;
 		Money other = (Money) obj;
-		if (mAmount == null) {
-			if (other.mAmount != null)
-				return false;
-		} else if (!mAmount.equals(other.mAmount))
+		if (!mAmount.equals(other.mAmount))
 			return false;
-		if (mCurrency == null) {
-			if (other.mCurrency != null)
-				return false;
-		} else if (!mCurrency.equals(other.mCurrency))
+		if (!mCurrency.equals(other.mCurrency))
 			return false;
 		return true;
 	}
 
 	@Override
-	public int compareTo(Money another) {
+	public int compareTo(@NonNull Money another) {
 		if (!mCurrency.equals(another.mCurrency))
 			throw new IllegalArgumentException("Cannot compare different currencies yet");
 		return mAmount.compareTo(another.mAmount);
@@ -449,27 +464,28 @@ public final class Money implements Comparable<Money>{
 	 * @param amountString Formatted String amount
 	 * @return String amount formatted in the default locale
 	 */
-	public static BigDecimal parseToDecimal(String amountString){	
+	@NonNull
+    public static BigDecimal parseToDecimal(@NonNull String amountString){
 		char separator = new DecimalFormatSymbols(Locale.US).getGroupingSeparator();
 		amountString = amountString.replace(Character.toString(separator), "");
 		NumberFormat formatter = NumberFormat.getInstance(Locale.US);		
 		if (formatter instanceof DecimalFormat) {
 		     ((DecimalFormat)formatter).setParseBigDecimal(true);		     
-		 }
-		BigDecimal result = null; //new BigDecimal(0);
+		}
+		BigDecimal result = new BigDecimal(0);
 		try {
 			result = (BigDecimal) formatter.parse(amountString);
-			
 		} catch (ParseException e) {
 			e.printStackTrace();		
 		}
-		return result;		
+        return result;
 	}
 
     /**
      * Returns a new instance of {@link Money} object with the absolute value of the current object
      * @return Money object with absolute value of this instance
      */
+    @NonNull
     public Money absolute() {
         return new Money(mAmount.abs(), mCurrency);
     }

--- a/app/src/org/gnucash/android/model/Split.java
+++ b/app/src/org/gnucash/android/model/Split.java
@@ -1,5 +1,8 @@
 package org.gnucash.android.model;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import org.gnucash.android.export.xml.GncXmlHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -20,31 +23,37 @@ public class Split {
     /**
      * Amount value of this split
      */
+    @NonNull
     private Money mAmount;
 
     /**
      * Unique ID of this split
      */
+    @NonNull
     private String mUID;
 
     /**
      * Transaction UID which this split belongs to
      */
-    private String mTransactionUID;
+    @NonNull
+    private String mTransactionUID = "";
 
     /**
      * Account UID which this split belongs to
      */
+    @NonNull
     private String mAccountUID;
 
     /**
      * The type of this transaction, credit or debit
      */
-    private TransactionType mSplitType;
+    @NonNull
+    private TransactionType mSplitType = TransactionType.CREDIT;
 
     /**
      * Memo associated with this split
      */
+    @Nullable
     private String mMemo;
 
     /**
@@ -52,7 +61,7 @@ public class Split {
      * @param amount Money amount of this split
      * @param accountUID String UID of transfer account
      */
-    public Split(Money amount, String accountUID){
+    public Split(@NonNull Money amount, @NonNull String accountUID){
         setAmount(amount);
         setAccountUID(accountUID);
         mUID = UUID.randomUUID().toString().replaceAll("-","");
@@ -63,7 +72,7 @@ public class Split {
      * @param sourceSplit Split to be cloned
      * @param generateUID Determines if the clone should have a new UID or should maintain the one from source
      */
-    public Split(Split sourceSplit, boolean generateUID){
+    public Split(@NonNull Split sourceSplit, boolean generateUID){
         this.mMemo          = sourceSplit.mMemo;
         this.mAccountUID    = sourceSplit.mAccountUID;
         this.mSplitType     = sourceSplit.mSplitType;
@@ -77,55 +86,62 @@ public class Split {
         }
     }
 
+    @NonNull
     public Money getAmount() {
         return mAmount;
     }
 
-    public void setAmount(Money amount) {
+    public void setAmount(@NonNull Money amount) {
         this.mAmount = amount;
     }
 
+    @NonNull
     public String getUID() {
         return mUID;
     }
 
-    public void setUID(String uid) {
+    public void setUID(@NonNull String uid) {
         this.mUID = uid;
     }
 
+    @NonNull
     public String getTransactionUID() {
         return mTransactionUID;
     }
 
-    public void setTransactionUID(String transactionUID) {
+    public void setTransactionUID(@NonNull String transactionUID) {
         this.mTransactionUID = transactionUID;
     }
 
+    @NonNull
     public String getAccountUID() {
         return mAccountUID;
     }
 
-    public void setAccountUID(String accountUID) {
+    public void setAccountUID(@NonNull String accountUID) {
         this.mAccountUID = accountUID;
     }
 
+    @NonNull
     public TransactionType getType() {
         return mSplitType;
     }
 
-    public void setType(TransactionType transactionType) {
+    public void setType(@NonNull TransactionType transactionType) {
         this.mSplitType = transactionType;
     }
 
+    @Nullable
     public String getMemo() {
         return mMemo;
     }
 
-    public void setMemo(String memo) {
+    public void setMemo(@Nullable String memo) {
         this.mMemo = memo;
     }
 
-    public Split createPair(String accountUID){
+    @NonNull
+    public Split createPair(@NonNull String accountUID){
         Split pair = new Split(mAmount.absolute(), accountUID);
         pair.setType(mSplitType.invert());
         pair.setMemo(mMemo);
@@ -133,7 +149,8 @@ public class Split {
         return pair;
     }
 
-    protected Split clone(){
+    @NonNull
+    protected Split clone() {
         Split split = new Split(mAmount, mAccountUID);
         split.mUID = mUID;
         split.setType(mSplitType);
@@ -145,14 +162,15 @@ public class Split {
     /**
      * Checks is this <code>other</code> is a pair split of this.
      * <p>Two splits are considered a pair if they have the same amount and opposite split types</p>
-     * @param other
-     * @return
+     * @param other the other split of the pair to be tested
+     * @return whether the two splits are a pair
      */
-    public boolean isPairOf(Split other) {
+    public boolean isPairOf(@NonNull Split other) {
         return mAmount.absolute().equals(other.mAmount.absolute())
                 && mSplitType.invert().equals(other.mSplitType);
     }
 
+    @NonNull
     @Override
     public String toString() {
         return mSplitType.name() + " of " + mAmount.toString() + " in account: " + mAccountUID;
@@ -160,8 +178,9 @@ public class Split {
 
     /**
      * Returns a string representation of the split which can be parsed again using {@link org.gnucash.android.model.Split#parseSplit(String)}
-     * @return
+     * @return the converted CSV string of this split
      */
+    @NonNull
     public String toCsv(){
         String splitString = mAmount.toString() + ";" + mAmount.getCurrency().getCurrencyCode() + ";"
                 + mAccountUID + ";" + mSplitType.name();
@@ -177,7 +196,7 @@ public class Split {
      * @param rootNode Parent node to append the split XML to
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(Document doc, Element rootNode) {
+    public void toGncXml(@NonNull Document doc, @NonNull Element rootNode) {
         Element idNode = doc.createElement(GncXmlHelper.TAG_SPLIT_ID);
         idNode.setAttribute("type", "guid");
         idNode.appendChild(doc.createTextNode(mUID));
@@ -217,7 +236,8 @@ public class Split {
      * @param splitString String containing formatted split
      * @return Split instance parsed from the string
      */
-    public static Split parseSplit(String splitString) {
+    @NonNull
+    public static Split parseSplit(@NonNull String splitString) {
         String[] tokens = splitString.split(";");
         Money amount = new Money(tokens[0], tokens[1]);
         Split split = new Split(amount, tokens[2]);

--- a/app/src/org/gnucash/android/model/Split.java
+++ b/app/src/org/gnucash/android/model/Split.java
@@ -1,7 +1,5 @@
 package org.gnucash.android.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.gnucash.android.export.xml.GncXmlHelper;
 import org.w3c.dom.Document;
@@ -23,37 +21,31 @@ public class Split {
     /**
      * Amount value of this split
      */
-    @NonNull
     private Money mAmount;
 
     /**
      * Unique ID of this split
      */
-    @NonNull
     private String mUID;
 
     /**
      * Transaction UID which this split belongs to
      */
-    @NonNull
     private String mTransactionUID = "";
 
     /**
      * Account UID which this split belongs to
      */
-    @NonNull
     private String mAccountUID;
 
     /**
      * The type of this transaction, credit or debit
      */
-    @NonNull
     private TransactionType mSplitType = TransactionType.CREDIT;
 
     /**
      * Memo associated with this split
      */
-    @Nullable
     private String mMemo;
 
     /**
@@ -61,7 +53,7 @@ public class Split {
      * @param amount Money amount of this split
      * @param accountUID String UID of transfer account
      */
-    public Split(@NonNull Money amount, @NonNull String accountUID){
+    public Split(Money amount, String accountUID){
         setAmount(amount);
         setAccountUID(accountUID);
         mUID = UUID.randomUUID().toString().replaceAll("-","");
@@ -72,7 +64,7 @@ public class Split {
      * @param sourceSplit Split to be cloned
      * @param generateUID Determines if the clone should have a new UID or should maintain the one from source
      */
-    public Split(@NonNull Split sourceSplit, boolean generateUID){
+    public Split(Split sourceSplit, boolean generateUID){
         this.mMemo          = sourceSplit.mMemo;
         this.mAccountUID    = sourceSplit.mAccountUID;
         this.mSplitType     = sourceSplit.mSplitType;
@@ -86,62 +78,55 @@ public class Split {
         }
     }
 
-    @NonNull
     public Money getAmount() {
         return mAmount;
     }
 
-    public void setAmount(@NonNull Money amount) {
+    public void setAmount(Money amount) {
         this.mAmount = amount;
     }
 
-    @NonNull
     public String getUID() {
         return mUID;
     }
 
-    public void setUID(@NonNull String uid) {
+    public void setUID(String uid) {
         this.mUID = uid;
     }
 
-    @NonNull
     public String getTransactionUID() {
         return mTransactionUID;
     }
 
-    public void setTransactionUID(@NonNull String transactionUID) {
+    public void setTransactionUID(String transactionUID) {
         this.mTransactionUID = transactionUID;
     }
 
-    @NonNull
     public String getAccountUID() {
         return mAccountUID;
     }
 
-    public void setAccountUID(@NonNull String accountUID) {
+    public void setAccountUID(String accountUID) {
         this.mAccountUID = accountUID;
     }
 
-    @NonNull
     public TransactionType getType() {
         return mSplitType;
     }
 
-    public void setType(@NonNull TransactionType transactionType) {
+    public void setType(TransactionType transactionType) {
         this.mSplitType = transactionType;
     }
 
-    @Nullable
     public String getMemo() {
         return mMemo;
     }
 
-    public void setMemo(@Nullable String memo) {
+    public void setMemo(String memo) {
         this.mMemo = memo;
     }
 
-    @NonNull
-    public Split createPair(@NonNull String accountUID){
+    public Split createPair(String accountUID){
         Split pair = new Split(mAmount.absolute(), accountUID);
         pair.setType(mSplitType.invert());
         pair.setMemo(mMemo);
@@ -149,7 +134,6 @@ public class Split {
         return pair;
     }
 
-    @NonNull
     protected Split clone() {
         Split split = new Split(mAmount, mAccountUID);
         split.mUID = mUID;
@@ -165,12 +149,11 @@ public class Split {
      * @param other the other split of the pair to be tested
      * @return whether the two splits are a pair
      */
-    public boolean isPairOf(@NonNull Split other) {
+    public boolean isPairOf(Split other) {
         return mAmount.absolute().equals(other.mAmount.absolute())
                 && mSplitType.invert().equals(other.mSplitType);
     }
 
-    @NonNull
     @Override
     public String toString() {
         return mSplitType.name() + " of " + mAmount.toString() + " in account: " + mAccountUID;
@@ -180,7 +163,6 @@ public class Split {
      * Returns a string representation of the split which can be parsed again using {@link org.gnucash.android.model.Split#parseSplit(String)}
      * @return the converted CSV string of this split
      */
-    @NonNull
     public String toCsv(){
         String splitString = mAmount.toString() + ";" + mAmount.getCurrency().getCurrencyCode() + ";"
                 + mAccountUID + ";" + mSplitType.name();
@@ -196,7 +178,7 @@ public class Split {
      * @param rootNode Parent node to append the split XML to
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(@NonNull Document doc, @NonNull Element rootNode) {
+    public void toGncXml(Document doc, Element rootNode) {
         Element idNode = doc.createElement(GncXmlHelper.TAG_SPLIT_ID);
         idNode.setAttribute("type", "guid");
         idNode.appendChild(doc.createTextNode(mUID));
@@ -236,8 +218,7 @@ public class Split {
      * @param splitString String containing formatted split
      * @return Split instance parsed from the string
      */
-    @NonNull
-    public static Split parseSplit(@NonNull String splitString) {
+    public static Split parseSplit(String splitString) {
         String[] tokens = splitString.split(";");
         Money amount = new Money(tokens[0], tokens[1]);
         Split split = new Split(amount, tokens[2]);

--- a/app/src/org/gnucash/android/model/Transaction.java
+++ b/app/src/org/gnucash/android/model/Transaction.java
@@ -17,6 +17,8 @@
 package org.gnucash.android.model;
 
 import android.content.Intent;
+import android.support.annotation.NonNull;
+
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.export.ofx.OfxHelper;
@@ -76,27 +78,32 @@ public class Transaction {
     /**
      * Currency used by splits in this transaction
      */
+    @NonNull
     private String mCurrencyCode = Money.DEFAULT_CURRENCY_CODE;
 
     /**
      * The splits making up this transaction
      */
+    @NonNull
     private List<Split> mSplitList = new ArrayList<Split>();
 
 	/**
 	 * Unique identifier of the transaction.
 	 * This is automatically generated when the transaction is created.
 	 */
+    @NonNull
 	private String mUID;
 
 	/**
 	 * Name describing the transaction
 	 */
+    @NonNull
 	private String mDescription;
 
 	/**
 	 * An extra note giving details about the transaction
 	 */
+    @NonNull
 	private String mNotes = "";
 
 	/**
@@ -122,7 +129,7 @@ public class Transaction {
 	 * provided data and initializes the rest to default values.
 	 * @param name Name of the transaction
 	 */
-	public Transaction(String name) {
+	public Transaction(@NonNull String name) {
 		initDefaults();
 		setDescription(name);
 	}
@@ -135,7 +142,7 @@ public class Transaction {
      * @param transaction Transaction to be cloned
      * @param generateNewUID Flag to determine if new UID should be assigned or not
      */
-    public Transaction(Transaction transaction, boolean generateNewUID){
+    public Transaction(@NonNull Transaction transaction, boolean generateNewUID){
         initDefaults();
         setDescription(transaction.getDescription());
         setNote(transaction.getNote());
@@ -160,6 +167,7 @@ public class Transaction {
      * Returns list of splits for this transaction
      * @return {@link java.util.List} of splits in the transaction
      */
+    @NonNull
     public List<Split> getSplits(){
         return mSplitList;
     }
@@ -169,6 +177,7 @@ public class Transaction {
      * @param accountUID Unique Identifier of the account
      * @return List of {@link org.gnucash.android.model.Split}s
      */
+    @NonNull
     public List<Split> getSplits(String accountUID){
         List<Split> splits = new ArrayList<Split>();
         for (Split split : mSplitList) {
@@ -184,7 +193,7 @@ public class Transaction {
      * <p>All the splits in the list will have their transaction UID set to this transaction</p>
      * @param splitList List of splits for this transaction
      */
-    public void setSplits(List<Split> splitList){
+    public void setSplits(@NonNull List<Split> splitList){
         mSplitList = splitList;
     }
 
@@ -193,7 +202,7 @@ public class Transaction {
      * <p>Sets the split UID and currency to that of this transaction</p>
      * @param split Split for this transaction
      */
-    public void addSplit(Split split){
+    public void addSplit(@NonNull Split split){
         //sets the currency of the split to the currency of the transaction
         split.setAmount(split.getAmount().withCurrency(Currency.getInstance(mCurrencyCode)));
         split.setTransactionUID(mUID);
@@ -207,7 +216,7 @@ public class Transaction {
      * @return Money balance of the transaction for the specified account
      * @see #computeBalance(String, java.util.List)
      */
-    public Money getBalance(String accountUID){
+    public Money getBalance(@NonNull String accountUID){
         return computeBalance(accountUID, mSplitList);
     }
 
@@ -217,6 +226,7 @@ public class Transaction {
      * means there is an extra amount which is unresolved.
      * @return Money imbalance of the transaction
      */
+    @NonNull
     public Money getImbalance(){
         Money imbalance = Money.createZeroInstance(mCurrencyCode);
         for (Split split : mSplitList) {
@@ -236,7 +246,8 @@ public class Transaction {
      * @param splitList List of splits
      * @return Money list of splits
      */
-    public static Money computeBalance(String accountUID, List<Split> splitList){
+    @NonNull
+    public static Money computeBalance(@NonNull String accountUID, @NonNull List<Split> splitList) {
         AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         AccountType accountType = accountsDbAdapter.getAccountType(accountUID);
         String currencyCode = accountsDbAdapter.getCurrencyCode(accountUID);
@@ -269,6 +280,7 @@ public class Transaction {
      * Returns the currency code of this transaction.
      * @return ISO 4217 currency code string
      */
+    @NonNull
     public String getCurrencyCode() {
         return mCurrencyCode;
     }
@@ -279,7 +291,7 @@ public class Transaction {
      * Transactions always use the currency of their accounts. </p>
      * @param currencyCode String with ISO 4217 currency code
      */
-    public void setCurrencyCode(String currencyCode) {
+    public void setCurrencyCode(@NonNull String currencyCode) {
         this.mCurrencyCode = currencyCode;
     }
 
@@ -288,6 +300,7 @@ public class Transaction {
      * @return Currency of the transaction
      * @see #getCurrencyCode()
      */
+    @NonNull
     public Currency getCurrency(){
         return Currency.getInstance(this.mCurrencyCode);
     }
@@ -296,7 +309,8 @@ public class Transaction {
 	 * Returns the description of the transaction
 	 * @return Transaction description
 	 */
-	public String getDescription() {
+	@NonNull
+    public String getDescription() {
 		return mDescription;
 	}
 
@@ -304,7 +318,7 @@ public class Transaction {
 	 * Sets the transaction description
 	 * @param description String description
 	 */
-	public void setDescription(String description) {
+	public void setDescription(@NonNull String description) {
 		this.mDescription = description.trim();
 	}
 
@@ -312,7 +326,7 @@ public class Transaction {
 	 * Add notes to the transaction
 	 * @param notes String containing notes for the transaction
 	 */
-	public void setNote(String notes) {
+	public void setNote(@NonNull String notes) {
 		this.mNotes = notes;
 	}
 
@@ -320,7 +334,8 @@ public class Transaction {
 	 * Returns the transaction notes
 	 * @return String notes of transaction
 	 */
-	public String getNote() {
+	@NonNull
+    public String getNote() {
 		return mNotes;
 	}
 
@@ -328,7 +343,7 @@ public class Transaction {
 	 * Set the time of the transaction
 	 * @param timestamp Time when transaction occurred as {@link Date}
 	 */
-	public void setTime(Date timestamp){
+	public void setTime(@NonNull Date timestamp){
 		this.mTimestamp = timestamp.getTime();
 	}
 
@@ -355,7 +370,7 @@ public class Transaction {
 	 * @param transactionUID Unique ID string
      * @see #resetUID()
 	 */
-	public void setUID(String transactionUID) {
+	public void setUID(@NonNull String transactionUID) {
 		this.mUID = transactionUID;
 	}
 
@@ -369,7 +384,8 @@ public class Transaction {
 	 * Returns unique ID string for transaction
 	 * @return String with Unique ID of transaction
 	 */
-	public String getUID() {
+	@NonNull
+    public String getUID() {
 		return mUID;
 	}
 
@@ -380,7 +396,8 @@ public class Transaction {
      * @param shouldReduceBalance <code>true</code> if type should reduce balance, <code>false</code> otherwise
      * @return TransactionType for the account
      */
-    public static TransactionType getTypeForBalance(AccountType accountType, boolean shouldReduceBalance){
+    @NonNull
+    public static TransactionType getTypeForBalance(@NonNull AccountType accountType, boolean shouldReduceBalance){
         TransactionType type;
         if (accountType.hasDebitNormalBalance()) {
             type = shouldReduceBalance ? TransactionType.CREDIT : TransactionType.DEBIT;
@@ -395,8 +412,8 @@ public class Transaction {
      * @return true if the amount represents a decrease in the account balance, false otherwise
      * @see #getTypeForBalance(AccountType, boolean)
      */
-    public static boolean shouldDecreaseBalance(AccountType accountType, TransactionType transactionType){
-        if (accountType.hasDebitNormalBalance()){
+    public static boolean shouldDecreaseBalance(@NonNull AccountType accountType, @NonNull TransactionType transactionType) {
+        if (accountType.hasDebitNormalBalance()) {
             return transactionType == TransactionType.CREDIT;
         } else
             return transactionType == TransactionType.DEBIT;
@@ -441,7 +458,7 @@ public class Transaction {
      * @param doc XML document to which transaction should be added
      * @param accountUID Unique Identifier of the account which called the method.  @return Element in DOM corresponding to transaction
      */
-	public Element toOFX(Document doc, String accountUID){
+	public Element toOFX(@NonNull Document doc, @NonNull String accountUID){
         Money balance = getBalance(accountUID);
         TransactionType transactionType = balance.isNegative() ? TransactionType.DEBIT : TransactionType.CREDIT;
 
@@ -513,7 +530,7 @@ public class Transaction {
      * @param rootElement Parent node for the XML
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(Document doc, Element rootElement) {
+    public void toGncXml(@NonNull Document doc, @NonNull Element rootElement) {
         Element idNode = doc.createElement(GncXmlHelper.TAG_TRX_ID);
         idNode.setAttribute(GncXmlHelper.ATTR_KEY_TYPE, GncXmlHelper.ATTR_VALUE_GUID);
         idNode.appendChild(doc.createTextNode(mUID));
@@ -578,7 +595,8 @@ public class Transaction {
      * @param transaction Transaction used to create intent
      * @return Intent with transaction details as extras
      */
-    public static Intent createIntent(Transaction transaction){
+    @NonNull
+    public static Intent createIntent(@NonNull Transaction transaction){
         Intent intent = new Intent(Intent.ACTION_INSERT);
         intent.setType(Transaction.MIME_TYPE);
         intent.putExtra(Intent.EXTRA_TITLE, transaction.getDescription());

--- a/app/src/org/gnucash/android/model/Transaction.java
+++ b/app/src/org/gnucash/android/model/Transaction.java
@@ -237,10 +237,9 @@ public class Transaction {
      * @return Money list of splits
      */
     public static Money computeBalance(String accountUID, List<Split> splitList){
-        AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(GnuCashApplication.getAppContext());
+        AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         AccountType accountType = accountsDbAdapter.getAccountType(accountUID);
         String currencyCode = accountsDbAdapter.getCurrencyCode(accountUID);
-        accountsDbAdapter.close();
 
         boolean isDebitAccount = accountType.hasDebitNormalBalance();
         Money balance = Money.createZeroInstance(currencyCode);
@@ -493,10 +492,9 @@ public class Transaction {
             acctId.appendChild(doc.createTextNode(transferAccountUID));
 
             Element accttype = doc.createElement(OfxHelper.TAG_ACCOUNT_TYPE);
-            AccountsDbAdapter acctDbAdapter = new AccountsDbAdapter(GnuCashApplication.getAppContext());
+            AccountsDbAdapter acctDbAdapter = GnuCashApplication.getAccountsDbAdapter();
             OfxAccountType ofxAccountType = Account.convertToOfxAccountType(acctDbAdapter.getAccountType(transferAccountUID));
             accttype.appendChild(doc.createTextNode(ofxAccountType.toString()));
-            acctDbAdapter.close();
 
             Element bankAccountTo = doc.createElement(OfxHelper.TAG_BANK_ACCOUNT_TO);
             bankAccountTo.appendChild(bankId);

--- a/app/src/org/gnucash/android/model/Transaction.java
+++ b/app/src/org/gnucash/android/model/Transaction.java
@@ -17,7 +17,6 @@
 package org.gnucash.android.model;
 
 import android.content.Intent;
-import android.support.annotation.NonNull;
 
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
@@ -78,32 +77,27 @@ public class Transaction {
     /**
      * Currency used by splits in this transaction
      */
-    @NonNull
     private String mCurrencyCode = Money.DEFAULT_CURRENCY_CODE;
 
     /**
      * The splits making up this transaction
      */
-    @NonNull
     private List<Split> mSplitList = new ArrayList<Split>();
 
 	/**
 	 * Unique identifier of the transaction.
 	 * This is automatically generated when the transaction is created.
 	 */
-    @NonNull
 	private String mUID;
 
 	/**
 	 * Name describing the transaction
 	 */
-    @NonNull
 	private String mDescription;
 
 	/**
 	 * An extra note giving details about the transaction
 	 */
-    @NonNull
 	private String mNotes = "";
 
 	/**
@@ -129,7 +123,7 @@ public class Transaction {
 	 * provided data and initializes the rest to default values.
 	 * @param name Name of the transaction
 	 */
-	public Transaction(@NonNull String name) {
+	public Transaction(String name) {
 		initDefaults();
 		setDescription(name);
 	}
@@ -142,7 +136,7 @@ public class Transaction {
      * @param transaction Transaction to be cloned
      * @param generateNewUID Flag to determine if new UID should be assigned or not
      */
-    public Transaction(@NonNull Transaction transaction, boolean generateNewUID){
+    public Transaction(Transaction transaction, boolean generateNewUID){
         initDefaults();
         setDescription(transaction.getDescription());
         setNote(transaction.getNote());
@@ -167,7 +161,6 @@ public class Transaction {
      * Returns list of splits for this transaction
      * @return {@link java.util.List} of splits in the transaction
      */
-    @NonNull
     public List<Split> getSplits(){
         return mSplitList;
     }
@@ -177,7 +170,6 @@ public class Transaction {
      * @param accountUID Unique Identifier of the account
      * @return List of {@link org.gnucash.android.model.Split}s
      */
-    @NonNull
     public List<Split> getSplits(String accountUID){
         List<Split> splits = new ArrayList<Split>();
         for (Split split : mSplitList) {
@@ -193,7 +185,7 @@ public class Transaction {
      * <p>All the splits in the list will have their transaction UID set to this transaction</p>
      * @param splitList List of splits for this transaction
      */
-    public void setSplits(@NonNull List<Split> splitList){
+    public void setSplits(List<Split> splitList){
         mSplitList = splitList;
     }
 
@@ -202,7 +194,7 @@ public class Transaction {
      * <p>Sets the split UID and currency to that of this transaction</p>
      * @param split Split for this transaction
      */
-    public void addSplit(@NonNull Split split){
+    public void addSplit(Split split){
         //sets the currency of the split to the currency of the transaction
         split.setAmount(split.getAmount().withCurrency(Currency.getInstance(mCurrencyCode)));
         split.setTransactionUID(mUID);
@@ -216,7 +208,7 @@ public class Transaction {
      * @return Money balance of the transaction for the specified account
      * @see #computeBalance(String, java.util.List)
      */
-    public Money getBalance(@NonNull String accountUID){
+    public Money getBalance(String accountUID){
         return computeBalance(accountUID, mSplitList);
     }
 
@@ -226,7 +218,6 @@ public class Transaction {
      * means there is an extra amount which is unresolved.
      * @return Money imbalance of the transaction
      */
-    @NonNull
     public Money getImbalance(){
         Money imbalance = Money.createZeroInstance(mCurrencyCode);
         for (Split split : mSplitList) {
@@ -246,8 +237,7 @@ public class Transaction {
      * @param splitList List of splits
      * @return Money list of splits
      */
-    @NonNull
-    public static Money computeBalance(@NonNull String accountUID, @NonNull List<Split> splitList) {
+    public static Money computeBalance(String accountUID, List<Split> splitList) {
         AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         AccountType accountType = accountsDbAdapter.getAccountType(accountUID);
         String currencyCode = accountsDbAdapter.getCurrencyCode(accountUID);
@@ -280,7 +270,6 @@ public class Transaction {
      * Returns the currency code of this transaction.
      * @return ISO 4217 currency code string
      */
-    @NonNull
     public String getCurrencyCode() {
         return mCurrencyCode;
     }
@@ -291,7 +280,7 @@ public class Transaction {
      * Transactions always use the currency of their accounts. </p>
      * @param currencyCode String with ISO 4217 currency code
      */
-    public void setCurrencyCode(@NonNull String currencyCode) {
+    public void setCurrencyCode(String currencyCode) {
         this.mCurrencyCode = currencyCode;
     }
 
@@ -300,7 +289,6 @@ public class Transaction {
      * @return Currency of the transaction
      * @see #getCurrencyCode()
      */
-    @NonNull
     public Currency getCurrency(){
         return Currency.getInstance(this.mCurrencyCode);
     }
@@ -309,7 +297,6 @@ public class Transaction {
 	 * Returns the description of the transaction
 	 * @return Transaction description
 	 */
-	@NonNull
     public String getDescription() {
 		return mDescription;
 	}
@@ -318,7 +305,7 @@ public class Transaction {
 	 * Sets the transaction description
 	 * @param description String description
 	 */
-	public void setDescription(@NonNull String description) {
+	public void setDescription(String description) {
 		this.mDescription = description.trim();
 	}
 
@@ -326,7 +313,7 @@ public class Transaction {
 	 * Add notes to the transaction
 	 * @param notes String containing notes for the transaction
 	 */
-	public void setNote(@NonNull String notes) {
+	public void setNote(String notes) {
 		this.mNotes = notes;
 	}
 
@@ -334,7 +321,6 @@ public class Transaction {
 	 * Returns the transaction notes
 	 * @return String notes of transaction
 	 */
-	@NonNull
     public String getNote() {
 		return mNotes;
 	}
@@ -343,7 +329,7 @@ public class Transaction {
 	 * Set the time of the transaction
 	 * @param timestamp Time when transaction occurred as {@link Date}
 	 */
-	public void setTime(@NonNull Date timestamp){
+	public void setTime(Date timestamp){
 		this.mTimestamp = timestamp.getTime();
 	}
 
@@ -370,7 +356,7 @@ public class Transaction {
 	 * @param transactionUID Unique ID string
      * @see #resetUID()
 	 */
-	public void setUID(@NonNull String transactionUID) {
+	public void setUID(String transactionUID) {
 		this.mUID = transactionUID;
 	}
 
@@ -384,7 +370,6 @@ public class Transaction {
 	 * Returns unique ID string for transaction
 	 * @return String with Unique ID of transaction
 	 */
-	@NonNull
     public String getUID() {
 		return mUID;
 	}
@@ -396,8 +381,7 @@ public class Transaction {
      * @param shouldReduceBalance <code>true</code> if type should reduce balance, <code>false</code> otherwise
      * @return TransactionType for the account
      */
-    @NonNull
-    public static TransactionType getTypeForBalance(@NonNull AccountType accountType, boolean shouldReduceBalance){
+    public static TransactionType getTypeForBalance(AccountType accountType, boolean shouldReduceBalance){
         TransactionType type;
         if (accountType.hasDebitNormalBalance()) {
             type = shouldReduceBalance ? TransactionType.CREDIT : TransactionType.DEBIT;
@@ -412,7 +396,7 @@ public class Transaction {
      * @return true if the amount represents a decrease in the account balance, false otherwise
      * @see #getTypeForBalance(AccountType, boolean)
      */
-    public static boolean shouldDecreaseBalance(@NonNull AccountType accountType, @NonNull TransactionType transactionType) {
+    public static boolean shouldDecreaseBalance(AccountType accountType, TransactionType transactionType) {
         if (accountType.hasDebitNormalBalance()) {
             return transactionType == TransactionType.CREDIT;
         } else
@@ -458,7 +442,7 @@ public class Transaction {
      * @param doc XML document to which transaction should be added
      * @param accountUID Unique Identifier of the account which called the method.  @return Element in DOM corresponding to transaction
      */
-	public Element toOFX(@NonNull Document doc, @NonNull String accountUID){
+	public Element toOFX(Document doc, String accountUID){
         Money balance = getBalance(accountUID);
         TransactionType transactionType = balance.isNegative() ? TransactionType.DEBIT : TransactionType.CREDIT;
 
@@ -530,7 +514,7 @@ public class Transaction {
      * @param rootElement Parent node for the XML
      * @deprecated Use the {@link org.gnucash.android.export.xml.GncXmlExporter} to generate XML
      */
-    public void toGncXml(@NonNull Document doc, @NonNull Element rootElement) {
+    public void toGncXml(Document doc, Element rootElement) {
         Element idNode = doc.createElement(GncXmlHelper.TAG_TRX_ID);
         idNode.setAttribute(GncXmlHelper.ATTR_KEY_TYPE, GncXmlHelper.ATTR_VALUE_GUID);
         idNode.appendChild(doc.createTextNode(mUID));
@@ -595,8 +579,7 @@ public class Transaction {
      * @param transaction Transaction used to create intent
      * @return Intent with transaction details as extras
      */
-    @NonNull
-    public static Intent createIntent(@NonNull Transaction transaction){
+    public static Intent createIntent(Transaction transaction){
         Intent intent = new Intent(Intent.ACTION_INSERT);
         intent.setType(Transaction.MIME_TYPE);
         intent.putExtra(Intent.EXTRA_TITLE, transaction.getDescription());

--- a/app/src/org/gnucash/android/receivers/AccountCreator.java
+++ b/app/src/org/gnucash/android/receivers/AccountCreator.java
@@ -18,6 +18,7 @@ package org.gnucash.android.receivers;
 
 import java.util.Currency;
 
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.db.AccountsDbAdapter;
 
@@ -57,9 +58,7 @@ public class AccountCreator extends BroadcastReceiver {
 		if (uid != null)
 			account.setUID(uid);
 		
-		AccountsDbAdapter accountsAdapter = new AccountsDbAdapter(context);
-		accountsAdapter.addAccount(account);
-		accountsAdapter.close();
+		GnuCashApplication.getAccountsDbAdapter().addAccount(account);
 	}
 
 }

--- a/app/src/org/gnucash/android/receivers/TransactionRecorder.java
+++ b/app/src/org/gnucash/android/receivers/TransactionRecorder.java
@@ -21,6 +21,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.TransactionsDbAdapter;
 import org.gnucash.android.model.*;
 import org.gnucash.android.ui.widget.WidgetConfigurationActivity;
@@ -91,12 +93,9 @@ public class TransactionRecorder extends BroadcastReceiver {
             }
         }
 
-		TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(context);
-		transactionsDbAdapter.addTransaction(transaction);
+		GnuCashApplication.getTransactionDbAdapter().addTransaction(transaction);
 		
 		WidgetConfigurationActivity.updateAllWidgets(context);
-
-		transactionsDbAdapter.close();
 	}
 
 }

--- a/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -209,11 +209,11 @@ public class AccountFormFragment extends SherlockFragment {
 	 * @return New instance of the dialog fragment
 	 */
     @NonNull
-	static public AccountFormFragment newInstance(@NonNull AccountsDbAdapter dbAdapter){
-		AccountFormFragment f = new AccountFormFragment();
-		f.mAccountsDbAdapter = dbAdapter;
-		return f;
-	}
+	static public AccountFormFragment newInstance() {
+        AccountFormFragment f = new AccountFormFragment();
+        f.mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+        return f;
+    }
 	
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -356,7 +356,8 @@ public class AccountFormFragment extends SherlockFragment {
         mNameEditText.setText(account.getName());
 
         if (mUseDoubleEntry) {
-            long doubleDefaultAccountId = mAccountsDbAdapter.getAccountID(account.getDefaultTransferAccountUID());
+            String defaultTransferUID = account.getDefaultTransferAccountUID();
+            long doubleDefaultAccountId = (defaultTransferUID == null ? -1 : mAccountsDbAdapter.getAccountID(defaultTransferUID));
             setDefaultTransferAccountSelection(doubleDefaultAccountId);
         }
 
@@ -388,7 +389,7 @@ public class AccountFormFragment extends SherlockFragment {
      * Initializes the preview of the color picker (color square) to the specified color
      * @param colorHex Color of the format #rgb or #rrggbb
      */
-    private void initializeColorSquarePreview(String colorHex){
+    private void initializeColorSquarePreview(@NonNull String colorHex){
         if (colorHex != null)
             mColorSquare.setBackgroundColor(Color.parseColor(colorHex));
         else
@@ -412,6 +413,7 @@ public class AccountFormFragment extends SherlockFragment {
     private void setDefaultTransferAccountInputsVisible(boolean visible) {
         final int visibility = visible ? View.VISIBLE : View.GONE;
         final View view = getView();
+        assert view != null;
         view.findViewById(R.id.layout_default_transfer_account).setVisibility(visibility);
         view.findViewById(R.id.label_default_transfer_account).setVisibility(visibility);
     }
@@ -570,6 +572,7 @@ public class AccountFormFragment extends SherlockFragment {
 		mParentAccountCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(condition, null);
 		if (mParentAccountCursor.getCount() <= 0){
             final View view = getView();
+            assert view != null;
             view.findViewById(R.id.layout_parent_account).setVisibility(View.GONE);
             view.findViewById(R.id.label_parent_account).setVisibility(View.GONE);
         }
@@ -756,7 +759,7 @@ public class AccountFormFragment extends SherlockFragment {
                     // mAccountsDbAdapter.getDescendantAccountUIDs() will ensure a parent-child order
                     Account acct = mapAccount.get(uid);
                     // mAccount cannot be root, so acct here cannot be top level account.
-                    if (acct.getParentUID().equals(mAccount.getUID())) {
+                    if (mAccount.getUID().equals(acct.getParentUID())) {
                         acct.setFullName(mAccount.getFullName() + AccountsDbAdapter.ACCOUNT_NAME_SEPARATOR + acct.getName());
                     }
                     else {

--- a/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -298,7 +298,7 @@ public class AccountFormFragment extends SherlockFragment {
 		ArrayAdapter<String> currencyArrayAdapter = new ArrayAdapter<String>(
 				getActivity(), 
 				android.R.layout.simple_spinner_item, 
-				getResources().getStringArray(R.array.currency_names));		
+				getResources().getStringArray(R.array.currency_names));
 		currencyArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		mCurrencySpinner.setAdapter(currencyArrayAdapter);
 
@@ -309,8 +309,11 @@ public class AccountFormFragment extends SherlockFragment {
             getSherlockActivity().getSupportActionBar().setTitle(R.string.title_edit_account);
         }
         mRootAccountUID = mAccountsDbAdapter.getGnuCashRootAccountUID();
-        mRootAccountId = mAccountsDbAdapter.getAccountID(mRootAccountUID);
-
+        if (mRootAccountUID == null) {
+            mRootAccountId = -1;
+        } else {
+            mRootAccountId = mAccountsDbAdapter.getAccountID(mRootAccountUID);
+        }
         //need to load the cursor adapters for the spinners before initializing the views
         loadAccountTypesList();
         loadDefaultTransferAccountList();
@@ -522,16 +525,17 @@ public class AccountFormFragment extends SherlockFragment {
     /**
      * Initializes the default transfer account spinner with eligible accounts
      */
-    private void loadDefaultTransferAccountList(){
-        String condition = DatabaseSchema.AccountEntry.COLUMN_UID + " != '" + mAccountUID + "' "
+    private void loadDefaultTransferAccountList() {
+        String condition = DatabaseSchema.AccountEntry.COLUMN_UID + " != ? "
                 + " AND " + DatabaseSchema.AccountEntry.COLUMN_PLACEHOLDER + "=0"
-                + " AND " + DatabaseSchema.AccountEntry.COLUMN_UID + " != '" + mAccountsDbAdapter.getGnuCashRootAccountUID() + "'";
+                + " AND " + DatabaseSchema.AccountEntry.COLUMN_UID + " != ?";
         /*
-      Cursor holding data set of eligible transfer accounts
-     */
-        Cursor defaultTransferAccountCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(condition);
+         * Cursor holding data set of eligible transfer accounts
+         */
+        Cursor defaultTransferAccountCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(condition,
+                new String[]{mAccountUID, "" + mAccountsDbAdapter.getGnuCashRootAccountUID()});
 
-        if (defaultTransferAccountCursor == null || mDefaulTransferAccountSpinner.getCount() <= 0){
+        if (mDefaulTransferAccountSpinner.getCount() <= 0) {
             setDefaultTransferAccountInputsVisible(false);
         }
 
@@ -563,8 +567,8 @@ public class AccountFormFragment extends SherlockFragment {
         if (mParentAccountCursor != null)
             mParentAccountCursor.close();
 
-		mParentAccountCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(condition);
-		if (mParentAccountCursor == null || mParentAccountCursor.getCount() <= 0){
+		mParentAccountCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(condition, null);
+		if (mParentAccountCursor.getCount() <= 0){
             final View view = getView();
             view.findViewById(R.id.layout_parent_account).setVisibility(View.GONE);
             view.findViewById(R.id.label_parent_account).setVisibility(View.GONE);

--- a/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -27,7 +27,6 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.text.TextUtils;
@@ -208,7 +207,6 @@ public class AccountFormFragment extends SherlockFragment {
 	 * @param dbAdapter {@link AccountsDbAdapter} for saving the account
 	 * @return New instance of the dialog fragment
 	 */
-    @NonNull
 	static public AccountFormFragment newInstance() {
         AccountFormFragment f = new AccountFormFragment();
         f.mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
@@ -228,8 +226,7 @@ public class AccountFormFragment extends SherlockFragment {
 	/**
 	 * Inflates the dialog view and retrieves references to the dialog elements
 	 */
-	@Override @NonNull
-	public View onCreateView(LayoutInflater inflater, ViewGroup container,
+	@Override	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.fragment_new_account, container, false);
 		getSherlockActivity().getSupportActionBar().setTitle(R.string.title_add_account);
@@ -389,7 +386,7 @@ public class AccountFormFragment extends SherlockFragment {
      * Initializes the preview of the color picker (color square) to the specified color
      * @param colorHex Color of the format #rgb or #rrggbb
      */
-    private void initializeColorSquarePreview(@NonNull String colorHex){
+    private void initializeColorSquarePreview(String colorHex){
         if (colorHex != null)
             mColorSquare.setBackgroundColor(Color.parseColor(colorHex));
         else
@@ -785,7 +782,6 @@ public class AccountFormFragment extends SherlockFragment {
      * Returns the currently selected account type in the spinner
      * @return {@link org.gnucash.android.model.AccountType} currently selected
      */
-    @NonNull
     private AccountType getSelectedAccountType() {
         int selectedAccountTypeIndex = mAccountTypeSpinner.getSelectedItemPosition();
         String[] accountTypeEntries = getResources().getStringArray(R.array.key_account_type_entries);

--- a/app/src/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsActivity.java
@@ -408,7 +408,7 @@ public class AccountsActivity extends PassLockActivity implements OnAccountClick
         FragmentTransaction fragmentTransaction = fragmentManager
                 .beginTransaction();
 
-        AccountFormFragment accountFormFragment = AccountFormFragment.newInstance(null);
+        AccountFormFragment accountFormFragment = AccountFormFragment.newInstance();
         accountFormFragment.setArguments(args);
 
         fragmentTransaction.replace(R.id.fragment_container,

--- a/app/src/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsActivity.java
@@ -495,9 +495,7 @@ public class AccountsActivity extends PassLockActivity implements OnAccountClick
             delegate = new TaskDelegate() {
                 @Override
                 public void onTaskComplete() {
-                    AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(activity);
-                    accountsDbAdapter.updateAllAccounts(DatabaseSchema.AccountEntry.COLUMN_CURRENCY, currencyCode);
-                    accountsDbAdapter.close();
+                    GnuCashApplication.getAccountsDbAdapter().updateAllAccounts(DatabaseSchema.AccountEntry.COLUMN_CURRENCY, currencyCode);
                 }
             };
         }

--- a/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -51,6 +51,7 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.db.*;
 import org.gnucash.android.export.ExportDialogFragment;
@@ -212,7 +213,7 @@ public class AccountsListFragment extends SherlockListFragment implements
         if (args != null)
             mParentAccountUID = args.getString(UxArgument.PARENT_ACCOUNT_UID);
 
-        mAccountsDbAdapter = new AccountsDbAdapter(getActivity());
+        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         mAccountsCursorAdapter = new AccountsCursorAdapter(
                 getActivity().getApplicationContext(),
                 R.layout.list_item_account, null,
@@ -429,8 +430,6 @@ public class AccountsListFragment extends SherlockListFragment implements
     @Override
     public void onDestroy() {
         super.onDestroy();
-        mAccountsDbAdapter.close();
-        mAccountsCursorAdapter.close();
     }
 
     /**
@@ -556,7 +555,7 @@ public class AccountsListFragment extends SherlockListFragment implements
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int whichButton) {
                                     Context context = getDialog().getContext();
-                                    AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(context);
+                                    AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
                                     if (uid == null) {
                                         accountsDbAdapter.deleteAllRecords();
                                         Toast.makeText(context, R.string.toast_all_accounts_deleted, Toast.LENGTH_SHORT).show();
@@ -566,7 +565,6 @@ public class AccountsListFragment extends SherlockListFragment implements
                                         long rowId = accountsDbAdapter.getID(uid);
                                         ((AccountsListFragment) getTargetFragment()).deleteAccount(rowId, deleteSubAccountsCheckBox.isChecked());
                                     }
-                                    accountsDbAdapter.close();
                                 }
                             })
                     .setNegativeButton(R.string.alert_dialog_cancel,
@@ -621,7 +619,7 @@ public class AccountsListFragment extends SherlockListFragment implements
 
         @Override
         public Cursor loadInBackground() {
-            mDatabaseAdapter = new AccountsDbAdapter(getContext());
+            mDatabaseAdapter = GnuCashApplication.getAccountsDbAdapter();
             Cursor cursor;
 
             if (mFilter != null){
@@ -665,11 +663,7 @@ public class AccountsListFragment extends SherlockListFragment implements
         public AccountsCursorAdapter(Context context, int layout, Cursor c,
                                      String[] from, int[] to) {
             super(context, layout, c, from, to, 0);
-            transactionsDBAdapter = new TransactionsDbAdapter(context);
-        }
-
-        public void close() {
-            transactionsDBAdapter.close();
+            transactionsDBAdapter = GnuCashApplication.getTransactionDbAdapter();
         }
 
         @Override

--- a/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -27,6 +27,7 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -540,6 +541,7 @@ public class AccountsListFragment extends SherlockListFragment implements
             return frag;
         }
 
+        @NonNull
         @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             int title = getArguments().getInt("title");

--- a/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -624,7 +624,7 @@ public class AccountsListFragment extends SherlockListFragment implements
 
             if (mFilter != null){
                 cursor = ((AccountsDbAdapter)mDatabaseAdapter)
-                        .fetchAccounts(DatabaseSchema.AccountEntry.COLUMN_NAME + " LIKE '%" + mFilter + "%'");
+                        .fetchAccounts(DatabaseSchema.AccountEntry.COLUMN_NAME + " LIKE '%" + mFilter + "%'", null);
             } else {
                 if (mParentAccountUID != null && mParentAccountUID.length() > 0)
                     cursor = ((AccountsDbAdapter) mDatabaseAdapter).fetchSubAccounts(mParentAccountUID);

--- a/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -27,7 +27,6 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -541,8 +540,7 @@ public class AccountsListFragment extends SherlockListFragment implements
             return frag;
         }
 
-        @NonNull
-        @Override
+            @Override
         public Dialog onCreateDialog(Bundle savedInstanceState) {
             int title = getArguments().getInt("title");
             final String uid = getArguments().getString(UxArgument.SELECTED_ACCOUNT_UID);

--- a/app/src/org/gnucash/android/ui/colorpicker/ColorPickerDialog.java
+++ b/app/src/org/gnucash/android/ui/colorpicker/ColorPickerDialog.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -100,7 +99,6 @@ public class ColorPickerDialog extends SherlockDialogFragment implements OnColor
         }
     }
 
-    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final Activity activity = getActivity();

--- a/app/src/org/gnucash/android/ui/colorpicker/ColorPickerDialog.java
+++ b/app/src/org/gnucash/android/ui/colorpicker/ColorPickerDialog.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -99,6 +100,7 @@ public class ColorPickerDialog extends SherlockDialogFragment implements OnColor
         }
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final Activity activity = getActivity();

--- a/app/src/org/gnucash/android/ui/settings/DeleteAllAccountsConfirmationDialog.java
+++ b/app/src/org/gnucash/android/ui/settings/DeleteAllAccountsConfirmationDialog.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.widget.Toast;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.export.xml.GncXmlExporter;
 import org.gnucash.android.ui.widget.WidgetConfigurationActivity;
@@ -51,9 +52,7 @@ public class DeleteAllAccountsConfirmationDialog extends DialogFragment {
                             public void onClick(DialogInterface dialog, int whichButton) {
                                 Context context = getDialog().getContext();
                                 GncXmlExporter.createBackup();
-                                AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(context);
-                                accountsDbAdapter.deleteAllRecords();
-                                accountsDbAdapter.close();
+                                GnuCashApplication.getAccountsDbAdapter().deleteAllRecords();
                                 Toast.makeText(context, R.string.toast_all_accounts_deleted, Toast.LENGTH_SHORT).show();
                                 WidgetConfigurationActivity.updateAllWidgets(context);
                             }

--- a/app/src/org/gnucash/android/ui/settings/DeleteAllTransacationsConfirmationDialog.java
+++ b/app/src/org/gnucash/android/ui/settings/DeleteAllTransacationsConfirmationDialog.java
@@ -58,20 +58,18 @@ public class DeleteAllTransacationsConfirmationDialog extends DialogFragment {
                                 GncXmlExporter.createBackup();
 
                                 Context context = getActivity();
-                                AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(context);
+                                AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
                                 List<Transaction> openingBalances = new ArrayList<Transaction>();
                                 boolean preserveOpeningBalances = GnuCashApplication.shouldSaveOpeningBalances(false);
                                 if (preserveOpeningBalances) {
                                     openingBalances = accountsDbAdapter.getAllOpeningBalanceTransactions();
-                                    accountsDbAdapter.close();
                                 }
-                                TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(context);
+                                TransactionsDbAdapter transactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
                                 transactionsDbAdapter.deleteAllRecords();
 
                                 if (preserveOpeningBalances) {
                                     transactionsDbAdapter.bulkAddTransactions(openingBalances);
                                 }
-                                transactionsDbAdapter.close();
                                 Toast.makeText(context, R.string.toast_all_transactions_deleted, Toast.LENGTH_SHORT).show();
                                 WidgetConfigurationActivity.updateAllWidgets(getActivity());
                             }

--- a/app/src/org/gnucash/android/ui/settings/SettingsActivity.java
+++ b/app/src/org/gnucash/android/ui/settings/SettingsActivity.java
@@ -239,9 +239,8 @@ public class SettingsActivity extends SherlockPreferenceActivity implements OnPr
                 Toast.makeText(this, R.string.toast_tap_again_to_confirm_delete, Toast.LENGTH_SHORT).show();
             } else {
                 GncXmlExporter.createBackup(); //create backup before deleting everything
-                AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(this);
+                AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
                 accountsDbAdapter.deleteAllRecords();
-                accountsDbAdapter.close();
                 Toast.makeText(this, R.string.toast_all_accounts_deleted, Toast.LENGTH_LONG).show();
             }
             Timer timer = new Timer();
@@ -258,17 +257,15 @@ public class SettingsActivity extends SherlockPreferenceActivity implements OnPr
                 List<Transaction> openingBalances = new ArrayList<Transaction>();
                 boolean preserveOpeningBalances = GnuCashApplication.shouldSaveOpeningBalances(false);
                 if (preserveOpeningBalances) {
-                    AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(this);
+                    AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
                     openingBalances = accountsDbAdapter.getAllOpeningBalanceTransactions();
-                    accountsDbAdapter.close();
                 }
-                TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(this);
+                TransactionsDbAdapter transactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
                 transactionsDbAdapter.deleteAllRecords();
 
                 if (preserveOpeningBalances) {
                     transactionsDbAdapter.bulkAddTransactions(openingBalances);
                 }
-                transactionsDbAdapter.close();
                 Toast.makeText(this, R.string.toast_all_transactions_deleted, Toast.LENGTH_LONG).show();
             }
             Timer timer = new Timer();

--- a/app/src/org/gnucash/android/ui/transaction/ScheduledTransactionsListFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/ScheduledTransactionsListFragment.java
@@ -23,7 +23,6 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Rect;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.SimpleCursorAdapter;
@@ -411,8 +410,7 @@ public class ScheduledTransactionsListFragment extends SherlockListFragment impl
             super(context);
         }
 
-        @Override @NonNull
-        public Cursor loadInBackground() {
+        @Override        public Cursor loadInBackground() {
             mDatabaseAdapter = GnuCashApplication.getTransactionDbAdapter();
             Cursor c = ((TransactionsDbAdapter) mDatabaseAdapter).fetchAllRecurringTransactions();
 

--- a/app/src/org/gnucash/android/ui/transaction/ScheduledTransactionsListFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/ScheduledTransactionsListFragment.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.SimpleCursorAdapter;
@@ -40,6 +41,7 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.Transaction;
 import org.gnucash.android.db.*;
 import org.gnucash.android.ui.UxArgument;
@@ -127,7 +129,7 @@ public class ScheduledTransactionsListFragment extends SherlockListFragment impl
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mTransactionsDbAdapter = new TransactionsDbAdapter(getActivity());
+        mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
         mCursorAdapter = new TransactionsCursorAdapter(
                 getActivity().getApplicationContext(),
                 R.layout.list_item_scheduled_trxn, null,
@@ -167,12 +169,6 @@ public class ScheduledTransactionsListFragment extends SherlockListFragment impl
     public void onResume() {
         super.onResume();
         refreshList();
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        mTransactionsDbAdapter.close();
     }
 
     @Override
@@ -415,13 +411,12 @@ public class ScheduledTransactionsListFragment extends SherlockListFragment impl
             super(context);
         }
 
-        @Override
+        @Override @NonNull
         public Cursor loadInBackground() {
-            mDatabaseAdapter = new TransactionsDbAdapter(getContext());
+            mDatabaseAdapter = GnuCashApplication.getTransactionDbAdapter();
             Cursor c = ((TransactionsDbAdapter) mDatabaseAdapter).fetchAllRecurringTransactions();
 
-            if (c != null)
-                registerContentObserver(c);
+            registerContentObserver(c);
             return c;
         }
     }

--- a/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -462,7 +462,7 @@ public class TransactionFormFragment extends SherlockFragment implements
         if (mCursor != null) {
             mCursor.close();
         }
-		mCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(conditions);
+		mCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(conditions, null);
 
         mCursorAdapter = new QualifiedAccountNameCursorAdapter(getActivity(),
                 android.R.layout.simple_spinner_item, mCursor);

--- a/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -22,10 +22,12 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.*;
 
+import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentManager;
 import android.text.Editable;
 import android.widget.*;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.*;
 import org.gnucash.android.model.*;
 import org.gnucash.android.ui.transaction.dialog.DatePickerDialogFragment;
@@ -186,7 +188,7 @@ public class TransactionFormFragment extends SherlockFragment implements
     /**
 	 * Create the view and retrieve references to the UI elements
 	 */
-	@Override
+	@Override @NonNull
 	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.fragment_new_transaction, container, false);
@@ -222,7 +224,7 @@ public class TransactionFormFragment extends SherlockFragment implements
 		}
 
         mAccountUID = getArguments().getString(UxArgument.SELECTED_ACCOUNT_UID);
-		mAccountsDbAdapter = new AccountsDbAdapter(getActivity());
+		mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         mAccountType = mAccountsDbAdapter.getAccountType(mAccountUID);
 
         ArrayAdapter<CharSequence> recurrenceAdapter = ArrayAdapter.createFromResource(getActivity(),
@@ -231,7 +233,7 @@ public class TransactionFormFragment extends SherlockFragment implements
         mRecurringTransactionSpinner.setAdapter(recurrenceAdapter);
 
         String transactionUID = getArguments().getString(UxArgument.SELECTED_TRANSACTION_UID);
-		mTransactionsDbAdapter = new TransactionsDbAdapter(getActivity());
+		mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
 		mTransaction = mTransactionsDbAdapter.getTransaction(transactionUID);
         if (mTransaction != null) {
             mMultiCurrency = mTransactionsDbAdapter.getNumCurrencies(mTransaction.getUID()) > 1;
@@ -576,7 +578,7 @@ public class TransactionFormFragment extends SherlockFragment implements
             Toast.makeText(getActivity(), R.string.toast_error_edit_multi_currency_transaction, Toast.LENGTH_LONG).show();
             return;
         }
-        AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(getActivity());
+        AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         String currencyCode = accountsDbAdapter.getCurrencyCode(newAccountId);
         Currency currency = Currency.getInstance(currencyCode);
         mCurrencyTextView.setText(currency.getSymbol(Locale.getDefault()));
@@ -585,8 +587,6 @@ public class TransactionFormFragment extends SherlockFragment implements
         mTransactionTypeButton.setAccountType(mAccountType);
 
         updateTransferAccountsList();
-
-        accountsDbAdapter.close();
     }
 
 	/**
@@ -626,11 +626,10 @@ public class TransactionFormFragment extends SherlockFragment implements
 		if (mTransaction != null){
             if (!mUseDoubleEntry){
                 //first remove old splits for this transaction, since there is only one split
-                SplitsDbAdapter splitsDbAdapter = new SplitsDbAdapter(getActivity());
+                SplitsDbAdapter splitsDbAdapter = GnuCashApplication.getSplitsDbAdapter();
                 for (Split split : mTransaction.getSplits()) {
                     splitsDbAdapter.deleteSplit(split.getUID());
                 }
-                splitsDbAdapter.close();
 
                 Split split = new Split(amount, accountUID);
                 split.setType(mTransactionTypeButton.getTransactionType());
@@ -709,8 +708,6 @@ public class TransactionFormFragment extends SherlockFragment implements
 		super.onDestroyView();
 		if (mCursor != null)
 			mCursor.close();
-		mAccountsDbAdapter.close();
-		mTransactionsDbAdapter.close();
 	}
 
 	@Override
@@ -760,11 +757,10 @@ public class TransactionFormFragment extends SherlockFragment implements
             setAmountEditViewVisible(View.GONE);
         }
 
-        SplitsDbAdapter splitsDbAdapter = new SplitsDbAdapter(getActivity());
+        SplitsDbAdapter splitsDbAdapter = GnuCashApplication.getSplitsDbAdapter();
         for (String removedSplitUID : removedSplitUIDs) {
             splitsDbAdapter.deleteRecord(splitsDbAdapter.getID(removedSplitUID));
         }
-        splitsDbAdapter.close();
     }
 
     /**
@@ -839,16 +835,16 @@ public class TransactionFormFragment extends SherlockFragment implements
 	 * @param amountString String with amount information
 	 * @return BigDecimal with the amount parsed from <code>amountString</code>
 	 */
+    @NonNull
 	public static BigDecimal parseInputToDecimal(String amountString){
 		String clean = stripCurrencyFormatting(amountString);
         if (clean.length() == 0) //empty string
                 return BigDecimal.ZERO;
 		//all amounts are input to 2 decimal places, so after removing decimal separator, divide by 100
         //TODO: Handle currencies with different kinds of decimal places
-		BigDecimal amount = new BigDecimal(clean).setScale(2,
+		return new BigDecimal(clean).setScale(2,
 				RoundingMode.HALF_EVEN).divide(new BigDecimal(100), 2,
 				RoundingMode.HALF_EVEN);
-		return amount;
 	}
 
     private class AmountTextWatcher extends AmountInputFormatter {

--- a/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -22,7 +22,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.*;
 
-import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentManager;
 import android.text.Editable;
 import android.widget.*;
@@ -188,8 +187,7 @@ public class TransactionFormFragment extends SherlockFragment implements
     /**
 	 * Create the view and retrieve references to the UI elements
 	 */
-	@Override @NonNull
-	public View onCreateView(LayoutInflater inflater, ViewGroup container,
+	@Override	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.fragment_new_transaction, container, false);
 
@@ -835,7 +833,6 @@ public class TransactionFormFragment extends SherlockFragment implements
 	 * @param amountString String with amount information
 	 * @return BigDecimal with the amount parsed from <code>amountString</code>
 	 */
-    @NonNull
 	public static BigDecimal parseInputToDecimal(String amountString){
 		String clean = stripCurrencyFormatting(amountString);
         if (clean.length() == 0) //empty string

--- a/app/src/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -281,7 +281,7 @@ public class TransactionsActivity extends PassLockActivity implements
 
 		mAccountUID = getIntent().getStringExtra(UxArgument.SELECTED_ACCOUNT_UID);
 
-        mAccountsDbAdapter = new AccountsDbAdapter(this);
+        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 
         setupActionBarNavigation();
 
@@ -409,9 +409,7 @@ public class TransactionsActivity extends PassLockActivity implements
         if (favoriteAccountMenuItem == null) //when the activity is used to edit a transaction
             return super.onPrepareOptionsMenu(menu);
 
-        AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(this);
-        boolean isFavoriteAccount = accountsDbAdapter.isFavoriteAccount(mAccountsDbAdapter.getAccountID(mAccountUID));
-        accountsDbAdapter.close();
+        boolean isFavoriteAccount = GnuCashApplication.getAccountsDbAdapter().isFavoriteAccount(mAccountsDbAdapter.getAccountID(mAccountUID));
 
         int favoriteIcon = isFavoriteAccount ? android.R.drawable.btn_star_big_on : android.R.drawable.btn_star_big_off;
         favoriteAccountMenuItem.setIcon(favoriteIcon);
@@ -435,12 +433,11 @@ public class TransactionsActivity extends PassLockActivity implements
 	        return true;
 
             case R.id.menu_favorite_account:
-                AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(this);
+                AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
                 long accountId = accountsDbAdapter.getAccountID(mAccountUID);
                 boolean isFavorite = accountsDbAdapter.isFavoriteAccount(accountId);
                 //toggle favorite preference
                 accountsDbAdapter.updateAccount(accountId, DatabaseSchema.AccountEntry.COLUMN_FAVORITE, isFavorite ? "0" : "1");
-                accountsDbAdapter.close();
                 supportInvalidateOptionsMenu();
                 return true;
 
@@ -469,7 +466,6 @@ public class TransactionsActivity extends PassLockActivity implements
 	protected void onDestroy() {
 		super.onDestroy();
         mAccountsCursor.close();
-		mAccountsDbAdapter.close();
 	}
 	
 	/**

--- a/app/src/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -47,6 +47,7 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.*;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.ui.transaction.dialog.BulkMoveDialogFragment;
@@ -117,11 +118,10 @@ public class TransactionsListFragment extends SherlockListFragment implements
 				return true;
 
 			case R.id.context_menu_delete:
-                SplitsDbAdapter splitsDbAdapter = new SplitsDbAdapter(getActivity());
+                SplitsDbAdapter splitsDbAdapter = GnuCashApplication.getSplitsDbAdapter();
 				for (long id : getListView().getCheckedItemIds()) {
                     splitsDbAdapter.deleteSplitsForTransactionAndAccount(mTransactionsDbAdapter.getUID(id), mAccountUID);
 				}
-                splitsDbAdapter.close();
 				refresh();
 				mode.finish();
 				WidgetConfigurationActivity.updateAllWidgets(getActivity());
@@ -140,7 +140,7 @@ public class TransactionsListFragment extends SherlockListFragment implements
 		Bundle args = getArguments();
 		mAccountUID = args.getString(UxArgument.SELECTED_ACCOUNT_UID);
 
-		mTransactionsDbAdapter = new TransactionsDbAdapter(getActivity());
+		mTransactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
 		mCursorAdapter = new TransactionsCursorAdapter(
 				getActivity().getApplicationContext(), 
 				R.layout.list_item_transaction, null, 
@@ -212,7 +212,6 @@ public class TransactionsListFragment extends SherlockListFragment implements
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
-		mTransactionsDbAdapter.close();
 	}
 	
 	@Override
@@ -492,7 +491,7 @@ public class TransactionsListFragment extends SherlockListFragment implements
 		
 		@Override
 		public Cursor loadInBackground() {
-			mDatabaseAdapter = new TransactionsDbAdapter(getContext());
+			mDatabaseAdapter = GnuCashApplication.getTransactionDbAdapter();
 			Cursor c = ((TransactionsDbAdapter) mDatabaseAdapter).fetchAllTransactionsForAccount(accountUID);
 			if (c != null)
 				registerContentObserver(c);

--- a/app/src/org/gnucash/android/ui/transaction/dialog/BulkMoveDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/BulkMoveDialogFragment.java
@@ -69,13 +69,8 @@ public class BulkMoveDialogFragment extends DialogFragment {
 	 * GUID of account from which to move the transactions
 	 */
 	String mOriginAccountUID = null;
-	
-	/**
-	 * Accounts database adapter
-	 */
-	private AccountsDbAdapter mAccountsDbAdapter;
-	
-	/**
+
+    /**
 	 * Creates the view and retrieves references to the dialog elements
 	 */
 	@Override
@@ -104,13 +99,20 @@ public class BulkMoveDialogFragment extends DialogFragment {
 				mTransactionIds.length);
 		getDialog().setTitle(title);
 		
-		mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
-        String conditions = "(" + DatabaseSchema.AccountEntry.COLUMN_UID    + " != '" + mOriginAccountUID + "' AND "
-                + DatabaseSchema.AccountEntry.COLUMN_CURRENCY               + " = '" + mAccountsDbAdapter.getCurrencyCode(mOriginAccountUID)
-                + "' AND " + DatabaseSchema.AccountEntry.COLUMN_UID         + " != '" + mAccountsDbAdapter.getGnuCashRootAccountUID()
-                + "' AND " + DatabaseSchema.AccountEntry.COLUMN_PLACEHOLDER + " = 0"
+		/*
+	  Accounts database adapter
+	 */
+        AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
+        String conditions = "(" + DatabaseSchema.AccountEntry.COLUMN_UID    + " != ? AND "
+                + DatabaseSchema.AccountEntry.COLUMN_CURRENCY               + " = ? AND "
+                + DatabaseSchema.AccountEntry.COLUMN_UID         + " != ? AND "
+                + DatabaseSchema.AccountEntry.COLUMN_PLACEHOLDER + " = 0"
                 + ")";
-		Cursor cursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(conditions);
+		Cursor cursor = accountsDbAdapter.fetchAccountsOrderedByFullName(conditions,
+                new String[]{mOriginAccountUID,
+                        accountsDbAdapter.getCurrencyCode(mOriginAccountUID),
+                        "" + accountsDbAdapter.getGnuCashRootAccountUID()
+                });
 
 		SimpleCursorAdapter mCursorAdapter = new QualifiedAccountNameCursorAdapter(getActivity(),
                 android.R.layout.simple_spinner_item, cursor);
@@ -148,7 +150,7 @@ public class BulkMoveDialogFragment extends DialogFragment {
                 String srcAccountUID    = ((TransactionsActivity)getActivity()).getCurrentAccountUID();
                 String dstAccountUID    = trxnAdapter.getAccountUID(dstAccountId);
 				for (long trxnId : mTransactionIds) {
-					trxnAdapter.moveTranscation(trxnAdapter.getUID(trxnId), srcAccountUID, dstAccountUID);
+					trxnAdapter.moveTransaction(trxnAdapter.getUID(trxnId), srcAccountUID, dstAccountUID);
 				}
 
 				WidgetConfigurationActivity.updateAllWidgets(getActivity());

--- a/app/src/org/gnucash/android/ui/transaction/dialog/BulkMoveDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/BulkMoveDialogFragment.java
@@ -17,6 +17,7 @@
 package org.gnucash.android.ui.transaction.dialog;
 
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.TransactionsDbAdapter;
@@ -103,7 +104,7 @@ public class BulkMoveDialogFragment extends DialogFragment {
 				mTransactionIds.length);
 		getDialog().setTitle(title);
 		
-		mAccountsDbAdapter = new AccountsDbAdapter(getActivity());
+		mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
         String conditions = "(" + DatabaseSchema.AccountEntry.COLUMN_UID    + " != '" + mOriginAccountUID + "' AND "
                 + DatabaseSchema.AccountEntry.COLUMN_CURRENCY               + " = '" + mAccountsDbAdapter.getCurrencyCode(mOriginAccountUID)
                 + "' AND " + DatabaseSchema.AccountEntry.COLUMN_UID         + " != '" + mAccountsDbAdapter.getGnuCashRootAccountUID()
@@ -139,7 +140,7 @@ public class BulkMoveDialogFragment extends DialogFragment {
 				}
 				
 				long dstAccountId = mDestinationAccountSpinner.getSelectedItemId();
-				TransactionsDbAdapter trxnAdapter = new TransactionsDbAdapter(getActivity());
+				TransactionsDbAdapter trxnAdapter = GnuCashApplication.getTransactionDbAdapter();
 				if (!trxnAdapter.getCurrencyCode(dstAccountId).equals(trxnAdapter.getCurrencyCode(mOriginAccountUID))){
 					Toast.makeText(getActivity(), R.string.toast_incompatible_currency, Toast.LENGTH_LONG).show();
 					return;
@@ -149,7 +150,6 @@ public class BulkMoveDialogFragment extends DialogFragment {
 				for (long trxnId : mTransactionIds) {
 					trxnAdapter.moveTranscation(trxnAdapter.getUID(trxnId), srcAccountUID, dstAccountUID);
 				}
-				trxnAdapter.close();
 
 				WidgetConfigurationActivity.updateAllWidgets(getActivity());
 				((Refreshable)getTargetFragment()).refresh();

--- a/app/src/org/gnucash/android/ui/transaction/dialog/DatePickerDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/DatePickerDialogFragment.java
@@ -23,6 +23,7 @@ import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.Dialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 /**
@@ -67,6 +68,8 @@ public class DatePickerDialogFragment extends DialogFragment {
 	/**
 	 * Creates and returns an Android {@link DatePickerDialog}
 	 */
+    @NonNull
+    @Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
 		Calendar cal = mDate == null ? Calendar.getInstance() : mDate;
 		

--- a/app/src/org/gnucash/android/ui/transaction/dialog/DatePickerDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/DatePickerDialogFragment.java
@@ -23,7 +23,6 @@ import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.Dialog;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 /**
@@ -68,7 +67,6 @@ public class DatePickerDialogFragment extends DialogFragment {
 	/**
 	 * Creates and returns an Android {@link DatePickerDialog}
 	 */
-    @NonNull
     @Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
 		Calendar cal = mDate == null ? Calendar.getInstance() : mDate;

--- a/app/src/org/gnucash/android/ui/transaction/dialog/SplitEditorDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/SplitEditorDialogFragment.java
@@ -189,16 +189,19 @@ public class SplitEditorDialogFragment extends DialogFragment {
     private void initArgs() {
         mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 
-        Bundle args     = getArguments();
-        mAccountUID      = ((TransactionsActivity)getActivity()).getCurrentAccountUID();
-        mBaseAmount     = new BigDecimal(args.getString(UxArgument.AMOUNT_STRING));
+        Bundle args = getArguments();
+        mAccountUID = ((TransactionsActivity) getActivity()).getCurrentAccountUID();
+        mBaseAmount = new BigDecimal(args.getString(UxArgument.AMOUNT_STRING));
 
         String conditions = "(" //+ AccountEntry._ID + " != " + mAccountId + " AND "
-                + (mMultiCurrency ? "" : (DatabaseSchema.AccountEntry.COLUMN_CURRENCY + " = '" + mAccountsDbAdapter.getCurrencyCode(mAccountUID)
-                + "' AND ")) + DatabaseSchema.AccountEntry.COLUMN_UID + " != '" + mAccountsDbAdapter.getGnuCashRootAccountUID()
-                + "' AND " + DatabaseSchema.AccountEntry.COLUMN_PLACEHOLDER + " = 0"
+                + (mMultiCurrency ? "" : (DatabaseSchema.AccountEntry.COLUMN_CURRENCY + " = ? AND "))
+                + DatabaseSchema.AccountEntry.COLUMN_UID + " != ? AND "
+                + DatabaseSchema.AccountEntry.COLUMN_PLACEHOLDER + " = 0"
                 + ")";
-        mCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(conditions);
+        mCursor = mAccountsDbAdapter.fetchAccountsOrderedByFullName(conditions,
+                mMultiCurrency ? new String[]{"" + mAccountsDbAdapter.getGnuCashRootAccountUID()} :
+                        new String[]{mAccountsDbAdapter.getCurrencyCode(mAccountUID), "" + mAccountsDbAdapter.getGnuCashRootAccountUID()}
+        );
     }
 
     /**

--- a/app/src/org/gnucash/android/ui/transaction/dialog/SplitEditorDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/SplitEditorDialogFragment.java
@@ -27,6 +27,7 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.*;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.SplitsDbAdapter;
@@ -105,7 +106,7 @@ public class SplitEditorDialogFragment extends DialogFragment {
         getDialog().setTitle(R.string.title_transaction_splits);
 
         mSplitItemViewList = new ArrayList<View>();
-        mSplitsDbAdapter = new SplitsDbAdapter(getActivity());
+        mSplitsDbAdapter = GnuCashApplication.getSplitsDbAdapter();
 
         //we are editing splits for a new transaction.
         // But the user may have already created some splits before. Let's check
@@ -186,7 +187,7 @@ public class SplitEditorDialogFragment extends DialogFragment {
      * Extracts arguments passed to the view and initializes necessary adapters and cursors
      */
     private void initArgs() {
-        mAccountsDbAdapter = new AccountsDbAdapter(getActivity());
+        mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 
         Bundle args     = getArguments();
         mAccountUID      = ((TransactionsActivity)getActivity()).getCurrentAccountUID();
@@ -366,8 +367,6 @@ public class SplitEditorDialogFragment extends DialogFragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        mAccountsDbAdapter.close();
-        mSplitsDbAdapter.close();
     }
 
     /**

--- a/app/src/org/gnucash/android/ui/transaction/dialog/TimePickerDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/TimePickerDialogFragment.java
@@ -22,6 +22,7 @@ import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 /**
@@ -65,6 +66,7 @@ public class TimePickerDialogFragment extends DialogFragment {
 	/**
 	 * Creates and returns an Android {@link TimePickerDialog}
 	 */
+    @NonNull
 	@Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
 		Calendar cal = mCurrentTime == null ? Calendar.getInstance() : mCurrentTime;

--- a/app/src/org/gnucash/android/ui/transaction/dialog/TimePickerDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/TimePickerDialogFragment.java
@@ -22,7 +22,6 @@ import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 /**
@@ -66,7 +65,6 @@ public class TimePickerDialogFragment extends DialogFragment {
 	/**
 	 * Creates and returns an Android {@link TimePickerDialog}
 	 */
-    @NonNull
 	@Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
 		Calendar cal = mCurrentTime == null ? Calendar.getInstance() : mCurrentTime;

--- a/app/src/org/gnucash/android/ui/transaction/dialog/TransactionsDeleteConfirmationDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/TransactionsDeleteConfirmationDialogFragment.java
@@ -29,7 +29,6 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 
 import com.actionbarsherlock.app.SherlockDialogFragment;
 import org.gnucash.android.ui.widget.WidgetConfigurationActivity;
@@ -54,8 +53,7 @@ public class TransactionsDeleteConfirmationDialogFragment extends SherlockDialog
         return frag;
     }
 
-    @Override @NonNull
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
+    @Override    public Dialog onCreateDialog(Bundle savedInstanceState) {
         int title = getArguments().getInt("title");
         final long rowId = getArguments().getLong(UxArgument.SELECTED_TRANSACTION_IDS);
         int message = rowId == 0 ? R.string.msg_delete_all_transactions_confirmation : R.string.msg_delete_transaction_confirmation;

--- a/app/src/org/gnucash/android/ui/transaction/dialog/TransactionsDeleteConfirmationDialogFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/dialog/TransactionsDeleteConfirmationDialogFragment.java
@@ -29,6 +29,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 
 import com.actionbarsherlock.app.SherlockDialogFragment;
 import org.gnucash.android.ui.widget.WidgetConfigurationActivity;
@@ -53,7 +54,7 @@ public class TransactionsDeleteConfirmationDialogFragment extends SherlockDialog
         return frag;
     }
 
-    @Override
+    @Override @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         int title = getArguments().getInt("title");
         final long rowId = getArguments().getLong(UxArgument.SELECTED_TRANSACTION_IDS);
@@ -64,15 +65,13 @@ public class TransactionsDeleteConfirmationDialogFragment extends SherlockDialog
                 .setPositiveButton(R.string.alert_dialog_ok_delete,
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int whichButton) {
-                                TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(getSherlockActivity());
+                                TransactionsDbAdapter transactionsDbAdapter = GnuCashApplication.getTransactionDbAdapter();
                                 if (rowId == 0) {
                                     GncXmlExporter.createBackup(); //create backup before deleting everything
                                     List<Transaction> openingBalances = new ArrayList<Transaction>();
                                     boolean preserveOpeningBalances = GnuCashApplication.shouldSaveOpeningBalances(false);
                                     if (preserveOpeningBalances) {
-                                        AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(getActivity());
-                                        openingBalances = accountsDbAdapter.getAllOpeningBalanceTransactions();
-                                        accountsDbAdapter.close();
+                                        openingBalances = GnuCashApplication.getAccountsDbAdapter().getAllOpeningBalanceTransactions();
                                     }
 
                                     transactionsDbAdapter.deleteAllRecords();
@@ -83,7 +82,6 @@ public class TransactionsDeleteConfirmationDialogFragment extends SherlockDialog
                                 } else {
                                     transactionsDbAdapter.deleteRecord(rowId);
                                 }
-                                transactionsDbAdapter.close();
                                 if (getTargetFragment() instanceof AccountsListFragment) {
                                     ((AccountsListFragment) getTargetFragment()).refresh();
                                 }

--- a/app/src/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -22,6 +22,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 import android.widget.TextView;
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.AccountsDbAdapter;
 import org.gnucash.android.model.Money;
 
@@ -40,7 +41,7 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
     public AccountBalanceTask(TextView balanceTextView, Context context){
         accountBalanceTextViewReference = new WeakReference<TextView>(balanceTextView);
-        accountsDbAdapter = new AccountsDbAdapter(context);
+        accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
     }
 
     @Override
@@ -68,7 +69,7 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
     @Override
     protected void onPostExecute(Money balance) {
         if (accountBalanceTextViewReference.get() != null && balance != null){
-            final Context context = accountsDbAdapter.getContext();
+            final Context context = GnuCashApplication.getAppContext();
             final TextView balanceTextView = accountBalanceTextViewReference.get();
             if (balanceTextView != null){
                 balanceTextView.setText(balance.formattedString());
@@ -77,6 +78,5 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
                 balanceTextView.setTextColor(fontColor);
             }
         }
-        accountsDbAdapter.close();
     }
 }

--- a/app/src/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
+++ b/app/src/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
@@ -146,10 +146,10 @@ public class WidgetConfigurationActivity extends Activity {
 		AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
 
 		AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
-		Account account = accountsDbAdapter.getAccount(accountUID);
-
-		
-		if (account == null){
+		Account account;
+        try {
+            account = accountsDbAdapter.getAccount(accountUID);
+        } catch (IllegalArgumentException e) {
 			Log.i("WidgetConfiguration", "Account not found, resetting widget " + appWidgetId);
 			//if account has been deleted, let the user know
 			RemoteViews views = new RemoteViews(context.getPackageName(),

--- a/app/src/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
+++ b/app/src/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
@@ -19,6 +19,7 @@ package org.gnucash.android.ui.widget;
 import java.util.Locale;
 
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.db.AccountsDbAdapter;
@@ -70,7 +71,7 @@ public class WidgetConfigurationActivity extends Activity {
 		mOkButton 		= (Button) findViewById(R.id.btn_save);
 		mCancelButton 	= (Button) findViewById(R.id.btn_cancel);
 
-		mAccountsDbAdapter = new AccountsDbAdapter(this);
+		mAccountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 		Cursor cursor = mAccountsDbAdapter.fetchAllRecordsOrderedByFullName();
 		
 		if (cursor.getCount() <= 0){
@@ -87,12 +88,6 @@ public class WidgetConfigurationActivity extends Activity {
 		bindListeners();
 	}
 
-	@Override
-	protected void onDestroy() {		
-		super.onDestroy();
-		mAccountsDbAdapter.close();
-	}
-	
 	/**
 	 * Sets click listeners for the buttons in the dialog
 	 */
@@ -150,7 +145,7 @@ public class WidgetConfigurationActivity extends Activity {
 		Log.i("WidgetConfiguration", "Updating widget: " + appWidgetId);
 		AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
 
-		AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(context);
+		AccountsDbAdapter accountsDbAdapter = GnuCashApplication.getAccountsDbAdapter();
 		Account account = accountsDbAdapter.getAccount(accountUID);
 
 		
@@ -202,7 +197,6 @@ public class WidgetConfigurationActivity extends Activity {
 		views.setOnClickPendingIntent(R.id.btn_new_transaction, pendingIntent);
 		
 		appWidgetManager.updateAppWidget(appWidgetId, views);
-        accountsDbAdapter.close();
 	}
 	
 	/**

--- a/integration-tests/src/org/gnucash/android/test/db/AccountsDbAdapterTest.java
+++ b/integration-tests/src/org/gnucash/android/test/db/AccountsDbAdapterTest.java
@@ -3,23 +3,42 @@ package org.gnucash.android.test.db;
 import java.util.Currency;
 import java.util.List;
 
+import org.gnucash.android.db.DatabaseHelper;
+import org.gnucash.android.db.SplitsDbAdapter;
+import org.gnucash.android.db.TransactionsDbAdapter;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Transaction;
 import org.gnucash.android.db.AccountsDbAdapter;
 
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
 import android.test.AndroidTestCase;
+import android.util.Log;
 
 public class AccountsDbAdapterTest extends AndroidTestCase {
 
 	private static final String BRAVO_ACCOUNT_NAME = "Bravo";
 	private static final String ALPHA_ACCOUNT_NAME = "Alpha";
-	private AccountsDbAdapter mAdapter;
+    private DatabaseHelper mDbHelper;
+    private SQLiteDatabase mDb;
+    private AccountsDbAdapter mAccountsDbAdapter;
+    private TransactionsDbAdapter mTransactionsDbAdapter;
+    private SplitsDbAdapter mSplitsDbAdapter;
 	
 	@Override
 	protected void setUp() throws Exception {		
 		super.setUp();
-		mAdapter = new AccountsDbAdapter(getContext());
-		mAdapter.deleteAllRecords();
+        mDbHelper = new DatabaseHelper(getContext());
+        try {
+            mDb = mDbHelper.getWritableDatabase();
+        } catch (SQLException e) {
+            Log.e(getClass().getName(), "Error getting database: " + e.getMessage());
+            mDb = mDbHelper.getReadableDatabase();
+        }
+        mSplitsDbAdapter = new SplitsDbAdapter(mDb);
+        mTransactionsDbAdapter = new TransactionsDbAdapter(mDb, mSplitsDbAdapter);
+        mAccountsDbAdapter = new AccountsDbAdapter(mDb, mTransactionsDbAdapter);
+		mAccountsDbAdapter.deleteAllRecords();
 		Account first = new Account(ALPHA_ACCOUNT_NAME);
 		Transaction t1 = new Transaction("T800");
 		Transaction t2 = new Transaction("T1000");
@@ -27,12 +46,12 @@ public class AccountsDbAdapterTest extends AndroidTestCase {
 		Account second = new Account(BRAVO_ACCOUNT_NAME);
 		Transaction t = new Transaction("buyout");
 		
-		mAdapter.addAccount(second);
-		mAdapter.addAccount(first);
+		mAccountsDbAdapter.addAccount(second);
+		mAccountsDbAdapter.addAccount(first);
 	}
 	
 	public void testAlphabeticalSorting(){
-		List<Account> accountsList = mAdapter.getAllAccounts();
+		List<Account> accountsList = mAccountsDbAdapter.getAllAccounts();
 		assertEquals(2, accountsList.size());
 		//bravo was saved first, but alpha should be first alphabetically
 		assertEquals(ALPHA_ACCOUNT_NAME, accountsList.get(0).getName());
@@ -47,9 +66,9 @@ public class AccountsDbAdapterTest extends AndroidTestCase {
 		acc1.addTransaction(trx);
 		acc1.addTransaction(term);
 		
-		mAdapter.addAccount(acc1);
+		mAccountsDbAdapter.addAccount(acc1);
 		
-		Account account = mAdapter.getAccount("simile");
+		Account account = mAccountsDbAdapter.getAccount("simile");
 		for (Transaction t : account.getTransactions()) {
 			assertEquals("JPY", t.getBalance(acc1.getUID()).getCurrency().getCurrencyCode());
 		}
@@ -58,7 +77,8 @@ public class AccountsDbAdapterTest extends AndroidTestCase {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		mAdapter.deleteAllRecords();
-		mAdapter.close();
+		mAccountsDbAdapter.deleteAllRecords();
+        mDbHelper.close();
+        mDb.close();
 	}
 }


### PR DESCRIPTION
up to babbfc6 :
DbHelper, SQLiteDatabase, AccountsDbAdaper, TransactionsDbAdapter, SplitsDbAdapter  moved to `GnuCashApplication`. Static methods are added to GnuCashAplication to get DbAdapters. DbHelper, SQLiteDatabase, DbAdapters now are only created in `GnuCashApplication`'s `onCreate`, and later retrieved by the static methods. DbAdapter does not use Context any more.

Modified some cursor related code. Moved cursor.close() to try/finally blocks, and removed null checked for cursors.

Added `Nullable`, `NonNull` annotations to DbAdapters, Account/Transation/Split, and some related methods. These annotations would not affect generated code, but can help identify possible bugs before/during compile.