### PR TITLE
Export using GnuCash log format (don't merge)

### DIFF
--- a/app/res/layout/dialog_export.xml
+++ b/app/res/layout/dialog_export.xml
@@ -68,6 +68,11 @@
                          android:layout_width="wrap_content"
                          android:layout_height="wrap_content"
                          android:text="OFX"/>
+
+            <RadioButton android:id="@+id/radio_log_format"
+                         android:layout_width="wrap_content"
+                         android:layout_height="wrap_content"
+                         android:text="LOG"/>
         </RadioGroup>
         <TextView android:id="@+id/export_warning"
                   android:layout_marginLeft="@dimen/dialog_padding"

--- a/app/res/values/key_strings.xml
+++ b/app/res/values/key_strings.xml
@@ -45,6 +45,7 @@
     <string-array name="key_export_format_values">
         <item>QIF</item>
         <item>OFX</item>
+        <item>LOG</item>
     </string-array>
     <string-array name="key_recurrence_period_millis">
         <item>0</item>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -381,6 +381,7 @@
     <string-array name="export_formats">
         <item>QIF</item>
         <item>OFX</item>
+        <item>LOG</item>
     </string-array>
     <string-array name="recurrence_period_strings">
         <item>NONE</item>

--- a/app/src/org/gnucash/android/db/DatabaseAdapter.java
+++ b/app/src/org/gnucash/android/db/DatabaseAdapter.java
@@ -240,6 +240,12 @@ public abstract class DatabaseAdapter {
         		null, null, null, null, null, null);
 	}
 
