### PR TITLE
some multi currency support based on value and quantity

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
@@ -212,7 +212,7 @@ public class SplitsDbAdapter extends DatabaseAdapter<Split> {
                 if (!hasDebitNormalBalance) {
                     amount_num = -amount_num;
                 }
-                return new Money(amount_num, amount_denom, Currency.getInstance(currencyCode));
+                return new Money(amount_num, amount_denom, currencyCode);
             }
         } finally {
             cursor.close();

--- a/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/SplitsDbAdapter.java
@@ -199,9 +199,9 @@ public class SplitsDbAdapter extends DatabaseAdapter<Split> {
 
         cursor = mDb.query(SplitEntry.TABLE_NAME + " , " + TransactionEntry.TABLE_NAME,
                 new String[]{"TOTAL ( CASE WHEN " + SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_TYPE + " = 'DEBIT' THEN " +
-                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_VALUE_NUM + " ELSE - " +
-                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_VALUE_NUM + " END )",
-                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_VALUE_DENOM},
+                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_QUANTITY_NUM + " ELSE - " +
+                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_QUANTITY_NUM + " END )",
+                        SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_QUANTITY_DENOM},
                 selection, selectionArgs, null, null, null);
 
         try {

--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -271,7 +271,8 @@ public class GncXmlExporter extends Exporter{
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_TYPE + " AS split_type",
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_VALUE_NUM + " AS split_value_num",
                         SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_VALUE_DENOM + " AS split_value_denom",
-                        SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_ACCOUNT_UID + " AS split_acct_uid"},
+                        SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_QUANTITY_NUM + " AS split_quantity_num",
+                        SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_QUANTITY_DENOM + " AS split_quantity_denom",                        SplitEntry.TABLE_NAME+"."+ SplitEntry.COLUMN_ACCOUNT_UID + " AS split_acct_uid"},
                         where, null,
                         TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " ASC , " +
                         TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_UID + " ASC ");
