### PR TITLE
Fix saving state in AccountsListFragment

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -105,6 +105,11 @@ public class AccountsListFragment extends Fragment implements
      */
     protected static final String TAG = "AccountsListFragment";
 
+	/**
+	 * Tag to save {@link AccountsListFragment#mDisplayMode} to fragment state
+     */
+    private static final String STATE_DISPLAY_MODE = "mDisplayMode";
+
     /**
      * Database adapter for loading Account records from the database
      */
@@ -176,6 +181,9 @@ public class AccountsListFragment extends Fragment implements
         Bundle args = getArguments();
         if (args != null)
             mParentAccountUID = args.getString(UxArgument.PARENT_ACCOUNT_UID);
+
+        if (savedInstanceState != null)
+            mDisplayMode = (DisplayMode) savedInstanceState.getSerializable(STATE_DISPLAY_MODE);
     }
 
     @Override
@@ -293,6 +301,12 @@ public class AccountsListFragment extends Fragment implements
     @Override
     public void refresh() {
         getLoaderManager().restartLoader(0, null, this);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putSerializable(STATE_DISPLAY_MODE, mDisplayMode);
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -105,8 +105,8 @@ public class AccountsListFragment extends Fragment implements
      */
     protected static final String TAG = "AccountsListFragment";
 
-	/**
-	 * Tag to save {@link AccountsListFragment#mDisplayMode} to fragment state
+    /**
+     * Tag to save {@link AccountsListFragment#mDisplayMode} to fragment state
      */
     private static final String STATE_DISPLAY_MODE = "mDisplayMode";
 


### PR DESCRIPTION
AccountsListFragment didn't save it state that caused to displaying identical fragments in ViewPager.

Steps to reproduce:
- open homescreen (AccountsActivity);
- check ViewPager fragments;
- rotate device;
- check ViewPager fragments, they all will have mDisplayMode with value TOP_LEVEL.

![device-2016-04-11-231446](https://cloud.githubusercontent.com/assets/1074496/14442662/aa01946c-0043-11e6-9b74-869293a5cad4.png)
