### PR TITLE
List favorite accounts first in Recents tab

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
@@ -970,7 +970,9 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
                 null,
                 SplitEntry.TABLE_NAME + "." + SplitEntry.COLUMN_ACCOUNT_UID, //groupby
                 null, //haveing
-                "MAX ( " + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + " ) DESC", // order
+                AccountEntry.COLUMN_FAVORITE + " DESC, "
+                    + "MAX (" + TransactionEntry.TABLE_NAME + "." + TransactionEntry.COLUMN_TIMESTAMP + "), "
+                    + AccountEntry.COLUMN_FULL_NAME + " ASC", // order
                 Integer.toString(numberOfRecent) // limit;
         );
     }


### PR DESCRIPTION
**Not to be merged**

While using the application, I usually have the _Favorites_ tab selected. There are the accounts I use most of the time (of course). However, there are also some accounts that I use less frequently. Then, the _Recents_ tab come in handy. The problem is, if later I need a favorite account, I might have to scroll down or switch back to _Favorites_.

What I've been thinking for some time is to list favorite accounts first in _Recents_. That would make easier to access both kinds of accounts and _Favorites_ tab could be removed.

What do you think? If you like the idea I can finish implementing it.