@@ -405,7 +406,11 @@ public class GncXmlExporter extends Exporter{
             xmlSerializer.text(strValue);
             xmlSerializer.endTag(null, GncXmlHelper.TAG_SPLIT_VALUE);
             // quantity, in the split account's currency
-            // TODO: multi currency support.
+            String splitQuantityNum = cursor.getString(cursor.getColumnIndexOrThrow("split_quantity_num"));
+            String splitQuantityDenom = cursor.getString(cursor.getColumnIndexOrThrow("split_quantity_denom"));
+            if (!exportTemplates) {
+                strValue = (trxType.equals("CREDIT") ? "-" : "") + splitValueNum + "/" + splitQuantityDenom;
+            }
             xmlSerializer.startTag(null, GncXmlHelper.TAG_SPLIT_QUANTITY);
             xmlSerializer.text(strValue);
             xmlSerializer.endTag(null, GncXmlHelper.TAG_SPLIT_QUANTITY);

--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlHelper.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlHelper.java
@@ -161,7 +161,7 @@ public abstract class GncXmlHelper {
 
     /**
      * Parses amount strings from GnuCash XML into {@link java.math.BigDecimal}s.
-     * The amounts are formatted as 12345/4100
+     * The amounts are formatted as 12345/100
      * @param amountString String containing the amount
      * @return BigDecimal with numerical value
      * @throws ParseException if the amount could not be parsed
@@ -174,7 +174,8 @@ public abstract class GncXmlHelper {
         }
 
         int scale = amountString.length() - pos - 2; //do this before, because we could modify the string
-        String numerator = TransactionFormFragment.stripCurrencyFormatting(amountString.substring(0, pos));
+        //String numerator = TransactionFormFragment.stripCurrencyFormatting(amountString.substring(0, pos));
+        String numerator = amountString.substring(0,pos);
         BigInteger numeratorInt = new BigInteger(numerator);
         return new BigDecimal(numeratorInt, scale);
     }

--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -132,9 +132,14 @@ public class GncXmlHandler extends DefaultHandler {
     Split mSplit;
 
     /**
-     * (Absolute) quantity of the split
+     * (Absolute) quantity of the split, which uses split account currency
      */
     BigDecimal mQuantity;
+
+    /**
+     * (Absolute) value of the split, which uses transaction currency
+     */
+    BigDecimal mValue;
 
     /**
      * Whether the quantity is negative
@@ -263,7 +268,7 @@ public class GncXmlHandler extends DefaultHandler {
                 mISO4217Currency = false;
                 break;
             case GncXmlHelper.TAG_TRN_SPLIT:
-                mSplit = new Split(Money.getZeroInstance(),"");
+                mSplit = new Split(Money.getZeroInstance(), "");
                 break;
             case GncXmlHelper.TAG_DATE_POSTED:
                 mIsDatePosted = true;
@@ -470,6 +475,16 @@ public class GncXmlHandler extends DefaultHandler {
             case GncXmlHelper.TAG_SPLIT_MEMO:
                 mSplit.setMemo(characterString);
                 break;
+            case GncXmlHelper.TAG_SPLIT_VALUE:
+                try {
+                    mValue = GncXmlHelper.parseSplitAmount(characterString).abs(); // use sign from quantity
+                } catch (ParseException e) {
+                    String msg = "Error parsing split quantity - " + characterString;
+                    Crashlytics.log(msg);
+                    Crashlytics.logException(e);
+                    throw new SAXException(msg, e);
+                }
+                break;
             case GncXmlHelper.TAG_SPLIT_QUANTITY:
                 // delay the assignment of currency when the split account is seen
                 try {
@@ -490,11 +505,12 @@ public class GncXmlHandler extends DefaultHandler {
                 break;
             case GncXmlHelper.TAG_SPLIT_ACCOUNT:
                 if (!mInTemplates) {
-                    //the split amount uses the account currency
-                    Money amount = new Money(mQuantity, getCurrencyForAccount(characterString));
                     //this is intentional: GnuCash XML formats split amounts, credits are negative, debits are positive.
                     mSplit.setType(mNegativeQuantity ? TransactionType.CREDIT : TransactionType.DEBIT);
-                    mSplit.setValue(amount);
+                    //the split amount uses the account currency
+                    mSplit.setQuantity(new Money(mQuantity, getCurrencyForAccount(characterString)));
+                    //the split value uses the transaction currency
+                    mSplit.setValue(new Money(mQuantity, mTransaction.getCurrency()));
                     mSplit.setAccountUID(characterString);
                 } else {
                     if (!mIgnoreTemplateTransaction)

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -116,12 +116,12 @@ public final class Money implements Comparable<Money>{
 		init();
 	}
 
-	public static BigDecimal getBigDecimal(long numerator, int denominator) {
+	public static BigDecimal getBigDecimal(long numerator, long denominator) {
 		int scale;
 		if (numerator == 0 && denominator == 0) {
 			denominator = 1;
 		}
-		switch (denominator) {
+		switch ((int)denominator) {
 			case 1: scale = 0; break;
 			case 10: scale = 1; break;
 			case 100: scale = 2; break;
@@ -132,17 +132,6 @@ public final class Money implements Comparable<Money>{
 		return new BigDecimal(BigInteger.valueOf(numerator), scale);
 	}
 
-	/**
-	 * Overloaded constructor
-	 * @param numerator numerator of the money instance
-	 * @param denominator denominator of the money instance
-	 * @param currency {@link Currency} associated with the <code>amount</code>
-	 */
-	public Money(long numerator, int denominator, Currency currency){
-		this.mAmount = getBigDecimal(numerator, denominator);
-		this.mCurrency = currency;
-	}
-	
 	/**
 	 * Overloaded constructor
 	 * @param amount {@link BigDecimal} value of the money instance
@@ -186,7 +175,7 @@ public final class Money implements Comparable<Money>{
 	 * @param currencyCode 3-character currency code string
 	 */
 	public Money(long numerator, long denominator, String currencyCode){
-		mAmount = new BigDecimal(numerator).divide(new BigDecimal(denominator), MathContext.UNLIMITED);
+		mAmount = getBigDecimal(numerator, denominator);
 		setCurrency(Currency.getInstance(currencyCode));
 	}
 

--- a/app/src/main/java/org/gnucash/android/model/Split.java
+++ b/app/src/main/java/org/gnucash/android/model/Split.java
@@ -2,6 +2,7 @@ package org.gnucash.android.model;
 
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 /**
  * A split amount in a transaction.
@@ -49,7 +50,8 @@ public class Split extends BaseModel{
      * @param value Money value amount of this split
      * @param accountUID String UID of transfer account
      */
-    public Split(@NonNull Money value, String accountUID){
+    public Split(@NonNull Money value, @NonNull Money quantity, String accountUID){
+        setQuantity(quantity);
         setValue(value);
         setAccountUID(accountUID);
         //NOTE: This is a rather simplististic approach to the split type.
@@ -57,6 +59,22 @@ public class Split extends BaseModel{
         //the database everytime a split is created. So we keep it simple here. Set the type you want explicity.
         mSplitType = value.isNegative() ? TransactionType.DEBIT : TransactionType.CREDIT;
     }
+
+    /**
+     * Initialize split with a value amount and account
+     * @param value Money value amount of this split
+     * @param accountUID String UID of transfer account
+     */
+    public Split(@NonNull Money amount, String accountUID){
+        setQuantity(amount);
+        setValue(amount);
+        setAccountUID(accountUID);
+        //NOTE: This is a rather simplististic approach to the split type.
+        //It typically also depends on the account type of the account. But we do not want to access
+        //the database everytime a split is created. So we keep it simple here. Set the type you want explicity.
+        mSplitType = amount.isNegative() ? TransactionType.DEBIT : TransactionType.CREDIT;
+    }
+
 
     /**
      * Clones the <code>sourceSplit</code> to create a new instance with same fields
@@ -94,10 +112,16 @@ public class Split extends BaseModel{
      * @param amount Money value of this split
      * @see #setQuantity(Money)
      */
-    public void setValue(Money amount) {
-        this.mValue = amount;
-        if (mQuantity == null){
-            mQuantity = amount;
+    public void setValue(Money value) {
+        mValue = value;
+        // remove the following when porting to value/quantity is done
+        if (mQuantity == null) {
+            Log.e(getClass().getSimpleName(), "Are you sure you want set the value instead of the quantity?");
+            try {
+                throw new Exception("");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/model/Transaction.java
+++ b/app/src/main/java/org/gnucash/android/model/Transaction.java
@@ -179,21 +179,20 @@ public class Transaction extends BaseModel{
      * @return Split whose amount is the imbalance of this transaction
      */
     public Split getAutoBalanceSplit(){
-        //FIXME: when multiple currencies per transaction are supported
-        Currency lastCurrency = null;
-        for (Split split : mSplitList) {
-            Currency currentCurrency = split.getValue().getCurrency();
-            if (lastCurrency == null)
-                lastCurrency = currentCurrency;
-            else if (lastCurrency != currentCurrency){
-                return null; //for now we will not autobalance multi-currency transactions
-            }
-            lastCurrency = currentCurrency;
-        }
+        //The values should be balanced even for multi-currency transactions
+        //Currency lastCurrency = null;
+        //for (Split split : mSplitList) {
+        //    Currency currentCurrency = split.getQuantity().getCurrency();
+        //    if (lastCurrency == null)
+        //        lastCurrency = currentCurrency;
+        //    else if (lastCurrency != currentCurrency){
+        //        return null; //for now we will not autobalance multi-currency transactions
+        //    }
+        //}
 
         //if all the splits are the same currency but the transaction is another
-        if (!lastCurrency.getCurrencyCode().equals(mCurrencyCode))
-            return null;
+        //if (!lastCurrency.getCurrencyCode().equals(mCurrencyCode))
+        //    return null;
 
         Money imbalance = getImbalance();
         if (!imbalance.isAmountZero()){
@@ -272,9 +271,10 @@ public class Transaction extends BaseModel{
     public Money getImbalance(){
         Money imbalance = Money.createZeroInstance(mCurrencyCode);
         for (Split split : mSplitList) {
-            //TODO: Handle this better when multi-currency support is introduced
-            if (!split.getValue().getCurrency().getCurrencyCode().equals(mCurrencyCode))
-                return Money.createZeroInstance(mCurrencyCode); //abort
+            if (!split.getValue().getCurrency().getCurrencyCode().equals(mCurrencyCode)) {
+                // values in transactions are always in the same currency
+                throw new RuntimeException("Splits values in transaction are not in the same currency");
+            }
             Money amount = split.getValue().absolute();
             if (split.getType() == TransactionType.DEBIT)
                 imbalance = imbalance.subtract(amount);


### PR DESCRIPTION
Some notes:
The account balance should be the same with gnucash even with multi-currency transactions, if no price table exists in the desktop version. The price table can be deleted from the desktop version.

Split.setValue will NOT set quantity any more. If quantity is null it will print an error message. Remove this check and error message when everyone knows this.

During import, the amount format should not contain any special characters according to gnucash XML doc. So I removed the special treatment for special characters.

Auto balance for multi-currency should work for gnucash generated XML files, but it won't work for old GNCA exports. Extra splits would be created.