### PR TITLE
Enable remote debugging from Chrome developer tools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -228,6 +228,8 @@ dependencies {
         transitive = true;
     }
 
+    compile 'com.facebook.stetho:stetho:1.3.1'
+
     testCompile('org.robolectric:robolectric:3.1',
             'junit:junit:4.12',
             'joda-time:joda-time:2.7',

--- a/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
@@ -120,16 +120,7 @@ public class GnuCashApplication extends Application{
                 new CrashlyticsCore.Builder().disabled(!isCrashlyticsEnabled()).build())
                 .build());
 
-        // Set this up once when your application launches
-        Config config = new Config("gnucash.uservoice.com");
-        config.setTopicId(107400);
-        config.setForumId(320493);
-        config.putUserTrait("app_version_name", BuildConfig.VERSION_NAME);
-        config.putUserTrait("app_version_code", BuildConfig.VERSION_CODE);
-        config.putUserTrait("android_version", Build.VERSION.RELEASE);
-        // config.identifyUser("USER_ID", "User Name", "email@example.com");
-        UserVoice.init(config, this);
-
+        setUpUserVoice();
 
         BookDbHelper bookDbHelper = new BookDbHelper(getApplicationContext());
         mBooksDbAdapter = new BooksDbAdapter(bookDbHelper.getWritableDatabase());
@@ -350,6 +341,23 @@ public class GnuCashApplication extends Application{
                 pendingIntent);
 
         context.startService(alarmIntent); //run the service the first time
+    }
+
+    /**
+     * Sets up UserVoice.
+     *
+     * <p>Allows users to contact with us and access help topics.</p>
+     */
+    private void setUpUserVoice() {
+        // Set this up once when your application launches
+        Config config = new Config("gnucash.uservoice.com");
+        config.setTopicId(107400);
+        config.setForumId(320493);
+        config.putUserTrait("app_version_name", BuildConfig.VERSION_NAME);
+        config.putUserTrait("app_version_code", BuildConfig.VERSION_CODE);
+        config.putUserTrait("android_version", Build.VERSION.RELEASE);
+        // config.identifyUser("USER_ID", "User Name", "email@example.com");
+        UserVoice.init(config, this);
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
@@ -31,6 +31,7 @@ import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
+import com.facebook.stetho.Stetho;
 import com.uservoice.uservoicesdk.Config;
 import com.uservoice.uservoicesdk.UserVoice;
 
@@ -138,6 +139,9 @@ public class GnuCashApplication extends Application{
         //TODO: migrate preferences from defaultShared to book
 
         setDefaultCurrencyCode(getDefaultCurrencyCode());
+
+        if (BuildConfig.DEBUG)
+            setUpRemoteDebuggingFromChrome();
     }
 
     /**
@@ -346,5 +350,20 @@ public class GnuCashApplication extends Application{
                 pendingIntent);
 
         context.startService(alarmIntent); //run the service the first time
+    }
+
+    /**
+     * Sets up Stetho to enable remote debugging from Chrome developer tools.
+     *
+     * <p>Among other things, allows access to the database and preferences.
+     * See http://facebook.github.io/stetho/#features</p>
+     */
+    private void setUpRemoteDebuggingFromChrome() {
+        Stetho.Initializer initializer =
+                Stetho.newInitializerBuilder(this)
+                        .enableWebKitInspector(
+                                Stetho.defaultInspectorModulesProvider(this))
+                        .build();
+        Stetho.initialize(initializer);
     }
 }


### PR DESCRIPTION
Adds [Stetho](http://facebook.github.io/), a debug bridge that, among other things, allows to access the database and preferences of the application through Chrome developer tools.

The database access is especially useful. It allows to browse the tables and send SQL queries.

To make it simple, I've included the library in all builds, although at runtime it's only enabled for debug builds. If you find it useful and want it to be included only for debug builds, I can set it up with a separate debug Application like explained [here](http://stackoverflow.com/a/30172663).