### PR TITLE
Make widgets able to hide the account balance

### DIFF
--- a/app/src/main/java/org/gnucash/android/receivers/TransactionAppWidgetProvider.java
+++ b/app/src/main/java/org/gnucash/android/receivers/TransactionAppWidgetProvider.java
@@ -18,6 +18,7 @@ package org.gnucash.android.receivers;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.preference.PreferenceManager;
 
@@ -42,14 +43,15 @@ public class TransactionAppWidgetProvider extends AppWidgetProvider {
         // Perform this loop procedure for each App Widget that belongs to this provider
         for (int i=0; i<N; i++) {
             int appWidgetId = appWidgetIds[i];
-
-            String accountUID = PreferenceManager
-                    .getDefaultSharedPreferences(context)
+            SharedPreferences defaultSharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+            String accountUID = defaultSharedPrefs
                     .getString(UxArgument.SELECTED_ACCOUNT_UID + appWidgetId, null);
+            boolean shouldDisplayBalance = defaultSharedPrefs
+                    .getBoolean(UxArgument.SHOULD_DISPLAY_BALANCE + appWidgetId, true);
             if (accountUID == null)
             	return;
             
-            WidgetConfigurationActivity.updateWidget(context, appWidgetId, accountUID);
+            WidgetConfigurationActivity.updateWidget(context, appWidgetId, accountUID, shouldDisplayBalance);
         }
 	}
 

--- a/app/src/main/java/org/gnucash/android/ui/common/UxArgument.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/UxArgument.java
@@ -73,6 +73,11 @@ public final class UxArgument {
     public static final String SELECTED_ACCOUNT_UID = "account_uid";
 
     /**
+     * Key for passing whether a widget should display the balance
+     */
+    public static final String SHOULD_DISPLAY_BALANCE = "should_display_balance";
+
+    /**
      * Key for passing argument for the parent account GUID.
      */
     public static final String PARENT_ACCOUNT_UID = "parent_account_uid";

--- a/app/src/main/res/layout/widget_configuration.xml
+++ b/app/src/main/res/layout/widget_configuration.xml
@@ -35,5 +35,12 @@
         android:layout_height="wrap_content" 
         android:minHeight="?android:attr/listPreferredItemHeight" />
 
+	<CheckBox
+		android:id="@+id/input_should_display_balance"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:text="@string/label_should_display_balance"
+		android:checked="true"/>
+
     <include layout="@layout/default_buttons"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="label_permission_record_transaction">Record transactions in GnuCash</string>
     <string name="label_permission_create_account">Create accounts in GnuCash</string>
     <string name="label_display_account">Display account</string>
+    <string name="label_should_display_balance">Display balance?</string>
     <string name="btn_create_accounts">Create Accounts</string>
     <string name="title_default_accounts">Select accounts to create</string>
 	<string name="error_no_accounts">No accounts exist in GnuCash.\nCreate an account before adding a widget</string>


### PR DESCRIPTION
This commit adds an option to widgets which lets you hide the balance of the account that the widget is displaying. If you have set a passcode then the widget will default to not showing the account balance, otherwise it will default to showing the account balance.

This resolves part of #598.