### PR TITLE
fix wrong uid in new split

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -261,7 +261,7 @@ public class SplitEditorFragment extends Fragment {
             splitCurrencyTextView.setText(accountCurrency.getSymbol());
             splitTypeButton.setAmountFormattingListener(splitAmountEditText, splitCurrencyTextView);
             splitTypeButton.setChecked(mBaseAmount.signum() > 0);
-            splitUidTextView.setText(UUID.randomUUID().toString());
+            splitUidTextView.setText(UUID.randomUUID().toString().replaceAll("-", ""));
 
             if (split != null) {
                 splitAmountEditText.setCurrency(split.getValue().getCurrency());


### PR DESCRIPTION
The generated UUID for a new split is in the wrong format, which will result in an erroneous split when the exported XML is opened by GnuCash desktop.