### PR TITLE
Preserve report type accross rotation

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/report/ReportsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportsActivity.java
@@ -45,7 +45,6 @@ import org.gnucash.android.ui.common.Refreshable;
 import org.gnucash.android.ui.util.dialog.DateRangePickerDialogFragment;
 import org.joda.time.LocalDate;
 
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -74,6 +73,7 @@ public class ReportsActivity extends BaseDrawerActivity implements AdapterView.O
             Color.parseColor("#ba037c"), Color.parseColor("#708809"), Color.parseColor("#32072c"),
             Color.parseColor("#fddef8"), Color.parseColor("#fa0e6e"), Color.parseColor("#d9e7b5")
     };
+    private static final String STATE_REPORT_TYPE = "STATE_REPORT_TYPE";
 
     @Bind(R.id.time_range_spinner) Spinner mTimeRangeSpinner;
     @Bind(R.id.report_account_type_spinner) Spinner mAccountTypeSpinner;
@@ -123,8 +123,11 @@ public class ReportsActivity extends BaseDrawerActivity implements AdapterView.O
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            mReportType = (ReportType) savedInstanceState.getSerializable(STATE_REPORT_TYPE);
+        }
 
+        super.onCreate(savedInstanceState);
         mTransactionsDbAdapter = TransactionsDbAdapter.getInstance();
 
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this, R.array.report_time_range,
@@ -413,5 +416,12 @@ public class ReportsActivity extends BaseDrawerActivity implements AdapterView.O
      */
     public void refresh(String uid) {
         refresh();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putSerializable(STATE_REPORT_TYPE, mReportType);
     }
 }


### PR DESCRIPTION
Not sure if this is the best way to avoid the crash but for an unknown reason the `onAttachFragment()` is being called from parent's `onCreate()`

* fixes codinguser/gnucash-android#633