### PR TITLE
Rewrite upgrade db versin 6 to 7

### DIFF
--- a/app/src/org/gnucash/android/db/DatabaseHelper.java
+++ b/app/src/org/gnucash/android/db/DatabaseHelper.java
@@ -303,7 +303,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                             + TransactionEntry.TABLE_NAME + "_bak." + KEY_DOUBLE_ENTRY_ACCOUNT_UID + " , "
                             + TransactionEntry.TABLE_NAME + "_baK." + TransactionEntry.COLUMN_UID
                             + " FROM " + TransactionEntry.TABLE_NAME + "_bak , " + AccountEntry.TABLE_NAME
-                            + " ON " + TransactionEntry.TABLE_NAME + "_bak." + KEY_DOUBLE_ENTRY_ACCOUNT_UID + " = " + AccountEntry.TABLE_NAME + "." + AccountEntry.COLUMN_UID
+                            + " ON " + TransactionEntry.TABLE_NAME + "_bak.account_uid = " + AccountEntry.TABLE_NAME + "." + AccountEntry.COLUMN_UID
                             + " WHERE " + TransactionEntry.TABLE_NAME + "_bak." + KEY_DOUBLE_ENTRY_ACCOUNT_UID + " IS NOT NULL"
                     );
                     // drop backup transaction table


### PR DESCRIPTION
Rewrite DB upgrade without the need to export and import, which also eliminates the need for DbAdapters.

This will remove the need to maintain legacy support for old db format.

However, the CREDIT/DEBIT (split.type) confused me. I'm not sure whether they are correct.

I test upgrading from 1.3.3, wiht CASH/INCOME/EXPENSE account, create one transaction in INCOME which increases CASH, one transaction in EXPENSE which decreases CASH. After the upgrade, the money change in CASH seem to be correct.
However, upgrading from 1.3.3 to 1.4.3 gave me a wired result, with both transactions decreases CASH.
I think you mush check that part to see whether it is correct.

Other than that, the code should work. I tried to import my whole account tree with no problem.
