### PR TITLE
Bugfix 654: App crashes when trying modify account if default transaction account no longer exist

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/DatabaseSchema.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseSchema.java
@@ -39,7 +39,7 @@ public class DatabaseSchema {
      * Version number of database containing accounts and transactions info.
      * With any change to the database schema, this number must increase
      */
-    public static final int DATABASE_VERSION = 13;
+    public static final int DATABASE_VERSION = 14;
 
     /**
      * Name of the database

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -247,7 +247,9 @@ public class AccountsListFragment extends Fragment implements
         if (acc.getTransactionCount() > 0 || mAccountsDbAdapter.getSubAccountCount(acc.getUID()) > 0) {
             showConfirmationDialog(rowId);
         } else {
-            mAccountsDbAdapter.deleteRecord(rowId);
+            // Avoid calling AccountsDbAdapter.deleteRecord(long). See #654
+            String uid = mAccountsDbAdapter.getUID(rowId);
+            mAccountsDbAdapter.deleteRecord(uid);
             refresh();
         }
     }


### PR DESCRIPTION
Fixes #654 

At the end I've chosen the easiest path to avoid some problems or changing too much code.