### PR TITLE
Modify "Owncloud" in export destinations

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,7 +64,7 @@
     <item>SD卡</item>
     <item>DropBox</item>
     <item>Google Drive</item>
-    <item>Owncloud</item>
+    <item>分享至</item>
   </string-array>
   <string name="btn_move">移动</string>
   <string name="title_move_transactions">移动 %1$d 交易</string>


### PR DESCRIPTION
Updated res/values-zh-rCN/strings.xml. Changed the confusing "Owncloud" to " share to"
![screenshot_2015-12-29-09-06-26](https://cloud.githubusercontent.com/assets/9802641/12028299/1375de48-ae10-11e5-967f-b49900b9bb9f.png)
