### PR TITLE
Bugfix 603: scheduled transactions with multiple splits end up going to imbalance

### DIFF
--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -688,14 +688,14 @@ public class GncXmlHandler extends DefaultHandler {
                 break;
             case GncXmlHelper.TAG_TRANSACTION:
                 mTransaction.setTemplate(mInTemplates);
-                Split imbSplit = mTransaction.createAutoBalanceSplit();
-                if (imbSplit != null) {
-                    mAutoBalanceSplits.add(imbSplit);
-                }
                 if (mInTemplates){
                     if (!mIgnoreTemplateTransaction)
                         mTemplateTransactions.add(mTransaction);
                 } else {
+                    Split imbSplit = mTransaction.createAutoBalanceSplit();
+                    if (imbSplit != null) {
+                        mAutoBalanceSplits.add(imbSplit);
+                    }
                     mTransactionList.add(mTransaction);
                 }
                 if (mRecurrencePeriod > 0) { //if we find an old format recurrence period, parse it
@@ -1051,8 +1051,7 @@ public class GncXmlHandler extends DefaultHandler {
     private void handleEndOfTemplateNumericSlot(String characterString, TransactionType splitType) {
         try {
             // HACK: Check for bug #562. If a value has already been set, ignore the one just read
-            if (mSplit.getValue().equals(
-                    new Money(BigDecimal.ZERO, mSplit.getValue().getCommodity()))) {
+            if (mSplit.getValue().isAmountZero()) {
                 BigDecimal amountBigD = GncXmlHelper.parseSplitAmount(characterString);
                 Money amount = new Money(amountBigD, getCommodityForAccount(mSplit.getAccountUID()));
 

--- a/app/src/main/java/org/gnucash/android/model/Transaction.java
+++ b/app/src/main/java/org/gnucash/android/model/Transaction.java
@@ -179,7 +179,7 @@ public class Transaction extends BaseModel{
      * @return Split whose amount is the imbalance of this transaction
      */
     public Split createAutoBalanceSplit(){
-        Money imbalance = getImbalance(); //returns imbalance of 0 for multicurrency transactions
+        Money imbalance = getImbalance(); //returns imbalance of 0 for multi-currency transactions
         if (!imbalance.isAmountZero()){
             Split split = new Split(imbalance.negate(), mCurrencyCode); //yes, this is on purpose
             //the account UID is set to the currency. This should be overridden before saving to db
@@ -268,7 +268,11 @@ public class Transaction extends BaseModel{
     public Money getImbalance(){
         Money imbalance = Money.createZeroInstance(mCurrencyCode);
         for (Split split : mSplitList) {
-            if (!split.getQuantity().getCommodity().getCurrencyCode().equals(mCurrencyCode)) {
+            Money quantity = split.getQuantity();
+            if (quantity.isAmountZero()) {
+                continue;
+            }
+            if (!quantity.getCommodity().getCurrencyCode().equals(mCurrencyCode)) {
                 // this may happen when importing XML exported from GNCA before 2.0.0
                 // these transactions should only be imported from XML exported from GNC desktop
                 // so imbalance split should not be generated for them


### PR DESCRIPTION
Template transactions have splits with zero quantities but non-zero values.
The quantity's currency might be different than the value's currency.