### PR TITLE
Bugfix 617: Weekly scheduled exports are listed with the wrong day

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/util/RecurrenceParser.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/RecurrenceParser.java
@@ -16,6 +16,8 @@
 
 package org.gnucash.android.ui.util;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.format.Time;
 
 import com.codetroopers.betterpickers.recurrencepicker.EventRecurrence;
@@ -24,7 +26,10 @@ import org.gnucash.android.model.PeriodType;
 import org.gnucash.android.model.Recurrence;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Parses {@link EventRecurrence}s to generate
@@ -76,7 +81,7 @@ public class RecurrenceParser {
         periodType.setMultiplier(interval);
         Recurrence recurrence = new Recurrence(periodType);
         parseEndTime(eventRecurrence, recurrence);
-        recurrence.setByDay(parseByDay(eventRecurrence.byday));
+        recurrence.setByDays(parseByDay(eventRecurrence.byday));
         if (eventRecurrence.startDate != null)
             recurrence.setPeriodStart(new Timestamp(eventRecurrence.startDate.toMillis(false)));
 
@@ -85,7 +90,7 @@ public class RecurrenceParser {
 
     /**
      * Parses the end time from an EventRecurrence object and sets it to the <code>scheduledEvent</code>.
-     * The end time is specified in the dialog either by number of occurences or a date.
+     * The end time is specified in the dialog either by number of occurrences or a date.
      * @param eventRecurrence Event recurrence pattern obtained from dialog
      * @param recurrence Recurrence event to set the end period to
      */
@@ -100,90 +105,24 @@ public class RecurrenceParser {
     }
 
     /**
-     * Returns the date for the next day of the week
-     * @param dow Day of the week (Calendar constants)
-     * @return Calendar instance with the next day of the week
+     * Parses an array of byDay values to return a list of days of week
+     * constants from {@link Calendar}.
+     *
+     * <p>Currently only supports byDay values for weeks.</p>
+     *
+     * @param byDay Array of byDay values
+     * @return list of days of week constants from Calendar.
      */
-    private static Calendar nextDayOfWeek(int dow) {
-        Calendar date = Calendar.getInstance();
-        int diff = dow - date.get(Calendar.DAY_OF_WEEK);
-        if (!(diff > 0)) {
-            diff += 7;
+    private static @NonNull List<Integer> parseByDay(@Nullable int[] byDay) {
+        if (byDay == null) {
+            return Collections.emptyList();
         }
-        date.add(Calendar.DAY_OF_MONTH, diff);
-        return date;
-    }
 
-    /**
-     * Parses an array of byday values to return the string concatenation of days of the week.
-     * <p>Currently only supports byDay values for weeks</p>
-     * @param byday Array of byday values
-     * @return String concat of days of the week or null if {@code byday} was empty
-     */
-    private static String parseByDay(int[] byday){
-        if (byday == null || byday.length == 0){
-            return null;
+        List<Integer> byDaysList = new ArrayList<>(byDay.length);
+        for (int day : byDay) {
+            byDaysList.add(EventRecurrence.day2CalendarDay(day));
         }
-        //todo: parse for month and year as well, when our dialog supports those
-        StringBuilder builder = new StringBuilder();
-        for (int day : byday) {
-            switch (day)
-            {
-                case EventRecurrence.SU:
-                    builder.append("SU");
-                    break;
-                case EventRecurrence.MO:
-                    builder.append("MO");
-                    break;
-                case EventRecurrence.TU:
-                    builder.append("TU");
-                    break;
-                case EventRecurrence.WE:
-                    builder.append("WE");
-                    break;
-                case EventRecurrence.TH:
-                    builder.append("TH");
-                    break;
-                case EventRecurrence.FR:
-                    builder.append("FR");
-                    break;
-                case EventRecurrence.SA:
-                    builder.append("SA");
-                    break;
-                default:
-                    throw new RuntimeException("bad day of week: " + day);
-            }
-            builder.append(",");
-        }
-        builder.deleteCharAt(builder.length()-1);
-        return builder.toString();
-    }
 
-    /**
-     * Converts one of the SU, MO, etc. constants to the Calendar.SUNDAY
-     * constants.  btw, I think we should switch to those here too, to
-     * get rid of this function, if possible.
-     */
-    public static int day2CalendarDay(int day)
-    {
-        switch (day)
-        {
-            case EventRecurrence.SU:
-                return Calendar.SUNDAY;
-            case EventRecurrence.MO:
-                return Calendar.MONDAY;
-            case EventRecurrence.TU:
-                return Calendar.TUESDAY;
-            case EventRecurrence.WE:
-                return Calendar.WEDNESDAY;
-            case EventRecurrence.TH:
-                return Calendar.THURSDAY;
-            case EventRecurrence.FR:
-                return Calendar.FRIDAY;
-            case EventRecurrence.SA:
-                return Calendar.SATURDAY;
-            default:
-                throw new RuntimeException("bad day of week: " + day);
-        }
+        return byDaysList;
     }
 }


### PR DESCRIPTION
Fixes #617 

There some are important changes, so I thought you might want to review it.

Instead of storing the days of the week as a string ("MO;TH") in `mByDay`, which is painful to work with, I've changed it to store as a List of Calendar constants (`Calendar.MONDAY`) instead. If later we want to support specific days in the month, we can just change the list type to some other class to hold the new information.

As this was meant for hotfix/patches, I haven't changed the database structure but, in my opinion, we should think of storing `recurrence_byday` in a separate table. Apart from not conforming with the first normal form, the parsing of the column (`RecurrenceDbAdapter.{byDaysToString,stringToByDays}` ) makes it awkward to work with.