### PR TITLE
Bugfix 583:   Scheduled exports are always executed twice a day

### DIFF
--- a/app/src/main/java/org/gnucash/android/service/ScheduledActionService.java
+++ b/app/src/main/java/org/gnucash/android/service/ScheduledActionService.java
@@ -164,6 +164,9 @@ public class ScheduledActionService extends IntentService {
         if (endTime > 0 && endTime < now)
             return executionCount;
 
+        if (scheduledAction.computeNextScheduledExecutionTime() > now)
+            return 0;
+
         ExportParams params = ExportParams.parseCsv(scheduledAction.getTag());
         try {
             //wait for async task to finish before we proceed (we are holding a wake lock)


### PR DESCRIPTION
Fixes #583.