+    public Cursor query(String table, String[] columns, String where, String[] whereArgs, String groupBy,
+                                 String having, String orderBy)
+    {
+        return mDb.query(table, columns, where, whereArgs, groupBy, having, orderBy);
+    }
+
 	/**
 	 * Deletes record with ID <code>rowID</code> from database table <code>tableName</code>
      * This does not delete the transactions and splits associated with the account

--- a/app/src/org/gnucash/android/export/ExportDialogFragment.java
+++ b/app/src/org/gnucash/android/export/ExportDialogFragment.java
@@ -128,6 +128,11 @@ public class ExportDialogFragment extends DialogFragment {
                 } else {
                     mExportWarningTextView.setVisibility(View.GONE);
                 }
+                break;
+            case R.id.radio_log_format:
+                mExportFormat = ExportFormat.LOG;
+                mExportWarningTextView.setText("This only works well with newly created transactions");
+                mExportWarningTextView.setVisibility(View.VISIBLE);
         }
         mFilePath = getActivity().getExternalFilesDir(null) + "/" + Exporter.buildExportFilename(mExportFormat);
     }
@@ -199,6 +204,12 @@ public class ExportDialogFragment extends DialogFragment {
         qifRadioButton.setOnClickListener(clickListener);
         if (defaultExportFormat.equalsIgnoreCase(ExportFormat.QIF.name())){
             qifRadioButton.performClick();
+        }
+
+        RadioButton logRadioButton = (RadioButton) v.findViewById(R.id.radio_log_format);
+        logRadioButton.setOnClickListener(clickListener);
+        if (defaultExportFormat.equalsIgnoreCase(ExportFormat.LOG.name())){
+            logRadioButton.performClick();
         }
 	}
 

--- a/app/src/org/gnucash/android/export/ExportFormat.java
+++ b/app/src/org/gnucash/android/export/ExportFormat.java
@@ -22,7 +22,8 @@ package org.gnucash.android.export;
 public enum ExportFormat {
     QIF("Quicken Interchange Format"),
     OFX("Open Financial eXchange"),
-    GNC_XML ("GnuCash XML");
+    GNC_XML ("GnuCash XML"),
+    LOG("GnuCash log");
 
     /**
      * Full name of the export format acronym
@@ -45,6 +46,8 @@ public enum ExportFormat {
                 return ".ofx";
             case GNC_XML:
                 return ".gnca";
+            case LOG:
+                return ".log";
             default:
                 return ".txt";
         }

--- a/app/src/org/gnucash/android/export/ExporterAsyncTask.java
+++ b/app/src/org/gnucash/android/export/ExporterAsyncTask.java
@@ -30,6 +30,7 @@ import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.widget.Toast;
 import org.gnucash.android.R;
+import org.gnucash.android.export.log.LogExporter;
 import org.gnucash.android.export.ofx.OfxExporter;
 import org.gnucash.android.export.qif.QifExporter;
 import org.gnucash.android.export.qif.QifHelper;
@@ -102,6 +103,10 @@ public class ExporterAsyncTask extends AsyncTask<ExportParams, Void, Boolean> {
 
                 case OFX:
                     mExporter = new OfxExporter(mExportParams);
+                    break;
+
+                case LOG:
+                    mExporter = new LogExporter(mExportParams);
                     break;
 
                 case GNC_XML:

--- a/app/src/org/gnucash/android/export/log/LogExporter.java
+++ b/app/src/org/gnucash/android/export/log/LogExporter.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.math.BigDecimal;
 import java.util.Currency;
 import java.util.Date;
+import java.util.UUID;
 
 public class LogExporter extends Exporter {
 
@@ -49,6 +50,7 @@ public class LogExporter extends Exporter {
             );
             try {
                 String currentTransactionUID = "";
+                String randomUID = "";
                 writer.append(LogHelper.header).append(LogHelper.lineEnd);
                 while (cursor.moveToNext()) {
                     String transactionUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_UID));
@@ -57,15 +59,16 @@ public class LogExporter extends Exporter {
                             writer.append(LogHelper.end).append(LogHelper.lineEnd);
                         }
                         currentTransactionUID = transactionUID;
+                        randomUID = UUID.randomUUID().toString().replaceAll("-", "");
                         writer.append(LogHelper.start).append(LogHelper.lineEnd);
                     }
                     // mod
                     writer.append(LogHelper.LOG_COMMIT).append(LogHelper.separator);
                     // trans_guid
-                    writer.append(transactionUID).append(LogHelper.separator);
+                    writer.append(randomUID).append(LogHelper.separator);
                     // split_guid
-                    String splitUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_UID));
-                    writer.append(splitUID).append(LogHelper.separator);
+                    // String splitUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_UID));
+                    writer.append(UUID.randomUUID().toString().replaceAll("-", "")).append(LogHelper.separator);
                     // time_now
                     writer.append(LogHelper.getLogFormattedTime((new Date()).getTime())).append(LogHelper.separator);
                     // date_entered

--- a/app/src/org/gnucash/android/export/log/LogExporter.java
+++ b/app/src/org/gnucash/android/export/log/LogExporter.java
@@ -30,7 +30,7 @@ public class LogExporter extends Exporter {
         TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(GnuCashApplication.getAppContext());
         try {
             Cursor cursor = transactionsDbAdapter.query (
-                    "trans_split_acct, trans_extra_info ON ON trans_extra_info.trans_acct_t_uid = trans_split_acct." +
+                    "trans_split_acct, trans_extra_info ON trans_extra_info.trans_acct_t_uid = trans_split_acct." +
                             DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_UID,
                     new String[]{
                             "*"
@@ -56,6 +56,7 @@ public class LogExporter extends Exporter {
                         if (!currentTransactionUID.equals("")) {
                             writer.append(LogHelper.end).append(LogHelper.lineEnd);
                         }
+                        currentTransactionUID = transactionUID;
                         writer.append(LogHelper.start).append(LogHelper.lineEnd);
                     }
                     // mod
@@ -85,10 +86,10 @@ public class LogExporter extends Exporter {
                     writer.append(description).append(LogHelper.separator);
                     // notes
                     String notes = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_NOTES));
-                    writer.append(notes).append(LogHelper.separator);
+                    writer.append(notes==null?"":notes).append(LogHelper.separator);
                     // memo
                     String memo = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_MEMO));
-                    writer.append(memo).append(LogHelper.separator);
+                    writer.append(memo==null?"":memo).append(LogHelper.separator);
                     // action
                     writer.append(LogHelper.separator);
                     // reconciled

--- a/app/src/org/gnucash/android/export/log/LogExporter.java
+++ b/app/src/org/gnucash/android/export/log/LogExporter.java
@@ -1,0 +1,131 @@
+package org.gnucash.android.export.log;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.db.AccountsDbAdapter;
+import org.gnucash.android.db.DatabaseSchema;
+import org.gnucash.android.db.TransactionsDbAdapter;
+import org.gnucash.android.export.ExportParams;
+import org.gnucash.android.export.Exporter;
+import org.gnucash.android.export.qif.QifHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.Date;
+
+public class LogExporter extends Exporter {
+
+    public LogExporter(ExportParams params) {
+        super(params);
+    }
+
+    @Override
+    public void generateExport(Writer writer) throws ExporterException {
+        TransactionsDbAdapter transactionsDbAdapter = new TransactionsDbAdapter(GnuCashApplication.getAppContext());
+        try {
+            Cursor cursor = transactionsDbAdapter.query (
+                    "trans_split_acct, trans_extra_info ON ON trans_extra_info.trans_acct_t_uid = trans_split_acct." +
+                            DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_UID,
+                    new String[]{
+                            "*"
+                    },
+                    // no recurrence transactions
+                    DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_RECURRENCE_PERIOD + " == 0" +
+                            (
+                                    mParameters.shouldExportAllTransactions() ?
+                                            "" : " AND " + DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_EXPORTED + " == 0"
+                            ),
+                    null,
+                    null,
+                    null,
+                    DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP + " ASC, "
+                        + DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_UID + " ASC"
+            );
+            try {
+                String currentTransactionUID = "";
+                writer.append(LogHelper.header).append(LogHelper.lineEnd);
+                while (cursor.moveToNext()) {
+                    String transactionUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_UID));
+                    if (!currentTransactionUID.equals(transactionUID)) {
+                        if (!currentTransactionUID.equals("")) {
+                            writer.append(LogHelper.end).append(LogHelper.lineEnd);
+                        }
+                        writer.append(LogHelper.start).append(LogHelper.lineEnd);
+                    }
+                    // mod
+                    writer.append(LogHelper.LOG_COMMIT).append(LogHelper.separator);
+                    // trans_guid
+                    writer.append(transactionUID).append(LogHelper.separator);
+                    // split_guid
+                    String splitUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_UID));
+                    writer.append(splitUID).append(LogHelper.separator);
+                    // time_now
+                    writer.append(LogHelper.getLogFormattedTime((new Date()).getTime())).append(LogHelper.separator);
+                    // date_entered
+                    String transTime = LogHelper.getLogFormattedTime(cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP)));
+                    writer.append(transTime).append(LogHelper.separator);
+                    // date_posted
+                    writer.append(transTime).append(LogHelper.separator);
+                    // acc_guid
+                    String accountUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.TABLE_NAME + "_" + DatabaseSchema.AccountEntry.COLUMN_UID));
+                    writer.append(accountUID).append(LogHelper.separator);
+                    // acc_name
+                    String accountName = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.TABLE_NAME + "_" + DatabaseSchema.AccountEntry.COLUMN_NAME));
+                    writer.append(accountName).append(LogHelper.separator);
+                    // num
+                    writer.append(LogHelper.separator);
+                    // description
+                    String description = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_DESCRIPTION));
+                    writer.append(description).append(LogHelper.separator);
+                    // notes
+                    String notes = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_NOTES));
+                    writer.append(notes).append(LogHelper.separator);
+                    // memo
+                    String memo = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_MEMO));
+                    writer.append(memo).append(LogHelper.separator);
+                    // action
+                    writer.append(LogHelper.separator);
+                    // reconciled
+                    writer.append("n" + LogHelper.separator);
+                    // amount
+                    String currency = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.TABLE_NAME + "_" + DatabaseSchema.TransactionEntry.COLUMN_CURRENCY));
+                    Currency trxCurrency = Currency.getInstance(currency);
+                    int fractionDigits = trxCurrency.getDefaultFractionDigits();
+                    int denomInt;
+                    denomInt = (int) Math.pow(10, fractionDigits);
+                    BigDecimal denom = new BigDecimal(denomInt);
+                    String denomString = Integer.toString(denomInt);
+                    String trxType = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_TYPE));
+                    BigDecimal value = new BigDecimal(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.SplitEntry.TABLE_NAME + "_" + DatabaseSchema.SplitEntry.COLUMN_AMOUNT)));
+                    value = value.multiply(denom);
+                    String strValue = (trxType.equals("CREDIT") ? "-" : "") + value.stripTrailingZeros().toPlainString() + "/" + denomString;
+                    writer.append(strValue).append(LogHelper.separator);
+                    // value
+                    writer.append(strValue).append(LogHelper.separator);
+                    // date_reconciled
+                    writer.append(LogHelper.DATE_RECONCILE).append(LogHelper.lineEnd);
+                }
+                writer.append(LogHelper.end);
+            }
+            finally {
+                cursor.close();
+            }
+            ContentValues contentValues = new ContentValues();
+            contentValues.put(DatabaseSchema.TransactionEntry.COLUMN_EXPORTED, 1);
+            transactionsDbAdapter.updateTransaction(contentValues, null, null);
+        }
+        catch (IOException e)
+        {
+            throw new ExporterException(mParameters, e);
+        }
+        finally {
+            transactionsDbAdapter.close();
+        }
+    }
+}

--- a/app/src/org/gnucash/android/export/log/LogHelper.java
+++ b/app/src/org/gnucash/android/export/log/LogHelper.java
@@ -1,0 +1,30 @@
+package org.gnucash.android.export.log;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class LogHelper {
+    static final String header = "mod\ttrans_guid\tsplit_guid\ttime_now\tdate_entered\tdate_posted\tacc_guid\tacc_name\tnum\tdescription\tnotes\tmemo\taction\treconciled\tamount\tvalue\tdate_reconciled\n" +
+            "-----------------";
+    static final String start = "===== START";
+    static final String end = "===== END";
+    static final String separator = "\t";
+    static final String lineEnd = "\n";
+    static final String LOG_COMMIT = "C";
+    static final String DATE_RECONCILE = "1970-01-01 08:00:00.000000 +08:00";
+    static final SimpleDateFormat LOG_DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+    public static String getLogFormattedTime(long milliseconds){
+        Date date = new Date(milliseconds);
+        String dateString = LOG_DATE_FORMATTER.format(date);
+        TimeZone tz = Calendar.getInstance().getTimeZone();
+        int offset = tz.getRawOffset();
+        String sign = offset > 0 ?  "+" : "-";
+        offset = offset > 0 ? offset : -offset;
+        int hours   = (int) (( offset / (1000*60*60)) % 24);
+        int minutes = (offset / (1000 * 60)) % 60;
+        return dateString + ".000000 " + sign + String.format("%02d:%02d", hours, minutes);
+    }
+}


### PR DESCRIPTION
OFX and GIF both have their limitation, GncXML cannot be used for transfer transactions (it cannot be imported). Looking at the GnuCash import menu, it seem that only replay GnuCash Log can report everything GnuCash needs: multi-currency, double entry, description, notes, memo, etc. So I created this exporter for generating (fake) gnucash logs.

However it also has its limitations, making it not a good way for normal user to use.
1. The replay log function in GnuCash is not intended for export/impot, it will assume that the log is generated by GnuCash, so only limited error check is applied. This may easily cause the GnuCash book result in error state.
2. Accounts are identified by GUID in the log, so only accounts already exist in GnuCash book can be corretly used.
3. The log is basicly recorded in a split by split style, with two possibkle edit action: Edit(insert) and delete. With the current GnuCash Android internal DB, deletion of split cannot be recorded. So if a transaction is edited in GCA, with one split deleted, others modified, the deletion cannot be replayed in GnuCash. (In OFX or GIF export, a new transaction will be created in GnuCash in this situation, possibly)
4. No auto-balancing after replay. In the situation in 3, if the exported transation is balanced, the transaction in GnuCash will not be balanced with one extra split. Imbalanced transactions in the log will not be corrected either. The GnuCash book will result in a strange state.

But for people who understands all the odds of log and replay log function, it can be a good way of export / import.
