### PR TITLE
Add TRADING to AccountType

### DIFF
--- a/app/src/org/gnucash/android/model/AccountType.java
+++ b/app/src/org/gnucash/android/model/AccountType.java
@@ -8,7 +8,7 @@ package org.gnucash.android.model;
 public enum AccountType {
     CASH(TransactionType.DEBIT), BANK(TransactionType.DEBIT), CREDIT, ASSET(TransactionType.DEBIT), LIABILITY,
     INCOME, EXPENSE(TransactionType.DEBIT), PAYABLE, RECEIVABLE(TransactionType.DEBIT), EQUITY, CURRENCY,
-    STOCK(TransactionType.DEBIT), MUTUAL(TransactionType.DEBIT), ROOT;
+    STOCK(TransactionType.DEBIT), MUTUAL(TransactionType.DEBIT), TRADING, ROOT;
 
     /**
      * Indicates that this type of normal balance the account type has


### PR DESCRIPTION
Missing TRADING enum prevented some account trees from being imported.
It showed an error toast saying "TRADING" was not in the AccountType
enum.
This patch adds it.