### PR TITLE
future transactions are not included in balance calculation

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
@@ -277,8 +277,14 @@ public class SplitsDbAdapter extends DatabaseAdapter {
                 TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TEMPLATE + " = 0";
 
         if (startTimestamp != -1 && endTimestamp != -1) {
-            selection += " AND " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " BETWEEN ? AND ?";
+            selection += " AND " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " BETWEEN ? AND ? ";
             selectionArgs = new String[]{String.valueOf(startTimestamp), String.valueOf(endTimestamp)};
+        } else if (startTimestamp == -1 && endTimestamp != -1) {
+            selection += " AND " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " <= ?";
+            selectionArgs = new String[]{String.valueOf(endTimestamp)};
+        } else if (startTimestamp != -1 && endTimestamp == -1) {
+            selection += " AND " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " >= ?";
+            selectionArgs = new String[]{String.valueOf(startTimestamp)};
         }
 
         cursor = mDb.query(SplitEntry.TABLE_NAME + " , " + TransactionEntry.TABLE_NAME,

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -55,7 +55,7 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
         Money balance = Money.getZeroInstance();
         try {
-            balance = accountsDbAdapter.getAccountBalance(params[0]);
+            balance = accountsDbAdapter.getAccountBalance(params[0], -1, System.currentTimeMillis());
         } catch (IllegalArgumentException ex){
             //sometimes a load computation has been started and the data set changes.
             //the account ID may no longer exist. So we catch that exception here and do nothing

--- a/app/src/main/java/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/widget/WidgetConfigurationActivity.java
@@ -170,7 +170,7 @@ public class WidgetConfigurationActivity extends Activity {
 		RemoteViews views = new RemoteViews(context.getPackageName(),
 				R.layout.widget_4x1);
 		views.setTextViewText(R.id.account_name, account.getName());
-        Money accountBalance = accountsDbAdapter.getAccountBalance(accountUID);
+        Money accountBalance = accountsDbAdapter.getAccountBalance(accountUID, -1, System.currentTimeMillis());
 
         views.setTextViewText(R.id.transactions_summary,
 				accountBalance.formattedString(Locale.getDefault()));


### PR DESCRIPTION
When calculating balance in AccountBalanceTask and Widge, only consider transactions whose time stamp is before the system time. ‘Future' transactions are ignore.

Widget is not tested.