### PR TITLE
Move mutable field PeriodType.mMultiplier to Recurrence.

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
@@ -42,7 +42,6 @@ import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.BaseModel;
 import org.gnucash.android.model.Commodity;
 import org.gnucash.android.model.Money;
-import org.gnucash.android.model.PeriodType;
 import org.gnucash.android.model.Recurrence;
 import org.gnucash.android.model.ScheduledAction;
 import org.gnucash.android.model.Transaction;
@@ -1360,13 +1359,12 @@ public class MigrationHelper {
                 String uid = cursor.getString(cursor.getColumnIndexOrThrow(ScheduledActionEntry.COLUMN_UID));
                 long period = cursor.getLong(cursor.getColumnIndexOrThrow("period"));
                 long startTime = cursor.getLong(cursor.getColumnIndexOrThrow(ScheduledActionEntry.COLUMN_START_TIME));
-                PeriodType periodType = PeriodType.parse(period);
-                Recurrence recurrence = new Recurrence(periodType);
+                Recurrence recurrence = Recurrence.fromLegacyPeriod(period);
                 recurrence.setPeriodStart(new Timestamp(startTime));
 
                 contentValues.clear();
                 contentValues.put(RecurrenceEntry.COLUMN_UID, recurrence.getUID());
-                contentValues.put(RecurrenceEntry.COLUMN_MULTIPLIER, recurrence.getPeriodType().getMultiplier());
+                contentValues.put(RecurrenceEntry.COLUMN_MULTIPLIER, recurrence.getMultiplier());
                 contentValues.put(RecurrenceEntry.COLUMN_PERIOD_TYPE, recurrence.getPeriodType().name());
                 contentValues.put(RecurrenceEntry.COLUMN_PERIOD_START, recurrence.getPeriodStart().toString());
                 db.insert(RecurrenceEntry.TABLE_NAME, null, contentValues);

--- a/app/src/main/java/org/gnucash/android/db/adapter/RecurrenceDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/RecurrenceDbAdapter.java
@@ -61,9 +61,9 @@ public class RecurrenceDbAdapter extends DatabaseAdapter<Recurrence> {
         String byDay = cursor.getString(cursor.getColumnIndexOrThrow(RecurrenceEntry.COLUMN_BYDAY));
 
         PeriodType periodType = PeriodType.valueOf(type);
-        periodType.setMultiplier((int) multiplier);
 
         Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier((int) multiplier);
         recurrence.setPeriodStart(Timestamp.valueOf(periodStart));
         if (periodEnd != null)
             recurrence.setPeriodEnd(Timestamp.valueOf(periodEnd));
@@ -77,7 +77,7 @@ public class RecurrenceDbAdapter extends DatabaseAdapter<Recurrence> {
     @Override
     protected @NonNull SQLiteStatement setBindings(@NonNull SQLiteStatement stmt, @NonNull final Recurrence recurrence) {
         stmt.clearBindings();
-        stmt.bindLong(1, recurrence.getPeriodType().getMultiplier());
+        stmt.bindLong(1, recurrence.getMultiplier());
         stmt.bindString(2, recurrence.getPeriodType().name());
         if (recurrence.getByDay() != null)
             stmt.bindString(3, recurrence.getByDay());

--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -23,10 +23,9 @@ import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 
-import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.BooksDbAdapter;
 import org.gnucash.android.db.adapter.CommoditiesDbAdapter;
-import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.RecurrenceDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
 import org.gnucash.android.export.ExportFormat;
@@ -36,9 +35,9 @@ import org.gnucash.android.model.Account;
 import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.BaseModel;
 import org.gnucash.android.model.Book;
-import org.gnucash.android.model.Commodity;
 import org.gnucash.android.model.Budget;
 import org.gnucash.android.model.BudgetAmount;
+import org.gnucash.android.model.Commodity;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.model.PeriodType;
 import org.gnucash.android.model.Recurrence;
@@ -49,7 +48,6 @@ import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -704,7 +702,7 @@ public class GncXmlExporter extends Exporter{
     private void exportRecurrence(XmlSerializer xmlSerializer, Recurrence recurrence) throws IOException{
         PeriodType periodType = recurrence.getPeriodType();
         xmlSerializer.startTag(null, GncXmlHelper.TAG_RX_MULT);
-        xmlSerializer.text(String.valueOf(periodType.getMultiplier()));
+        xmlSerializer.text(String.valueOf(recurrence.getMultiplier()));
         xmlSerializer.endTag(null, GncXmlHelper.TAG_RX_MULT);
         xmlSerializer.startTag(null, GncXmlHelper.TAG_RX_PERIOD_TYPE);
         xmlSerializer.text(periodType.name().toLowerCase());

--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -737,8 +737,8 @@ public class GncXmlHandler extends DefaultHandler {
             case GncXmlHelper.TAG_RX_PERIOD_TYPE:
                 try {
                     PeriodType periodType = PeriodType.valueOf(characterString.toUpperCase());
-                    periodType.setMultiplier(mRecurrenceMultiplier);
                     mRecurrence.setPeriodType(periodType);
+                    mRecurrence.setMultiplier(mRecurrenceMultiplier);
                 } catch (IllegalArgumentException ex){ //the period type constant is not supported
                     String msg = "Unsupported period constant: " + characterString;
                     Log.e(LOG_TAG, msg);

--- a/app/src/main/java/org/gnucash/android/model/Budget.java
+++ b/app/src/main/java/org/gnucash/android/model/Budget.java
@@ -202,7 +202,7 @@ public class Budget extends BaseModel {
      */
     public long getStartofCurrentPeriod(){
         LocalDateTime localDate = new LocalDateTime();
-        int interval = mRecurrence.getPeriodType().getMultiplier();
+        int interval = mRecurrence.getMultiplier();
         switch (mRecurrence.getPeriodType()){
             case DAY:
                 localDate = localDate.millisOfDay().withMinimumValue().plusDays(interval);
@@ -226,7 +226,7 @@ public class Budget extends BaseModel {
      */
     public long getEndOfCurrentPeriod(){
         LocalDateTime localDate = new LocalDateTime();
-        int interval = mRecurrence.getPeriodType().getMultiplier();
+        int interval = mRecurrence.getMultiplier();
         switch (mRecurrence.getPeriodType()){
             case DAY:
                 localDate = localDate.millisOfDay().withMaximumValue().plusDays(interval);
@@ -246,7 +246,7 @@ public class Budget extends BaseModel {
 
     public long getStartOfPeriod(int periodNum){
         LocalDateTime localDate = new LocalDateTime(mRecurrence.getPeriodStart().getTime());
-        int interval = mRecurrence.getPeriodType().getMultiplier() * periodNum;
+        int interval = mRecurrence.getMultiplier() * periodNum;
         switch (mRecurrence.getPeriodType()){
             case DAY:
                 localDate = localDate.millisOfDay().withMinimumValue().plusDays(interval);
@@ -271,7 +271,7 @@ public class Budget extends BaseModel {
      */
     public long getEndOfPeriod(int periodNum){
         LocalDateTime localDate = new LocalDateTime();
-        int interval = mRecurrence.getPeriodType().getMultiplier() * periodNum;
+        int interval = mRecurrence.getMultiplier() * periodNum;
         switch (mRecurrence.getPeriodType()){
             case DAY:
                 localDate = localDate.millisOfDay().withMaximumValue().plusDays(interval);

--- a/app/src/main/java/org/gnucash/android/model/PeriodType.java
+++ b/app/src/main/java/org/gnucash/android/model/PeriodType.java
@@ -16,12 +16,6 @@
 
 package org.gnucash.android.model;
 
-import android.content.res.Resources;
-
-import org.gnucash.android.R;
-import org.gnucash.android.app.GnuCashApplication;
-import org.gnucash.android.ui.util.RecurrenceParser;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -34,63 +28,6 @@ import java.util.Locale;
 public enum PeriodType {
     DAY, WEEK, MONTH, YEAR; // TODO: 22.10.2015 add support for hourly
 
-    int mMultiplier = 1; //multiplier for the period type
-
-    /**
-     * Computes the {@link PeriodType} for a given {@code period}
-     * @param period Period in milliseconds since Epoch
-     * @return PeriodType corresponding to the period
-     */
-    public static PeriodType parse(long period){
-        PeriodType periodType = DAY;
-        int result = (int) (period/ RecurrenceParser.YEAR_MILLIS);
-        if (result > 0) {
-            periodType = YEAR;
-            periodType.setMultiplier(result);
-            return periodType;
-        }
-
-        result = (int) (period/RecurrenceParser.MONTH_MILLIS);
-        if (result > 0) {
-            periodType = MONTH;
-            periodType.setMultiplier(result);
-            return periodType;
-        }
-
-        result = (int) (period/RecurrenceParser.WEEK_MILLIS);
-        if (result > 0) {
-            periodType = WEEK;
-            periodType.setMultiplier(result);
-            return periodType;
-        }
-
-        result = (int) (period/RecurrenceParser.DAY_MILLIS);
-        if (result > 0) {
-            periodType = DAY;
-            periodType.setMultiplier(result);
-            return periodType;
-        }
-
-        return periodType;
-    }
-
-    /**
-     * Sets the multiplier for this period type
-     * e.g. bi-weekly actions have period type {@link PeriodType#WEEK} and multiplier 2
-     * @param multiplier Multiplier for this period type
-     */
-    public void setMultiplier(int multiplier){
-        mMultiplier = multiplier;
-    }
-
-    /**
-     * Returns the multiplier for this period type. The default multiplier is 1.
-     * e.g. bi-weekly actions have period type {@link PeriodType#WEEK} and multiplier 2
-     * @return  Multiplier for this period type
-     */
-    public int getMultiplier(){
-        return mMultiplier;
-    }
 
     /**
      * Returns the frequency description of this period type.
@@ -107,27 +44,6 @@ public enum PeriodType {
                 return "MONTHLY";
             case YEAR:
                 return "YEARLY";
-            default:
-                return "";
-        }
-    }
-
-    /**
-     * Returns a localized string describing this period type's frequency.
-     * @return String describing period type
-     */
-    public String getFrequencyRepeatString(){
-        Resources res = GnuCashApplication.getAppContext().getResources();
-        //todo: take multiplier into account here
-        switch (this) {
-            case DAY:
-                return res.getQuantityString(R.plurals.label_every_x_days, mMultiplier, mMultiplier);
-            case WEEK:
-                return res.getQuantityString(R.plurals.label_every_x_weeks, mMultiplier, mMultiplier);
-            case MONTH:
-                return res.getQuantityString(R.plurals.label_every_x_months, mMultiplier, mMultiplier);
-            case YEAR:
-                return res.getQuantityString(R.plurals.label_every_x_years, mMultiplier, mMultiplier);
             default:
                 return "";
         }
@@ -155,6 +71,4 @@ public enum PeriodType {
         }
         return partString;
     }
-
-
 }

--- a/app/src/main/java/org/gnucash/android/model/ScheduledAction.java
+++ b/app/src/main/java/org/gnucash/android/model/ScheduledAction.java
@@ -20,12 +20,9 @@ import android.support.annotation.NonNull;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 
 import java.sql.Timestamp;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -151,7 +148,7 @@ public class ScheduledAction extends BaseModel{
             return  -1;
 
         LocalDateTime startTime = LocalDateTime.fromDateFields(new Date(mStartDate));
-        int multiplier = mRecurrence.getPeriodType().getMultiplier();
+        int multiplier = mRecurrence.getMultiplier();
 
         int factor = (mExecutionCount-1) * multiplier;
         switch (mRecurrence.getPeriodType()){
@@ -179,7 +176,7 @@ public class ScheduledAction extends BaseModel{
      * @return Next run time in milliseconds
      */
     public long computeNextScheduledExecutionTime(){
-        int multiplier = mRecurrence.getPeriodType().getMultiplier();
+        int multiplier = mRecurrence.getMultiplier();
         //this is the last planned time for the action to occur, not the last run time
         long lastActionTime = getTimeOfLastSchedule(); //mStartDate + ((mExecutionCount-1)*getPeriod());
         if (lastActionTime < 0){
@@ -472,8 +469,8 @@ public class ScheduledAction extends BaseModel{
      * @see #setRecurrence(Recurrence)
      */
     public void setRecurrence(PeriodType periodType, int ordinal){
-        periodType.setMultiplier(ordinal);
         Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier(ordinal);
         setRecurrence(recurrence);
     }
 
@@ -510,7 +507,7 @@ public class ScheduledAction extends BaseModel{
     public static ScheduledAction parseScheduledAction(Transaction transaction, long period){
         ScheduledAction scheduledAction = new ScheduledAction(ActionType.TRANSACTION);
         scheduledAction.mActionUID = transaction.getUID();
-        Recurrence recurrence = new Recurrence(PeriodType.parse(period));
+        Recurrence recurrence = Recurrence.fromLegacyPeriod(period);
         scheduledAction.setRecurrence(recurrence);
         return scheduledAction;
     }

--- a/app/src/main/java/org/gnucash/android/ui/util/RecurrenceParser.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/RecurrenceParser.java
@@ -73,8 +73,8 @@ public class RecurrenceParser {
         }
 
         int interval = eventRecurrence.interval == 0 ? 1 : eventRecurrence.interval; //bug from betterpickers library sometimes returns 0 as the interval
-        periodType.setMultiplier(interval);
         Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier(interval);
         parseEndTime(eventRecurrence, recurrence);
         recurrence.setByDay(parseByDay(eventRecurrence.byday));
         if (eventRecurrence.startDate != null)

--- a/app/src/test/java/org/gnucash/android/test/unit/db/ScheduledActionDbAdapterTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/db/ScheduledActionDbAdapterTest.java
@@ -65,8 +65,9 @@ public class ScheduledActionDbAdapterTest {
     public void testGenerateRepeatString(){
         ScheduledAction scheduledAction = new ScheduledAction(ScheduledAction.ActionType.TRANSACTION);
         PeriodType periodType = PeriodType.MONTH;
-        periodType.setMultiplier(2);
-        scheduledAction.setRecurrence(new Recurrence(periodType));
+        Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier(2);
+        scheduledAction.setRecurrence(recurrence);
         scheduledAction.setTotalPlannedExecutionCount(4);
         Resources res = GnuCashApplication.getAppContext().getResources();
         String repeatString = res.getQuantityString(R.plurals.label_every_x_months, 2, 2) + ", " +

--- a/app/src/test/java/org/gnucash/android/test/unit/model/RecurrenceTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/RecurrenceTest.java
@@ -61,8 +61,8 @@ public class RecurrenceTest {
         DateTime startTime = new DateTime(2016, 6, 6, 9, 0);
         DateTime endTime = new DateTime(2016, 8, 29, 10, 0);
         PeriodType biWeekly = PeriodType.WEEK;
-        biWeekly.setMultiplier(2);
         recurrence = new Recurrence(biWeekly);
+        recurrence.setMultiplier(2);
         recurrence.setPeriodStart(new Timestamp(startTime.getMillis()));
         recurrence.setPeriodEnd(new Timestamp(endTime.getMillis()));
 

--- a/app/src/test/java/org/gnucash/android/test/unit/model/ScheduledActionTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/ScheduledActionTest.java
@@ -98,9 +98,9 @@ public class ScheduledActionTest {
     public void testComputingNextScheduledExecution(){
         ScheduledAction scheduledAction = new ScheduledAction(ScheduledAction.ActionType.TRANSACTION);
         PeriodType periodType = PeriodType.MONTH;
-        periodType.setMultiplier(2);
 
         Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier(2);
         DateTime startDate = new DateTime(2015, 8, 15, 12, 0);
         recurrence.setPeriodStart(new Timestamp(startDate.getMillis()));
         scheduledAction.setRecurrence(recurrence);
@@ -116,8 +116,8 @@ public class ScheduledActionTest {
     public void testComputingTimeOfLastSchedule(){
         ScheduledAction scheduledAction = new ScheduledAction(ScheduledAction.ActionType.TRANSACTION);
         PeriodType periodType = PeriodType.WEEK;
-        periodType.setMultiplier(2);
         Recurrence recurrence = new Recurrence(periodType);
+        recurrence.setMultiplier(2);
         scheduledAction.setRecurrence(recurrence);
         DateTime startDate = new DateTime(2016, 6, 6, 9, 0);
         scheduledAction.setStartTime(startDate.getMillis());


### PR DESCRIPTION
PeriodType enum values should be immutable. The instances are shared so,
once a value is got, it shouldn't be possible to set its fields.

This was causing some tests to fail, as they were getting the same
instance but setting different values for the field.