### PR TITLE
Change widget button to open placeholder accounts

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
@@ -34,6 +34,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.ImageButton;
 import android.widget.RemoteViews;
 import android.widget.Spinner;
 import android.widget.Toast;
@@ -261,15 +262,21 @@ public class WidgetConfigurationActivity extends Activity {
 				.getActivity(context, appWidgetId, accountViewIntent, 0);
 		views.setOnClickPendingIntent(R.id.widget_layout, accountPendingIntent);
 		
-		Intent newTransactionIntent = new Intent(context, FormActivity.class);
-		newTransactionIntent.setAction(Intent.ACTION_INSERT_OR_EDIT);
-		newTransactionIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-		newTransactionIntent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.TRANSACTION.name());
-		newTransactionIntent.putExtra(UxArgument.BOOK_UID, bookUID);
-		newTransactionIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID, accountUID);
-		PendingIntent pendingIntent = PendingIntent
-				.getActivity(context, appWidgetId, newTransactionIntent, 0);	            
-		views.setOnClickPendingIntent(R.id.btn_new_transaction, pendingIntent);
+		if (accountsDbAdapter.isPlaceholderAccount(accountUID)) {
+			views.setOnClickPendingIntent(R.id.btn_view_account, accountPendingIntent);
+			views.setViewVisibility(R.id.btn_new_transaction, View.GONE);
+		} else {
+			Intent newTransactionIntent = new Intent(context, FormActivity.class);
+			newTransactionIntent.setAction(Intent.ACTION_INSERT_OR_EDIT);
+			newTransactionIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+			newTransactionIntent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.TRANSACTION.name());
+			newTransactionIntent.putExtra(UxArgument.BOOK_UID, bookUID);
+			newTransactionIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID, accountUID);
+			PendingIntent pendingIntent = PendingIntent
+					.getActivity(context, appWidgetId, newTransactionIntent, 0);
+			views.setOnClickPendingIntent(R.id.btn_new_transaction, pendingIntent);
+			views.setViewVisibility(R.id.btn_view_account, View.GONE);
+		}
 		
 		appWidgetManager.updateAppWidget(appWidgetId, views);
 	}

--- a/app/src/main/res/layout/widget_4x1.xml
+++ b/app/src/main/res/layout/widget_4x1.xml
@@ -54,5 +54,14 @@
 	        android:src="@drawable/content_new_holo_light"
 	        android:background="@drawable/appwidget_bg_clickable"
 	        android:contentDescription="@string/description_add_transaction_icon"/>
+
+	   <ImageButton android:id="@+id/btn_view_account"
+		   android:layout_width="48dp"
+		   android:layout_height="wrap_content"
+		   android:layout_marginRight="@dimen/edge_padding"
+		   android:layout_marginLeft="@dimen/edge_padding"
+		   android:src="@drawable/action_about_holo_light"
+		   android:background="@drawable/appwidget_bg_clickable"
+		   android:contentDescription="@string/description_view_account_icon"/>
 	</LinearLayout>        
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="info_details">Info</string>
     <string name="menu_export">Export…</string>
     <string name="description_add_transaction_icon">Add a new transaction to an account</string>
+    <string name="description_view_account_icon">View account details</string>
     <string name="label_no_accounts">No accounts to display</string>
     <string name="label_account_name">Account name</string>
     <string name="btn_cancel">Cancel</string>


### PR DESCRIPTION
When a widget is created for a placeholder account we change the "add transaction" button on the widget to instead be an "information" icon, which opens up the account details when clicked.

Should fix #592.