### PR TITLE
Avoid returning nulls from some Account methods

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
@@ -601,7 +601,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         String[] tokens = fullName.trim().split(ACCOUNT_NAME_SEPARATOR);
         String uid = getOrCreateGnuCashRootAccountUID();
         String parentName = "";
-        ArrayList<Account> accountsList = new ArrayList<Account>();
+        ArrayList<Account> accountsList = new ArrayList<>();
         for (String token : tokens) {
             parentName += token;
             String parentUID = findAccountUidByFullName(parentName);
@@ -841,8 +841,8 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
     public List<String> getDescendantAccountUIDs(String accountUID, String where, String[] whereArgs) {
         // accountsList will hold accountUID with all descendant accounts.
         // accountsListLevel will hold descendant accounts of the same level
-        ArrayList<String> accountsList = new ArrayList<String>();
-        ArrayList<String> accountsListLevel = new ArrayList<String>();
+        ArrayList<String> accountsList = new ArrayList<>();
+        ArrayList<String> accountsListLevel = new ArrayList<>();
         accountsListLevel.add(accountUID);
         for (;;) {
             Cursor cursor = mDb.query(AccountEntry.TABLE_NAME,
@@ -1105,14 +1105,14 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
      */
     public List<Transaction> getAllOpeningBalanceTransactions(){
         Cursor cursor = fetchAccounts(null, null, null);
-        List<Transaction> openingTransactions = new ArrayList<Transaction>();
+        List<Transaction> openingTransactions = new ArrayList<>();
         try {
             SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
             while (cursor.moveToNext()) {
                 long id = cursor.getLong(cursor.getColumnIndexOrThrow(AccountEntry._ID));
                 String accountUID = getUID(id);
                 String currencyCode = getCurrencyCode(accountUID);
-                ArrayList<String> accountList = new ArrayList<String>();
+                ArrayList<String> accountList = new ArrayList<>();
                 accountList.add(accountUID);
                 Money balance = splitsDbAdapter.computeSplitBalance(accountList,
                         currencyCode, getAccountType(accountUID).hasDebitNormalBalance());

--- a/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
@@ -173,8 +173,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         mReplaceStatement.clearBindings();
         mReplaceStatement.bindString(1, account.getUID());
         mReplaceStatement.bindString(2, account.getName());
-        if (account.getDescription() != null)
-            mReplaceStatement.bindString(3, account.getDescription());
+        mReplaceStatement.bindString(3, account.getDescription());
         mReplaceStatement.bindString(4, account.getAccountType().name());
         mReplaceStatement.bindString(5, account.getCurrency().getCurrencyCode());
         if (account.getColorHexCode() != null) {
@@ -407,7 +406,8 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         Account account = new Account(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_NAME)));
         populateBaseModelAttributes(c, account);
 
-        account.setDescription(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_DESCRIPTION)));
+        String description = c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_DESCRIPTION));
+        account.setDescription(description == null ? "" : description);
         account.setParentUID(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_PARENT_ACCOUNT_UID)));
         account.setAccountType(AccountType.valueOf(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_TYPE))));
         Currency currency = Currency.getInstance(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_CURRENCY)));

--- a/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
@@ -176,8 +176,8 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         mReplaceStatement.bindString(3, account.getDescription());
         mReplaceStatement.bindString(4, account.getAccountType().name());
         mReplaceStatement.bindString(5, account.getCurrency().getCurrencyCode());
