### PR TITLE
import with null parent

### DIFF
--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -378,7 +378,10 @@ public class GncXmlHandler extends DefaultHandler {
                     }
                     String parentUID = acc.getParentUID();
                     Account parentAccount = map.get(parentUID);
-                    if (parentAccount.getAccountType() == AccountType.ROOT) {
+                    // In accounts tree that are not imported, top level ROOT account
+                    // does not exist, which will make all top level accounts have a
+                    // null parent
+                    if (parentAccount == null || parentAccount.getAccountType() == AccountType.ROOT) {
                         // top level account, full name is the same as its name
                         mapFullName.put(acc.getUID(), acc.getName());
                         stack.pop();


### PR DESCRIPTION
When an account tree is created with gnucash-android (not imported), ROOT account may not exist. Thus in exported XML files, top level accounts do not have parent, causing the parentAcount to be null.

Added a check that will treat all accounts without a parent to be top level.

Should fix #295 .