### PR TITLE
fix the bug that modify account name will delete all transaction under the account

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseAdapter.java
@@ -56,6 +56,10 @@ public abstract class DatabaseAdapter<Model extends BaseModel> {
 
     protected SQLiteStatement mReplaceStatement;
 
+    public enum UpdateMethod {
+        insert, update, replace
+    };
+
     /**
      * Opens the database adapter with an existing database
      * @param db SQLiteDatabase object
@@ -618,6 +622,20 @@ public abstract class DatabaseAdapter<Model extends BaseModel> {
      */
     public void setTransactionSuccessful() {
         mDb.setTransactionSuccessful();
+    }
+
+    /// Foreign key constraits should be enabled in general.
+    /// But if it affects speed (check constraints takes time)
+    /// and the constrained can be assured by the program,
+    /// or if some SQL exec will cause deletion of records
+    /// (like use replace in accounts update will delete all transactions)
+    /// that need not be deleted, then it can be disabled temporarily
+    public void enableForeignKey(boolean enable) {
+        if (enable){
+            mDb.execSQL("PRAGMA foreign_keys=ON");
+        } else {
+            mDb.execSQL("PRAGMA foreign_keys=OFF");
+        }
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -846,7 +846,9 @@ public class AccountFormFragment extends Fragment {
 		if (mAccountsDbAdapter == null)
 			mAccountsDbAdapter = AccountsDbAdapter.getInstance();
         // bulk update, will not update transactions
+        mAccountsDbAdapter.enableForeignKey(false);
 		mAccountsDbAdapter.bulkAddRecords(accountsToUpdate);
+        mAccountsDbAdapter.enableForeignKey(true);
 
 		finishFragment();
 	}


### PR DESCRIPTION
quick fix to #436 .

It is caused by REPLACE sql command. REPLACE will delete then insert, and the deletion would cause the transactions to be deleted due to ON DELETE CASCADE on the foreign key constraint.