### PR TITLE
Fix widgets with negative values being green

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
@@ -175,7 +175,7 @@ public class WidgetConfigurationActivity extends Activity {
 
 		views.setTextViewText(R.id.transactions_summary,
 				accountBalance.formattedString(Locale.getDefault()));
-		int color = account.getBalance().isNegative() ? R.color.debit_red : R.color.credit_green;
+		int color = accountBalance.isNegative() ? R.color.debit_red : R.color.credit_green;
 		views.setTextColor(R.id.transactions_summary, context.getResources().getColor(color));
 
 


### PR DESCRIPTION
The number used to calculate whether a widget is red or green should be the same value as the one that is displayed. It was instead calling a (buggy) method which calculated a different balance to the one displayed. This patch fixes it to determine the colour using the same value as the one it is displaying.

This should fix issue #184.