### PR TITLE
Start autocompleting transactions with one character

### DIFF
--- a/app/src/main/res/layout/fragment_transaction_form.xml
+++ b/app/src/main/res/layout/fragment_transaction_form.xml
@@ -38,6 +38,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_span="2"
+                    android:completionThreshold="1"
                     android:hint="@string/label_transaction_name"
                     android:inputType="textCapSentences"
                     android:imeOptions="actionNext"


### PR DESCRIPTION
Less typing is better :)

I guess you just left the default. I can't find any reason for having to type two characters instead of one but, just in case, I leave it for you to approve.