### PR TITLE
Fixing squid:UselessParenthesesCheck-Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -218,7 +218,7 @@ public class AccountFormFragment extends Fragment {
         @Override
         public void onColorSelected(int color) {
             mColorSquare.setBackgroundColor(color);
-            mSelectedColor = String.format("#%06X", (0xFFFFFF & color));
+            mSelectedColor = String.format("#%06X", 0xFFFFFF & color);
         }
     };
 

--- a/app/src/main/java/org/gnucash/android/ui/account/DeleteAccountDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/DeleteAccountDialogFragment.java
@@ -110,7 +110,7 @@ public class DeleteAccountDialogFragment extends DialogFragment {
         ((TextView) transactionOptionsView.findViewById(R.id.description)).setText(R.string.label_delete_account_transactions_description);
         mDeleteTransactionsRadioButton = (RadioButton) transactionOptionsView.findViewById(R.id.radio_delete);
         mDeleteTransactionsRadioButton.setText(R.string.label_delete_transactions);
-        mMoveTransactionsRadioButton = ((RadioButton) transactionOptionsView.findViewById(R.id.radio_move));
+        mMoveTransactionsRadioButton = (RadioButton) transactionOptionsView.findViewById(R.id.radio_move);
         mTransactionsDestinationAccountSpinner = (Spinner) transactionOptionsView.findViewById(R.id.target_accounts_spinner);
 
         View accountOptionsView = view.findViewById(R.id.accounts_options);

--- a/app/src/main/java/org/gnucash/android/ui/colorpicker/ColorPickerPalette.java
+++ b/app/src/main/java/org/gnucash/android/ui/colorpicker/ColorPickerPalette.java
@@ -148,7 +148,7 @@ public class ColorPickerPalette extends TableLayout {
             accessibilityIndex = index;
         } else {
             // We're in a backwards-ordered row.
-            int rowMax = ((rowNumber + 1) * mNumColumns);
+            int rowMax = (rowNumber + 1) * mNumColumns;
             accessibilityIndex = rowMax - rowElements;
         }
 

--- a/app/src/main/java/org/gnucash/android/ui/report/BaseReportFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/BaseReportFragment.java
@@ -244,7 +244,7 @@ public abstract class BaseReportFragment extends Fragment implements
         switch (mGroupInterval) {
             case QUARTER:
                 int y = Years.yearsBetween(start.withDayOfYear(1).withMillisOfDay(0), end.withDayOfYear(1).withMillisOfDay(0)).getYears();
-                return (getQuarter(end) - getQuarter(start) + y * 4);
+                return getQuarter(end) - getQuarter(start) + y * 4;
             case MONTH:
                 return Months.monthsBetween(start.withDayOfMonth(1).withMillisOfDay(0), end.withDayOfMonth(1).withMillisOfDay(0)).getMonths();
             case YEAR:
@@ -261,7 +261,7 @@ public abstract class BaseReportFragment extends Fragment implements
      * @return a quarter
      */
     protected int getQuarter(LocalDateTime date) {
-        return ((date.getMonthOfYear() - 1) / 3 + 1);
+        return (date.getMonthOfYear() - 1) / 3 + 1;
     }
 
 

--- a/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
@@ -145,7 +145,7 @@ public class BalanceSheetFragment extends BaseReportFragment {
             Money balance = mAccountsDbAdapter.getAccountBalance(accountUID);
             View view = inflater.inflate(R.layout.row_balance_sheet, tableLayout, false);
             ((TextView)view.findViewById(R.id.account_name)).setText(name);
-            TextView balanceTextView = ((TextView) view.findViewById(R.id.account_balance));
+            TextView balanceTextView = (TextView) view.findViewById(R.id.account_balance);
             TransactionsActivity.displayBalance(balanceTextView, balance);
             tableLayout.addView(view);
         }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -263,7 +263,7 @@ public class TransactionFormFragment extends Fragment implements
     private void startTransferFunds() {
         Currency fromCurrency = Currency.getInstance(mTransactionsDbAdapter.getAccountCurrencyCode(mAccountUID));
         long id = mTransferAccountSpinner.getSelectedItemId();
-        String targetCurrency = mAccountsDbAdapter.getCurrencyCode((mAccountsDbAdapter.getUID(id)));
+        String targetCurrency = mAccountsDbAdapter.getCurrencyCode(mAccountsDbAdapter.getUID(id));
 
         if (fromCurrency.equals(Currency.getInstance(targetCurrency))
                 || !mAmountEditText.isInputModified()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger