### PR TITLE
Make widgets backwards compatible

### DIFF
--- a/app/src/main/java/org/gnucash/android/receivers/TransactionAppWidgetProvider.java
+++ b/app/src/main/java/org/gnucash/android/receivers/TransactionAppWidgetProvider.java
@@ -48,13 +48,13 @@ public class TransactionAppWidgetProvider extends AppWidgetProvider {
 			SharedPreferences bookSharedPreferences = PreferenceActivity.getActiveBookSharedPreferences();
 			String accountUID = bookSharedPreferences
                     .getString(UxArgument.SELECTED_ACCOUNT_UID + appWidgetId, null);
-            boolean shouldDisplayBalance = bookSharedPreferences
-                    .getBoolean(UxArgument.HIDE_ACCOUNT_BALANCE_IN_WIDGET + appWidgetId, true);
+            boolean hideAccountBalance = bookSharedPreferences
+                    .getBoolean(UxArgument.HIDE_ACCOUNT_BALANCE_IN_WIDGET + appWidgetId, false);
             if (accountUID == null)
             	return;
             
             WidgetConfigurationActivity.updateWidget(context, appWidgetId, accountUID,
-					BooksDbAdapter.getInstance().getActiveBookUID(), shouldDisplayBalance);
+					BooksDbAdapter.getInstance().getActiveBookUID(), hideAccountBalance);
         }
 	}
 

--- a/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
@@ -302,7 +302,7 @@ public class WidgetConfigurationActivity extends Activity {
 					final String accountUID = defaultSharedPrefs
 							.getString(UxArgument.SELECTED_ACCOUNT_UID + widgetId, null);
 					final boolean hideAccountBalance = defaultSharedPrefs
-							.getBoolean(UxArgument.HIDE_ACCOUNT_BALANCE_IN_WIDGET + widgetId, true);
+							.getBoolean(UxArgument.HIDE_ACCOUNT_BALANCE_IN_WIDGET + widgetId, false);
 
 					if (accountUID == null)
 						continue;


### PR DESCRIPTION
If we can't find the new "hide account balance" setting, we should default to the old behaviour: show the account balance.