### PR TITLE
Returning 0 in 'getTransactionMaxSplitNum'

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
@@ -1224,12 +1224,11 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         try {
             if (cursor.moveToFirst()) {
                 return (int)cursor.getLong(0);
-            } else {
-                return 0;
             }
         }
         finally {
             cursor.close();
         }
+        return 0;
     }
 }


### PR DESCRIPTION
There are a unused if condition, now in any case we return 0, if there was a exception or if there is nothing to get from the cursor.