### PR TITLE
Transaction amount input uses account commodity

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -494,6 +494,9 @@ public class TransactionFormFragment extends Fragment implements
 		Currency accountCurrency = Currency.getInstance(currencyCode);
 		mCurrencyTextView.setText(accountCurrency.getSymbol());
 
+        Commodity commodity = Commodity.getInstance(currencyCode);
+        mAmountEditText.setCommodity(commodity);
+
         mSaveTemplateCheckbox.setChecked(mTransaction.isTemplate());
         String scheduledActionUID = getArguments().getString(UxArgument.SCHEDULED_ACTION_UID);
         if (scheduledActionUID != null && !scheduledActionUID.isEmpty()) {
@@ -543,6 +546,9 @@ public class TransactionFormFragment extends Fragment implements
 		}
 		Currency accountCurrency = Currency.getInstance(code);
 		mCurrencyTextView.setText(accountCurrency.getSymbol());
+
+        Commodity commodity = Commodity.getInstance(code);
+        mAmountEditText.setCommodity(commodity);
 
         if (mUseDoubleEntry){
             String currentAccountUID = mAccountUID;


### PR DESCRIPTION
There was a bug where the amount input view was not having the commodity set. This led to bugs where, if the user creates or edits a transaction in a USD account, but the default is set to JPY, it will
truncate input after the decimal point.

I emailed you about this bug, but I decided that since it's available on Github, I would see if I could fix it myself :smiley_cat: 