### PR TITLE
Bugfix 526: Opening a scheduled transaction to view causes app to crash

### DIFF
--- a/app/src/main/java/org/gnucash/android/model/Recurrence.java
+++ b/app/src/main/java/org/gnucash/android/model/Recurrence.java
@@ -263,6 +263,9 @@ public class Recurrence extends BaseModel {
      * @return Number of occurrences, or -1 if there is no end date
      */
     public int getCount(){
+        if (mPeriodEnd == null)
+            return -1;
+
         int count = 0;
         LocalDate startDate = new LocalDate(mPeriodStart.getTime());
         LocalDate endDate = new LocalDate(mPeriodEnd.getTime());

--- a/app/src/test/java/org/gnucash/android/test/unit/model/RecurrenceTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/RecurrenceTest.java
@@ -58,4 +58,19 @@ public class RecurrenceTest {
 
         assertThat(recurrence.getCount()).isEqualTo(10);
     }
+
+    /**
+     * When no end period is set, getCount() should return the special value -1.
+     *
+     * <p>Tests for bug https://github.com/codinguser/gnucash-android/issues/526</p>
+     */
+    @Test
+    public void notSettingEndDate_shouldReturnSpecialCountValue() {
+        Recurrence recurrence = new Recurrence(PeriodType.MONTH);
+        Calendar cal = Calendar.getInstance();
+        cal.set(2015, Calendar.OCTOBER, 5);
+        recurrence.setPeriodStart(new Timestamp(cal.getTimeInMillis()));
+
+        assertThat(recurrence.getCount()).isEqualTo(-1);
+    }
 }


### PR DESCRIPTION
Fixes #526 

I haven't implemented going through `TransactionDetailFragment` first yet. I've found some bugs in the way that I'd like to fix first.

By the way, I've noticed the start and end periods are stored both in `scheduled_actions` and `recurrences` tables. Is this duplicated for convenience or should we remove one of them?