-        if (account.getColorHexCode() != Account.DEFAULT_COLOR) {
-            mReplaceStatement.bindString(6, account.getColorHexCode());
+        if (account.getColor() != Account.DEFAULT_COLOR) {
+            mReplaceStatement.bindString(6, convertToRGBHexString(account.getColor()));
         }
         mReplaceStatement.bindLong(7, account.isFavorite() ? 1 : 0);
         mReplaceStatement.bindString(8, account.getFullName());
@@ -203,6 +203,10 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
             mReplaceStatement.bindNull(14);
 
         return mReplaceStatement;
+    }
+
+    private String convertToRGBHexString(int color) {
+        return String.format("#%06X", (0xFFFFFF & color));
     }
 
     /**
@@ -416,7 +420,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         account.setDefaultTransferAccountUID(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID)));
         String color = c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_COLOR_CODE));
         if (color != null)
-            account.setColorCode(color);
+            account.setColor(color);
         account.setFavorite(c.getInt(c.getColumnIndexOrThrow(AccountEntry.COLUMN_FAVORITE)) == 1);
         account.setFullName(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_FULL_NAME)));
         account.setHidden(c.getInt(c.getColumnIndexOrThrow(AccountEntry.COLUMN_HIDDEN)) == 1);
@@ -563,7 +567,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
             account.setAccountType(AccountType.BANK);
             account.setParentUID(getOrCreateGnuCashRootAccountUID());
             account.setHidden(!GnuCashApplication.isDoubleEntryEnabled());
-            account.setColorCode("#964B00");
+            account.setColor("#964B00");
             addRecord(account);
             uid = account.getUID();
         }

--- a/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/AccountsDbAdapter.java
@@ -176,7 +176,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         mReplaceStatement.bindString(3, account.getDescription());
         mReplaceStatement.bindString(4, account.getAccountType().name());
         mReplaceStatement.bindString(5, account.getCurrency().getCurrencyCode());
-        if (account.getColorHexCode() != null) {
+        if (account.getColorHexCode() != Account.DEFAULT_COLOR) {
             mReplaceStatement.bindString(6, account.getColorHexCode());
         }
         mReplaceStatement.bindLong(7, account.isFavorite() ? 1 : 0);
@@ -414,7 +414,9 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         account.setCommodity(CommoditiesDbAdapter.getInstance().getCommodity(currency.getCurrencyCode()));
         account.setPlaceHolderFlag(c.getInt(c.getColumnIndexOrThrow(AccountEntry.COLUMN_PLACEHOLDER)) == 1);
         account.setDefaultTransferAccountUID(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID)));
-        account.setColorCode(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_COLOR_CODE)));
+        String color = c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_COLOR_CODE));
+        if (color != null)
+            account.setColorCode(color);
         account.setFavorite(c.getInt(c.getColumnIndexOrThrow(AccountEntry.COLUMN_FAVORITE)) == 1);
         account.setFullName(c.getString(c.getColumnIndexOrThrow(AccountEntry.COLUMN_FULL_NAME)));
         account.setHidden(c.getInt(c.getColumnIndexOrThrow(AccountEntry.COLUMN_HIDDEN)) == 1);

--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -467,7 +467,7 @@ public class GncXmlHandler extends DefaultHandler {
                             color = "#" + color.replaceAll(".(.)?", "$1").replace("null", "");
                         try {
                             if (mAccount != null)
-                                mAccount.setColorCode(color);
+                                mAccount.setColor(color);
                         } catch (IllegalArgumentException ex) {
                             //sometimes the color entry in the account file is "Not set" instead of just blank. So catch!
                             Log.e(LOG_TAG, "Invalid color code '" + color + "' for account " + mAccount.getName());

--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -75,6 +75,24 @@ public class GncXmlHandler extends DefaultHandler {
      */
     private static final String LOG_TAG = "GnuCashAccountImporter";
 
+    /*
+        ^             anchor for start of string
+        #             the literal #
+        (             start of group
+        ?:            indicate a non-capturing group that doesn't generate back-references
+        [0-9a-fA-F]   hexadecimal digit
+        {3}           three times
+        )             end of group
+        {2}           repeat twice
+        $             anchor for end of string
+     */
+    /**
+     * Regular expression for validating color code strings.
+     * Accepts #rgb and #rrggbb
+     */
+    //TODO: Allow use of #aarrggbb format as well
+    public static final String ACCOUNT_COLOR_HEX_REGEX = "^#(?:[0-9a-fA-F]{3}){2}$";
+
     /**
      * Adapter for saving the imported accounts
      */
@@ -463,7 +481,7 @@ public class GncXmlHandler extends DefaultHandler {
                     //so we trim the last digit in each block, doesn't affect the color much
                     if (!color.equals("Not Set")) {
                         // avoid known exception, printStackTrace is very time consuming
-                        if (!Pattern.matches(Account.COLOR_HEX_REGEX, color))
+                        if (!Pattern.matches(ACCOUNT_COLOR_HEX_REGEX, color))
                             color = "#" + color.replaceAll(".(.)?", "$1").replace("null", "");
                         try {
                             if (mAccount != null)

--- a/app/src/main/java/org/gnucash/android/model/Account.java
+++ b/app/src/main/java/org/gnucash/android/model/Account.java
@@ -197,16 +197,16 @@ public class Account extends BaseModel{
     }
 
 	/**
-	 * Returns the account mDescription
-	 * @return String with mDescription
+	 * Returns the account description
+	 * @return String with description
 	 */
 	public String getDescription() {
 		return mDescription;
 	}
 
 	/**
-	 * Sets the account mDescription
-	 * @param description String mDescription
+	 * Sets the account description
+	 * @param description Account description
 	 */
 	public void setDescription(@NonNull String description) {
 		this.mDescription = description;
@@ -326,7 +326,7 @@ public class Account extends BaseModel{
     }
 
     /**
-	 * @return the mCurrency
+	 * Returns the currency for this account.
 	 */
 	public Currency getCurrency() {
 		return Currency.getInstance(mCurrencyCode);
@@ -342,7 +342,6 @@ public class Account extends BaseModel{
 
 	/**
 	 * Return the commodity for this account
-	 * @return
 	 */
 	public Commodity getCommodity(){
 		return mCommodity;

--- a/app/src/main/java/org/gnucash/android/model/Account.java
+++ b/app/src/main/java/org/gnucash/android/model/Account.java
@@ -18,6 +18,7 @@ package org.gnucash.android.model;
 
 
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 
 import org.gnucash.android.BuildConfig;
 import org.gnucash.android.app.GnuCashApplication;
@@ -88,7 +89,7 @@ public class Account extends BaseModel{
 	/**
 	 * Account description
 	 */
-	private String mDescription;
+	private String mDescription = "";
 
 	/**
 	 * Currency used by transactions in this account
@@ -222,7 +223,7 @@ public class Account extends BaseModel{
 	 * Sets the account mDescription
 	 * @param description String mDescription
 	 */
-	public void setDescription(String description) {
+	public void setDescription(@NonNull String description) {
 		this.mDescription = description;
 	}
 

--- a/app/src/main/java/org/gnucash/android/model/Account.java
+++ b/app/src/main/java/org/gnucash/android/model/Account.java
@@ -18,12 +18,9 @@ package org.gnucash.android.model;
 
 
 import android.graphics.Color;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
 import org.gnucash.android.BuildConfig;
-import org.gnucash.android.app.GnuCashApplication;
-import org.gnucash.android.export.Exporter;
 import org.gnucash.android.export.ofx.OfxHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -72,9 +69,10 @@ public class Account extends BaseModel{
     public static final String COLOR_HEX_REGEX = "^#(?:[0-9a-fA-F]{3}){1,2}$";
 
 	/**
-	 * Default color, if not set explicitly through {@link #setColorCode(String)}.
+	 * Default color, if not set explicitly through {@link #setColor(String)}.
 	 */
-	public static final String DEFAULT_COLOR = "#cccccc"; // Color.LT_GRAY
+	// TODO: get it from a theme value?
+	public static final int DEFAULT_COLOR = Color.LTGRAY;
 
 	/**
      * Accounts types which are used by the OFX standard
@@ -139,7 +137,7 @@ public class Account extends BaseModel{
     /**
      * Account color field in hex format #rrggbb
      */
-    private String mColorCode = DEFAULT_COLOR;
+    private int mColor = DEFAULT_COLOR;
 
     /**
      * Flag which marks this account as a favorite account
@@ -300,23 +298,35 @@ public class Account extends BaseModel{
 	}
 
     /**
-     * Returns the color code of the account in the format #rrggbb
-     * @return Color code of the account
+     * Returns the color of the account.
+     * @return Color of the account as an int as returned by {@link Color}.
      */
-    public String getColorHexCode() {
-        return mColorCode;
+    public int getColor() {
+        return mColor;
     }
 
+	/**
+	 * Sets the color of the account.
+	 * @param color Color as an int as returned by {@link Color}.
+	 * @throws java.lang.IllegalArgumentException if the color is transparent,
+	 *   which is not supported.
+	 */
+	public void setColor(int color) {
+		if (Color.alpha(color) < 255)
+			throw new IllegalArgumentException("Transparent colors are not supported: " + color);
+		mColor = color;
+	}
+
     /**
-     * Sets the color code of the account.
+     * Sets the color of the account.
      * @param colorCode Color code to be set in the format #rrggbb or #rgb
      * @throws java.lang.IllegalArgumentException if the color code is not properly formatted
      */
-    public void setColorCode(@NonNull String colorCode) {
+    public void setColor(@NonNull String colorCode) {
         if (!Pattern.matches(COLOR_HEX_REGEX, colorCode))
             throw new IllegalArgumentException("Invalid color hex code: " + colorCode);
 
-        this.mColorCode = colorCode;
+        setColor(Color.parseColor(colorCode));
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/model/Account.java
+++ b/app/src/main/java/org/gnucash/android/model/Account.java
@@ -29,7 +29,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * An account represents a transaction account in with {@link Transaction}s may be recorded
@@ -49,24 +48,6 @@ public class Account extends BaseModel{
 	 * This is used when sending intents from third-party applications
 	 */
 	public static final String MIME_TYPE = "vnd.android.cursor.item/vnd." + BuildConfig.APPLICATION_ID + ".account";
-
-    /*
-        ^             anchor for start of string
-        #             the literal #
-        (             start of group
-        ?:            indicate a non-capturing group that doesn't generate back-references
-        [0-9a-fA-F]   hexadecimal digit
-        {3}           three times
-        )             end of group
-        {1,2}         repeat either once or twice
-        $             anchor for end of string
-     */
-    /**
-     * Regular expression for validating color code strings.
-     * Accepts #rgb and #rrggbb
-     */
-    //TODO: Allow use of #aarrggbb format as well
-    public static final String COLOR_HEX_REGEX = "^#(?:[0-9a-fA-F]{3}){1,2}$";
 
 	/**
 	 * Default color, if not set explicitly through {@link #setColor(String)}.
@@ -111,7 +92,7 @@ public class Account extends BaseModel{
 	 * Defaults to {@link AccountType#CASH}
 	 */
 	private AccountType mAccountType = AccountType.CASH;
-	
+
 	/**
 	 * List of transactions in this account
 	 */
@@ -153,13 +134,13 @@ public class Account extends BaseModel{
 	 * An extra key for passing the currency code (according ISO 4217) in an intent
 	 */
 	public static final String EXTRA_CURRENCY_CODE 	= "org.gnucash.android.extra.currency_code";
-	
+
 	/**
-	 * Extra key for passing the unique ID of the parent account when creating a 
+	 * Extra key for passing the unique ID of the parent account when creating a
 	 * new account using Intents
 	 */
 	public static final String EXTRA_PARENT_UID 	= "org.gnucash.android.extra.parent_uid";
-	
+
 	/**
 	 * Constructor
 	 * Creates a new account with the default currency and a generated unique ID
@@ -170,7 +151,7 @@ public class Account extends BaseModel{
         this.mFullName  = mName;
 		setCommodity(Commodity.DEFAULT_COMMODITY);
 	}
-	
+
 	/**
 	 * Overloaded constructor
 	 * @param name Name of the account
@@ -256,11 +237,11 @@ public class Account extends BaseModel{
 		transaction.setCommodity(mCommodity);
 		mTransactionsList.add(transaction);
 	}
-	
+
 	/**
 	 * Sets a list of transactions for this account.
 	 * Overrides any previous transactions with those in the list.
-	 * The account UID and currency of the transactions will be set to the unique ID 
+	 * The account UID and currency of the transactions will be set to the unique ID
 	 * and currency of the account respectively
 	 * @param transactionsList List of {@link Transaction}s to be set.
 	 */
@@ -275,7 +256,7 @@ public class Account extends BaseModel{
 	public List<Transaction> getTransactions(){
 		return mTransactionsList;
 	}
-	
+
 	/**
 	 * Returns the number of transactions in this account
 	 * @return Number transactions in account
@@ -319,13 +300,12 @@ public class Account extends BaseModel{
 
     /**
      * Sets the color of the account.
-     * @param colorCode Color code to be set in the format #rrggbb or #rgb
-     * @throws java.lang.IllegalArgumentException if the color code is not properly formatted
+     * @param colorCode Color code to be set in the format #rrggbb
+     * @throws java.lang.IllegalArgumentException if the color code is not properly formatted or
+	 *   the color is transparent.
      */
+	//TODO: Allow use of #aarrggbb format as well
     public void setColor(@NonNull String colorCode) {
-        if (!Pattern.matches(COLOR_HEX_REGEX, colorCode))
-            throw new IllegalArgumentException("Invalid color hex code: " + colorCode);
-
         setColor(Color.parseColor(colorCode));
     }
 

--- a/app/src/main/java/org/gnucash/android/model/Account.java
+++ b/app/src/main/java/org/gnucash/android/model/Account.java
@@ -17,6 +17,7 @@
 package org.gnucash.android.model;
 
 
+import android.graphics.Color;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
@@ -70,7 +71,12 @@ public class Account extends BaseModel{
     //TODO: Allow use of #aarrggbb format as well
     public static final String COLOR_HEX_REGEX = "^#(?:[0-9a-fA-F]{3}){1,2}$";
 
-    /**
+	/**
+	 * Default color, if not set explicitly through {@link #setColorCode(String)}.
+	 */
+	public static final String DEFAULT_COLOR = "#cccccc"; // Color.LT_GRAY
+
+	/**
      * Accounts types which are used by the OFX standard
      */
 	public enum OfxAccountType {CHECKING, SAVINGS, MONEYMRKT, CREDITLINE }
@@ -133,7 +139,7 @@ public class Account extends BaseModel{
     /**
      * Account color field in hex format #rrggbb
      */
-    private String mColorCode;
+    private String mColorCode = DEFAULT_COLOR;
 
     /**
      * Flag which marks this account as a favorite account
@@ -306,10 +312,7 @@ public class Account extends BaseModel{
      * @param colorCode Color code to be set in the format #rrggbb or #rgb
      * @throws java.lang.IllegalArgumentException if the color code is not properly formatted
      */
-    public void setColorCode(String colorCode) {
-        if (colorCode == null)
-            return;
-
+    public void setColorCode(@NonNull String colorCode) {
         if (!Pattern.matches(COLOR_HEX_REGEX, colorCode))
             throw new IllegalArgumentException("Invalid color hex code: " + colorCode);
 

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -106,12 +106,6 @@ public class AccountFormFragment extends Fragment {
 	 */
 	private AccountsDbAdapter mAccountsDbAdapter;
 
-	
-	/**
-	 * List of all currency codes (ISO 4217) supported by the app
-	 */
-	private List<String> mCurrencyCodes;
-
     /**
      * GUID of the parent account
      * This value is set to the parent account of the transaction being edited or
@@ -400,10 +394,9 @@ public class AccountFormFragment extends Fragment {
                 setDefaultTransferAccountSelection(doubleDefaultAccountId, true);
             } else {
                 String currentAccountUID = account.getParentUID();
-                long defaultTransferAccountID = 0;
                 String rootAccountUID = mAccountsDbAdapter.getOrCreateGnuCashRootAccountUID();
                 while (!currentAccountUID.equals(rootAccountUID)) {
-                    defaultTransferAccountID = mAccountsDbAdapter.getDefaultTransferAccountID(mAccountsDbAdapter.getID(currentAccountUID));
+                    long defaultTransferAccountID = mAccountsDbAdapter.getDefaultTransferAccountID(mAccountsDbAdapter.getID(currentAccountUID));
                     if (defaultTransferAccountID > 0) {
                         setDefaultTransferAccountSelection(defaultTransferAccountID, false);
                         break; //we found a parent with default transfer setting
@@ -523,7 +516,7 @@ public class AccountFormFragment extends Fragment {
         TypedArray colorTypedArray = res.obtainTypedArray(R.array.account_colors);
         int[] colorOptions = new int[colorTypedArray.length()];
         for (int i = 0; i < colorTypedArray.length(); i++) {
-             int color = colorTypedArray.getColor(i, R.color.title_green);
+             int color = colorTypedArray.getColor(i, getResources().getColor(R.color.title_green));
              colorOptions[i] = color;
         }
         return colorOptions;
@@ -678,7 +671,7 @@ public class AccountFormFragment extends Fragment {
      */
     private List<String> getAccountTypeStringList(){
         String[] accountTypes = Arrays.toString(AccountType.values()).replaceAll("\\[|]", "").split(",");
-        List<String> accountTypesList = new ArrayList<String>();
+        List<String> accountTypesList = new ArrayList<>();
         for (String accountType : accountTypes) {
             accountTypesList.add(accountType.trim());
         }
@@ -690,7 +683,7 @@ public class AccountFormFragment extends Fragment {
      */
     private void loadAccountTypesList(){
         String[] accountTypes = getResources().getStringArray(R.array.account_type_entry_values);
-        ArrayAdapter<String> accountTypesAdapter = new ArrayAdapter<String>(
+        ArrayAdapter<String> accountTypesAdapter = new ArrayAdapter<>(
                 getActivity(), android.R.layout.simple_list_item_1, accountTypes);
 
         accountTypesAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
@@ -805,7 +798,7 @@ public class AccountFormFragment extends Fragment {
                             null
                     ));
                 }
-                HashMap<String, Account> mapAccount = new HashMap<String, Account>();
+                HashMap<String, Account> mapAccount = new HashMap<>();
                 for (Account acct : accountsToUpdate) mapAccount.put(acct.getUID(), acct);
                 for (String uid: mDescendantAccountUIDs) {
                     // mAccountsDbAdapter.getDescendantAccountUIDs() will ensure a parent-child order

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -203,10 +203,7 @@ public class AccountFormFragment extends Fragment {
      */
     private boolean mUseDoubleEntry;
 
-    /**
-     * Default to transparent
-     */
-    private String mSelectedColor = null;
+    private String mSelectedColor = Account.DEFAULT_COLOR;
 
     /**
      * Trigger for color picker dialog
@@ -417,7 +414,7 @@ public class AccountFormFragment extends Fragment {
         }
 
         mPlaceholderCheckBox.setChecked(account.isPlaceholderAccount());
-        initializeColorSquarePreview(account.getColorHexCode());
+        mColorSquare.setBackgroundColor(Color.parseColor(account.getColorHexCode()));
 
         setAccountTypeSelection(account.getAccountType());
     }
@@ -438,17 +435,6 @@ public class AccountFormFragment extends Fragment {
             setParentAccountSelection(mAccountsDbAdapter.getID(mParentAccountUID));
         }
 
-    }
-
-    /**
-     * Initializes the preview of the color picker (color square) to the specified color
-     * @param colorHex Color of the format #rgb or #rrggbb
-     */
-    private void initializeColorSquarePreview(String colorHex){
-        if (colorHex != null)
-            mColorSquare.setBackgroundColor(Color.parseColor(colorHex));
-        else
-            mColorSquare.setBackgroundColor(Color.LTGRAY);
     }
 
     /**
@@ -549,10 +535,7 @@ public class AccountFormFragment extends Fragment {
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         int currentColor = Color.LTGRAY;
         if (mAccount != null){
-            String accountColor = mAccount.getColorHexCode();
-            if (accountColor != null){
-                currentColor = Color.parseColor(accountColor);
-            }
+            currentColor = Color.parseColor(mAccount.getColorHexCode());
         }
 
         ColorPickerDialog colorPickerDialogFragment = ColorPickerDialog.newInstance(

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -203,7 +203,7 @@ public class AccountFormFragment extends Fragment {
      */
     private boolean mUseDoubleEntry;
 
-    private String mSelectedColor = Account.DEFAULT_COLOR;
+    private int mSelectedColor = Account.DEFAULT_COLOR;
 
     /**
      * Trigger for color picker dialog
@@ -214,7 +214,7 @@ public class AccountFormFragment extends Fragment {
         @Override
         public void onColorSelected(int color) {
             mColorSquare.setBackgroundColor(color);
-            mSelectedColor = String.format("#%06X", (0xFFFFFF & color));
+            mSelectedColor = color;
         }
     };
 
@@ -414,7 +414,7 @@ public class AccountFormFragment extends Fragment {
         }
 
         mPlaceholderCheckBox.setChecked(account.isPlaceholderAccount());
-        mColorSquare.setBackgroundColor(Color.parseColor(account.getColorHexCode()));
+        mColorSquare.setBackgroundColor(account.getColor());
 
         setAccountTypeSelection(account.getAccountType());
     }
@@ -535,7 +535,7 @@ public class AccountFormFragment extends Fragment {
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         int currentColor = Color.LTGRAY;
         if (mAccount != null){
-            currentColor = Color.parseColor(mAccount.getColorHexCode());
+            currentColor = mAccount.getColor();
         }
 
         ColorPickerDialog colorPickerDialogFragment = ColorPickerDialog.newInstance(
@@ -757,7 +757,7 @@ public class AccountFormFragment extends Fragment {
 
         mAccount.setDescription(mDescriptionEditText.getText().toString());
         mAccount.setPlaceHolderFlag(mPlaceholderCheckBox.isChecked());
-        mAccount.setColorCode(mSelectedColor);
+        mAccount.setColor(mSelectedColor);
 
         long newParentAccountId;
         String newParentAccountUID;

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -395,9 +395,7 @@ public class AccountFormFragment extends Fragment {
 
         mNameEditText.setText(account.getName());
         mNameEditText.setSelection(mNameEditText.getText().length());
-
-        if (account.getDescription() != null)
-            mDescriptionEditText.setText(account.getDescription());
+        mDescriptionEditText.setText(account.getDescription());
 
         if (mUseDoubleEntry) {
             if (account.getDefaultTransferAccountUID() != null) {

--- a/app/src/main/java/org/gnucash/android/ui/report/BarChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/BarChartFragment.java
@@ -229,7 +229,7 @@ public class BarChartFragment extends Fragment implements OnChartValueSelectedLi
                         if (!accountToColorMap.containsKey(account.getUID())) {
                             Integer color;
                             if (mUseAccountColor) {
-                                color = Color.parseColor(account.getColorHexCode());
+                                color = account.getColor();
                             } else {
                                 color = COLORS[accountToColorMap.size() % COLORS.length];
                             }

--- a/app/src/main/java/org/gnucash/android/ui/report/BarChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/BarChartFragment.java
@@ -229,9 +229,7 @@ public class BarChartFragment extends Fragment implements OnChartValueSelectedLi
                         if (!accountToColorMap.containsKey(account.getUID())) {
                             Integer color;
                             if (mUseAccountColor) {
-                                color = (account.getColorHexCode() != null)
-                                        ? Color.parseColor(account.getColorHexCode())
-                                        : COLORS[accountToColorMap.size() % COLORS.length];
+                                color = Color.parseColor(account.getColorHexCode());
                             } else {
                                 color = COLORS[accountToColorMap.size() % COLORS.length];
                             }

--- a/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
@@ -200,7 +200,7 @@ public class PieChartFragment extends Fragment implements OnChartValueSelectedLi
                 if (balance > 0) {
                     dataSet.addEntry(new Entry((float) balance, dataSet.getEntryCount()));
                     colors.add(mUseAccountColor
-                            ? Color.parseColor(account.getColorHexCode())
+                            ? account.getColor()
                             : ReportsActivity.COLORS[(dataSet.getEntryCount() - 1) % ReportsActivity.COLORS.length]);
                     labels.add(account.getName());
                 }

--- a/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
@@ -199,7 +199,7 @@ public class PieChartFragment extends Fragment implements OnChartValueSelectedLi
                         mReportStartTime, mReportEndTime).asDouble();
                 if (balance > 0) {
                     dataSet.addEntry(new Entry((float) balance, dataSet.getEntryCount()));
-                    colors.add(mUseAccountColor && account.getColorHexCode() != null
+                    colors.add(mUseAccountColor
                             ? Color.parseColor(account.getColorHexCode())
                             : ReportsActivity.COLORS[(dataSet.getEntryCount() - 1) % ReportsActivity.COLORS.length]);
                     labels.add(account.getName());

--- a/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/PieChartFragment.java
@@ -85,7 +85,6 @@ public class PieChartFragment extends Fragment implements OnChartValueSelectedLi
     @Bind(R.id.selected_chart_slice) TextView mSelectedValueTextView;
 
     private AccountsDbAdapter mAccountsDbAdapter;
-    private TransactionsDbAdapter mTransactionsDbAdapter;
 
     private AccountType mAccountType;
 
@@ -127,7 +126,6 @@ public class PieChartFragment extends Fragment implements OnChartValueSelectedLi
                 .getBoolean(getString(R.string.key_use_account_color), false);
 
         mAccountsDbAdapter = AccountsDbAdapter.getInstance();
-        mTransactionsDbAdapter = TransactionsDbAdapter.getInstance();
 
         mCurrencyCode = GnuCashApplication.getDefaultCurrencyCode();
 

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportSummaryFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportSummaryFragment.java
@@ -16,7 +16,6 @@
 package org.gnucash.android.ui.report;
 
 import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -200,7 +199,7 @@ public class ReportSummaryFragment extends Fragment {
                         Collections.singletonList(account.getUID()), start, end).asDouble();
                 if (balance > 0) {
                     dataSet.addEntry(new Entry((float) balance, dataSet.getEntryCount()));
-                    colors.add(Color.parseColor(account.getColorHexCode()));
+                    colors.add(account.getColor());
                     labels.add(account.getName());
                 }
             }

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportSummaryFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportSummaryFragment.java
@@ -200,9 +200,7 @@ public class ReportSummaryFragment extends Fragment {
                         Collections.singletonList(account.getUID()), start, end).asDouble();
                 if (balance > 0) {
                     dataSet.addEntry(new Entry((float) balance, dataSet.getEntryCount()));
-                    colors.add(account.getColorHexCode() != null
-                            ? Color.parseColor(account.getColorHexCode())
-                            : ReportsActivity.COLORS[(dataSet.getEntryCount() - 1) % ReportsActivity.COLORS.length]);
+                    colors.add(Color.parseColor(account.getColorHexCode()));
                     labels.add(account.getName());
                 }
             }

--- a/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
@@ -105,8 +105,9 @@ public class AccountTest{
 	}
 
 	@Test
-	public void newInstance_shouldHaveNonNullDescription() {
+	public void newInstance_shouldReturnNonNullValues() {
 		Account account = new Account("Test account");
 		assertThat(account.getDescription()).isEqualTo("");
+		assertThat(account.getColorHexCode()).isEqualTo(Account.DEFAULT_COLOR);
 	}
 }

--- a/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
@@ -15,6 +15,8 @@
  */
 package org.gnucash.android.test.unit.model;
 
+import android.graphics.Color;
+
 import org.gnucash.android.BuildConfig;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Commodity;
@@ -66,7 +68,13 @@ public class AccountTest{
 	@Test(expected = IllegalArgumentException.class)
 	public void testSetInvalidColorCode(){
 		Account account = new Account("Test");
-		account.setColorCode("443859");
+		account.setColor("443859");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetColorWithAlphaComponent(){
+		Account account = new Account("Test");
+		account.setColor(Color.parseColor("#aa112233"));
 	}
 
 	@Test
@@ -108,6 +116,6 @@ public class AccountTest{
 	public void newInstance_shouldReturnNonNullValues() {
 		Account account = new Account("Test account");
 		assertThat(account.getDescription()).isEqualTo("");
-		assertThat(account.getColorHexCode()).isEqualTo(Account.DEFAULT_COLOR);
+		assertThat(account.getColor()).isEqualTo(Account.DEFAULT_COLOR);
 	}
 }

--- a/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/AccountTest.java
@@ -103,4 +103,10 @@ public class AccountTest{
 		assertThat(account.getCommodity()).isEqualTo(Commodity.EUR);
 		assertThat(account.getCurrency()).isEqualTo(Currency.getInstance("USD"));
 	}
+
+	@Test
+	public void newInstance_shouldHaveNonNullDescription() {
+		Account account = new Account("Test account");
+		assertThat(account.getDescription()).isEqualTo("");
+	}
 }


### PR DESCRIPTION
I've applied the idea of the [Null object pattern](https://en.wikipedia.org/wiki/Null_Object_pattern) to some methods of Account. It simplifies the code of its clients by not having to check for null values.

If it's ok, I plan to send more small pull requests like this one, trying to simplify the code little by little. This would make the code easier to understand, as sometimes I have difficulties due to the many conditionals.