### PR TITLE
Bugfix 577: Can't save transactions on single entry mode

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -938,8 +938,9 @@ public class TransactionFormFragment extends Fragment implements
      * @return {@code true} if the transaction can be saved, {@code false} otherwise
      */
     private boolean canSave(){
-        return (mAmountEditText.isInputValid())
-                && (mUseDoubleEntry && mTransferAccountSpinner.getCount() > 0);
+        return (mUseDoubleEntry && mAmountEditText.isInputValid()
+                                && mTransferAccountSpinner.getCount() > 0)
+               || (!mUseDoubleEntry && mAmountEditText.isInputValid());
     }
 
     /**


### PR DESCRIPTION
Introduced in 96a2045. I guess you meant this condition instead.

I haven't added a tests as, apart from not being able to run them on my phone yet, I'd say `TransactionsActivityTest.testAutoBalanceTransactions` should fail.