### PR TITLE
Avoid Price.toString() failing for certain values of numerator/denominator.

### DIFF
--- a/app/src/main/java/org/gnucash/android/model/Price.java
+++ b/app/src/main/java/org/gnucash/android/model/Price.java
@@ -4,6 +4,7 @@ import org.gnucash.android.util.TimestampHelper;
 
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.sql.Timestamp;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -156,6 +157,6 @@ public class Price extends BaseModel {
         BigDecimal denominator = new BigDecimal(mValueDenom);
         DecimalFormat formatter = (DecimalFormat) NumberFormat.getNumberInstance();
         formatter.setMaximumFractionDigits(6);
-        return formatter.format(numerator.divide(denominator));
+        return formatter.format(numerator.divide(denominator, MathContext.DECIMAL32));
     }
 }

--- a/app/src/test/java/org/gnucash/android/test/unit/model/PriceTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/PriceTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 
 public class PriceTest {
@@ -50,6 +51,26 @@ public class PriceTest {
         BigDecimal exchangeRate = new BigDecimal(exchangeRateString);
         Price price = new Price("commodity1UID", "commodity2UID", exchangeRate);
         assertThat(price.toString()).isEqualTo("1,234");
+    }
+
+    /**
+     * BigDecimal throws an ArithmeticException if it can't represent exactly
+     * a result. This can happen with divisions like 1/3 if no precision and
+     * round mode is specified with a MathContext.
+     */
+    @Test
+    public void toString_shouldNotFailForInfinitelyLongDecimalExpansion() {
+        long numerator = 1;
+        long denominator = 3;
+        Price price = new Price();
+
+        price.setValueNum(numerator);
+        price.setValueDenom(denominator);
+        try {
+            price.toString();
+        } catch (ArithmeticException e) {
+            fail("The numerator/denominator division in Price.toString() should not fail.");
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes a regression introduced in 66cc533 (bugfix #479) in which the numerator/denominator division fails with an `ArithmeticException` if no `MathContext` is provided. Somehow I missed it when moving code around.

Fixes Crashlitics issue [#196](https://fabric.io/gnucash/android/apps/org.gnucash.android/issues/571b4a95ffcdc04250f98ba03)
