### PR TITLE
Correction of condition for simple double-entry account

### DIFF
--- a/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -351,7 +351,9 @@ public class TransactionFormFragment extends SherlockFragment implements
                 }
             }
         } else {
-            setAmountEditViewVisible(View.GONE);
+            if (mUseDoubleEntry) {
+                setAmountEditViewVisible(View.GONE);
+            }
         }
         mSplitsList = new ArrayList<Split>(mTransaction.getSplits()); //we need a copy so we can modify with impunity
         mAmountEditText.setEnabled(mSplitsList.size() <= 2);


### PR DESCRIPTION
Partial fix to #247 .

When view is initialized, toggle button is available when number of splits is equal or lower than 2. However, the change of toggle button is only recorded when the two splits are a pair. So when two splits in a transactions is not a pair, or only one split exits in a transaction, the change in toggle button is not saved.

This fix only enables the toggle button when double entry is not enabled, or when double entry is enabled and only two splits which are a pair exist in a transaction.
