### PR TITLE
delete all splits of a transaction

### DIFF
--- a/app/src/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/AccountsDbAdapter.java
@@ -296,7 +296,7 @@ public class AccountsDbAdapter extends DatabaseAdapter {
             mDb.delete(TransactionEntry.TABLE_NAME,
                     TransactionEntry.COLUMN_UID  + " NOT IN ( SELECT DISTINCT "
                             + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_UID
-                            + " FROM trans_split_acct",
+                            + " FROM trans_split_acct )",
                     null);
             deleteRecord(AccountEntry.TABLE_NAME, rowId);
             mDb.setTransactionSuccessful();

--- a/app/src/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/SplitsDbAdapter.java
@@ -515,13 +515,19 @@ public class SplitsDbAdapter extends DatabaseAdapter {
      * @param transactionId Database record ID of the transaction
      * @return <code>true</code> if at least one split was deleted, <code>false</code> otherwise.
      */
-    public boolean deleteSplitsForTransaction(long transactionId){
+    public boolean deleteSplitsForTransaction(long transactionId) {
         String trxUID = getTransactionUID(transactionId);
-        boolean result = mDb.delete(SplitEntry.TABLE_NAME,
-                SplitEntry.COLUMN_TRANSACTION_UID + "=?",
-                new String[]{trxUID}) > 0;
-        result &= deleteTransaction(transactionId);
-        return result;
+        mDb.beginTransaction();
+        try {
+            mDb.delete(SplitEntry.TABLE_NAME,
+                    SplitEntry.COLUMN_TRANSACTION_UID + "=?",
+                    new String[]{trxUID});
+            boolean result = deleteTransaction(transactionId);
+            mDb.setTransactionSuccessful();
+            return result;
+        } finally {
+            mDb.endTransaction();
+        }
     }
 
     /**

--- a/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
+++ b/app/src/org/gnucash/android/db/TransactionsDbAdapter.java
@@ -439,8 +439,7 @@ public class TransactionsDbAdapter extends DatabaseAdapter {
     @Override
 	public boolean deleteRecord(long rowId){
 		Log.d(TAG, "Delete transaction with record Id: " + rowId);
-		return mSplitsDbAdapter.deleteSplitsForTransaction(rowId) &&
-                deleteRecord(TransactionEntry.TABLE_NAME, rowId);
+		return mSplitsDbAdapter.deleteSplitsForTransaction(rowId);
 	}
 	
 	/**

--- a/app/src/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -117,11 +117,9 @@ public class TransactionsListFragment extends SherlockListFragment implements
 				return true;
 
 			case R.id.context_menu_delete:
-                SplitsDbAdapter splitsDbAdapter = new SplitsDbAdapter(getActivity());
 				for (long id : getListView().getCheckedItemIds()) {
-                    splitsDbAdapter.deleteSplitsForTransactionAndAccount(mTransactionsDbAdapter.getUID(id), mAccountUID);
+                    mTransactionsDbAdapter.deleteRecord(id);
 				}
-                splitsDbAdapter.close();
 				refresh();
 				mode.finish();
 				WidgetConfigurationActivity.updateAllWidgets(getActivity());


### PR DESCRIPTION
When delete an account, delete all splits in related transactions.

In response to #242 .
