### PR TITLE
Bugfix 528: When using "XXX no currency" the accounts balances aren't calculated

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/SplitsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/SplitsDbAdapter.java
@@ -220,8 +220,7 @@ public class SplitsDbAdapter extends DatabaseAdapter<Split> {
                 long amount_denom = cursor.getLong(1);
                 String commodityCode = cursor.getString(2);
                 //Log.d(getClass().getName(), commodity + " " + amount_num + "/" + amount_denom);
-                if (commodityCode.equals("XXX") || amount_num == 0) {
-                    // ignore custom currency
+                if (amount_num == 0) {
                     continue;
                 }
                 if (!hasDebitNormalBalance) {


### PR DESCRIPTION
This fixes #528, however, it does so by removing an explicit check to not calculate the balance for this currency. There was no explanation in the code nor in the commit message. Also, I can't think of any reason to exclude this currency. Any idea @codinguser?

The check was added in ff7f8c0. @fefe982, if you could shed some light on this, it would be highly appreciated :)
