### PR TITLE
Prevent importing different ROOT account

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseAdapter.java
@@ -398,4 +398,25 @@ public abstract class DatabaseAdapter {
     public boolean deleteRecord(@NonNull String uid){
         return deleteRecord(getID(uid));
     }
+
+    /**
+     * Expose mDb.beginTransaction()
+     */
+    public void beginTransaction() {
+        mDb.beginTransaction();
+    }
+
+    /**
+     * Expose mDb.setTransactionSuccessful()
+     */
+    public void setTransactionSuccessful() {
+        mDb.setTransactionSuccessful();
+    }
+
+    /**
+     * Expose mDb.endTransaction()
+     */
+    public void endTransaction() {
+        mDb.endTransaction();
+    }
 }


### PR DESCRIPTION
Stop importing (by throw) if:
1) The import XML has no ROOT, and db is not empty.
     This is a backup restore. Everything should be cleared before import.
2) The import XML has multiple ROOT
     There's an error in import XML
3) The import XML has one ROOT, but it is different form the ROOT in the DB, or DB has no ROOT
     What imported is a different book from the one in the DB.

See discussion in #189.