### PR TITLE
Bugfix 544: Add dialog with extra checkbox for irreversible actions

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
@@ -38,6 +38,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.ListView;
@@ -199,30 +201,8 @@ public class BookManagerFragment extends ListFragment implements
                                 case R.id.ctx_menu_sync_book:
                                     //TODO implement sync
                                     return false;
-                                case R.id.ctx_menu_delete_book: {
-                                    AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
-                                    dialogBuilder.setTitle(getString(R.string.title_confirm_delete_book))
-                                            .setIcon(R.drawable.ic_close_black_24dp)
-                                            .setMessage(getString(R.string.msg_all_book_data_will_be_deleted));
-                                    dialogBuilder.setPositiveButton(getString(R.string.btn_delete_book), new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(DialogInterface dialog, int which) {
-                                            BooksDbAdapter.getInstance().deleteBook(bookUID);
-                                            refresh();
-                                        }
-                                    });
-                                    dialogBuilder.setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
-                                        @Override
-                                        public void onClick(DialogInterface dialog, int which) {
-                                            dialog.dismiss();
-                                        }
-                                    });
-                                    AlertDialog dialog = dialogBuilder.create();
-                                    dialog.show(); //must be called before you can access buttons
-                                    dialog.getButton(AlertDialog.BUTTON_POSITIVE)
-                                            .setTextColor(ContextCompat.getColor(context, R.color.account_red));
-                                }
-                                return true;
+                                case R.id.ctx_menu_delete_book:
+                                    return handleMenuDeleteBook(bookUID);
                                 default:
                                     return true;
                             }
@@ -236,6 +216,38 @@ public class BookManagerFragment extends ListFragment implements
                     popupMenu.show();
                 }
             });
+        }
+
+        private boolean handleMenuDeleteBook(final String bookUID) {
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+            dialogBuilder.setTitle(getString(R.string.title_confirm_delete_book))
+                    .setIcon(R.drawable.ic_close_black_24dp)
+                    .setView(R.layout.dialog_double_confirm)
+                    .setMessage(getString(R.string.msg_all_book_data_will_be_deleted));
+            dialogBuilder.setPositiveButton(getString(R.string.btn_delete_book), new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    BooksDbAdapter.getInstance().deleteBook(bookUID);
+                    refresh();
+                }
+            });
+            dialogBuilder.setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                }
+            });
+            final AlertDialog dialog = dialogBuilder.create();
+            dialog.show(); //must be called before you can access buttons
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+            CheckBox confirmCheckBox = dialog.findViewById(R.id.checkbox_confirm);
+            confirmCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(b);
+                }
+            });
+            return true;
         }
 
         /**

--- a/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
@@ -38,8 +38,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.ListView;
@@ -56,6 +54,7 @@ import org.gnucash.android.db.adapter.SplitsDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
 import org.gnucash.android.ui.account.AccountsActivity;
 import org.gnucash.android.ui.common.Refreshable;
+import org.gnucash.android.ui.settings.dialog.DeleteBookConfirmationDialog;
 import org.gnucash.android.util.BookUtils;
 import org.gnucash.android.util.PreferencesHelper;
 
@@ -219,34 +218,9 @@ public class BookManagerFragment extends ListFragment implements
         }
 
         private boolean handleMenuDeleteBook(final String bookUID) {
-            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
-            dialogBuilder.setTitle(getString(R.string.title_confirm_delete_book))
-                    .setIcon(R.drawable.ic_close_black_24dp)
-                    .setView(R.layout.dialog_double_confirm)
-                    .setMessage(getString(R.string.msg_all_book_data_will_be_deleted));
-            dialogBuilder.setPositiveButton(getString(R.string.btn_delete_book), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    BooksDbAdapter.getInstance().deleteBook(bookUID);
-                    refresh();
-                }
-            });
-            dialogBuilder.setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    dialog.dismiss();
-                }
-            });
-            final AlertDialog dialog = dialogBuilder.create();
-            dialog.show(); //must be called before you can access buttons
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-            CheckBox confirmCheckBox = dialog.findViewById(R.id.checkbox_confirm);
-            confirmCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                @Override
-                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
-                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(b);
-                }
-            });
+            DeleteBookConfirmationDialog dialog = DeleteBookConfirmationDialog.newInstance(bookUID);
+            dialog.show(getFragmentManager(), "delete_book");
+            dialog.setTargetFragment(BookManagerFragment.this, 0);
             return true;
         }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteAllAccountsConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteAllAccountsConfirmationDialog.java
@@ -16,13 +16,10 @@
 
 package org.gnucash.android.ui.settings.dialog;
 
-import android.annotation.TargetApi;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
 import android.widget.Toast;
 
 import org.gnucash.android.R;
@@ -36,7 +33,7 @@ import org.gnucash.android.ui.homescreen.WidgetConfigurationActivity;
  *
  * @author Ngewi Fet <ngewif@gmail.com>
  */
-public class DeleteAllAccountsConfirmationDialog extends DialogFragment {
+public class DeleteAllAccountsConfirmationDialog extends DoubleConfirmationDialog {
 
     public static DeleteAllAccountsConfirmationDialog newInstance() {
         DeleteAllAccountsConfirmationDialog frag = new DeleteAllAccountsConfirmationDialog();
@@ -45,7 +42,7 @@ public class DeleteAllAccountsConfirmationDialog extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new AlertDialog.Builder(getActivity())
+        return getDialogBuilder()
                 .setIcon(android.R.drawable.ic_delete)
                 .setTitle(R.string.title_confirm_delete).setMessage(R.string.confirm_delete_all_accounts)
                 .setPositiveButton(R.string.alert_dialog_ok_delete,
@@ -56,13 +53,6 @@ public class DeleteAllAccountsConfirmationDialog extends DialogFragment {
                                 AccountsDbAdapter.getInstance().deleteAllRecords();
                                 Toast.makeText(context, R.string.toast_all_accounts_deleted, Toast.LENGTH_SHORT).show();
                                 WidgetConfigurationActivity.updateAllWidgets(context);
-                            }
-                        }
-                )
-                .setNegativeButton(R.string.alert_dialog_cancel,
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int whichButton) {
-                                dismiss();
                             }
                         }
                 )

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteAllTransactionsConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteAllTransactionsConfirmationDialog.java
@@ -16,13 +16,11 @@
  */
 package org.gnucash.android.ui.settings.dialog;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -44,7 +42,7 @@ import java.util.List;
  * @author ngewif <ngewif@gmail.com>
  * @author Yongxin Wang <fefe.wyx@gmail.com>
  */
-public class DeleteAllTransactionsConfirmationDialog extends DialogFragment {
+public class DeleteAllTransactionsConfirmationDialog extends DoubleConfirmationDialog {
 
     public static DeleteAllTransactionsConfirmationDialog newInstance() {
         DeleteAllTransactionsConfirmationDialog frag = new DeleteAllTransactionsConfirmationDialog();
@@ -53,7 +51,7 @@ public class DeleteAllTransactionsConfirmationDialog extends DialogFragment {
 
     @Override
     @NonNull public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new AlertDialog.Builder(getActivity())
+        return getDialogBuilder()
                 .setIcon(android.R.drawable.ic_delete)
                 .setTitle(R.string.title_confirm_delete).setMessage(R.string.msg_delete_all_transactions_confirmation)
                 .setPositiveButton(R.string.alert_dialog_ok_delete,
@@ -80,19 +78,6 @@ public class DeleteAllTransactionsConfirmationDialog extends DialogFragment {
                             }
                         }
 
-                )
-                .
-
-                        setNegativeButton(R.string.alert_dialog_cancel,
-                                new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int whichButton) {
-                                        dismiss();
-                                    }
-                                }
-
-                        )
-                .
-
-                        create();
+                ).create();
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteBookConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteBookConfirmationDialog.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 Àlex Magaz Graça <alexandre.magaz@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gnucash.android.ui.settings.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+
+import org.gnucash.android.R;
+import org.gnucash.android.db.adapter.BooksDbAdapter;
+import org.gnucash.android.ui.common.Refreshable;
+
+/**
+ * Confirmation dialog for deleting a book.
+ *
+ * @author Àlex Magaz <alexandre.magaz@gmail.com>
+ */
+public class DeleteBookConfirmationDialog extends DialogFragment {
+
+    public static DeleteBookConfirmationDialog newInstance(String bookUID) {
+        DeleteBookConfirmationDialog frag = new DeleteBookConfirmationDialog();
+        Bundle args = new Bundle();
+        args.putString("bookUID", bookUID);
+        frag.setArguments(args);
+        return frag;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final String bookUID = getArguments().getString("bookUID");
+
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+        dialogBuilder.setTitle(getString(R.string.title_confirm_delete_book))
+                .setIcon(R.drawable.ic_close_black_24dp)
+                .setView(R.layout.dialog_double_confirm)
+                .setMessage(getString(R.string.msg_all_book_data_will_be_deleted));
+        dialogBuilder.setPositiveButton(getString(R.string.btn_delete_book), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                BooksDbAdapter.getInstance().deleteBook(bookUID);
+                ((Refreshable) getTargetFragment()).refresh();
+            }
+        });
+        dialogBuilder.setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+
+        return dialogBuilder.create();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        final AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog != null) {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+            CheckBox confirmCheckBox = dialog.findViewById(R.id.checkbox_confirm);
+            confirmCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(b);
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteBookConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DeleteBookConfirmationDialog.java
@@ -20,10 +20,6 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.DialogFragment;
-import android.support.v7.app.AlertDialog;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
 
 import org.gnucash.android.R;
 import org.gnucash.android.db.adapter.BooksDbAdapter;
@@ -34,8 +30,8 @@ import org.gnucash.android.ui.common.Refreshable;
  *
  * @author Àlex Magaz <alexandre.magaz@gmail.com>
  */
-public class DeleteBookConfirmationDialog extends DialogFragment {
-
+public class DeleteBookConfirmationDialog extends DoubleConfirmationDialog {
+    @NonNull
     public static DeleteBookConfirmationDialog newInstance(String bookUID) {
         DeleteBookConfirmationDialog frag = new DeleteBookConfirmationDialog();
         Bundle args = new Bundle();
@@ -47,43 +43,19 @@ public class DeleteBookConfirmationDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final String bookUID = getArguments().getString("bookUID");
-
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
-        dialogBuilder.setTitle(getString(R.string.title_confirm_delete_book))
+        return getDialogBuilder()
+                .setTitle(R.string.title_confirm_delete_book)
                 .setIcon(R.drawable.ic_close_black_24dp)
-                .setView(R.layout.dialog_double_confirm)
-                .setMessage(getString(R.string.msg_all_book_data_will_be_deleted));
-        dialogBuilder.setPositiveButton(getString(R.string.btn_delete_book), new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                BooksDbAdapter.getInstance().deleteBook(bookUID);
-                ((Refreshable) getTargetFragment()).refresh();
-            }
-        });
-        dialogBuilder.setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
-            }
-        });
-
-        return dialogBuilder.create();
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        final AlertDialog dialog = (AlertDialog) getDialog();
-        if (dialog != null) {
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-            CheckBox confirmCheckBox = dialog.findViewById(R.id.checkbox_confirm);
-            confirmCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                @Override
-                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
-                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(b);
-                }
-            });
-        }
+                .setMessage(R.string.msg_all_book_data_will_be_deleted)
+                .setPositiveButton(R.string.btn_delete_book, new DialogInterface.OnClickListener() {
+                    @SuppressWarnings("ConstantConditions")
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int which) {
+                        final String bookUID = getArguments().getString("bookUID");
+                        BooksDbAdapter.getInstance().deleteBook(bookUID);
+                        ((Refreshable) getTargetFragment()).refresh();
+                    }
+                })
+                .create();
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DoubleConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DoubleConfirmationDialog.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017 Àlex Magaz Graça <alexandre.magaz@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gnucash.android.ui.settings.dialog;
+
+import android.content.DialogInterface;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+
+import org.gnucash.android.R;
+
+/**
+ * Confirmation dialog with additional checkbox to confirm the action.
+ *
+ * <p>It's meant to avoid the user confirming irreversible actions by
+ * mistake. The positive button to confirm the action is only enabled
+ * when the checkbox is checked.</p>
+ *
+ * <p>Extend this class and override onCreateDialog to finish setting
+ * up the dialog. See getDialogBuilder().</p>
+ *
+ * @author Àlex Magaz <alexandre.magaz@gmail.com>
+ */
+public abstract class DoubleConfirmationDialog extends DialogFragment {
+    /**
+     * Returns the dialog builder with the defaults for a double confirmation
+     * dialog already set up.
+     *
+     * <p>Call it from onCreateDialog to finish setting up the dialog.
+     * At least the following should be set:</p>
+     *
+     * <ul>
+     *     <li>The title.</li>
+     *     <li>The positive button.</li>
+     * </ul>
+     *
+     * @return AlertDialog.Builder with the defaults for a double confirmation
+     * dialog already set up.
+     */
+    @NonNull
+    protected AlertDialog.Builder getDialogBuilder() {
+        return new AlertDialog.Builder(getActivity())
+                .setView(R.layout.dialog_double_confirm)
+                .setNegativeButton(R.string.btn_cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        onNegativeButton();
+                    }
+                });
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (getDialog() != null) {
+            ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+            setUpConfirmCheckBox();
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void setUpConfirmCheckBox() {
+        final AlertDialog dialog = (AlertDialog) getDialog();
+        CheckBox confirmCheckBox = dialog.findViewById(R.id.checkbox_confirm);
+        confirmCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(b);
+            }
+        });
+    }
+
+    /**
+     * Called when the negative button is pressed.
+     *
+     * <p>By default it just dismisses the dialog.</p>
+     */
+    protected void onNegativeButton() {
+        getDialog().dismiss();
+    }
+}

--- a/app/src/main/res/layout/dialog_double_confirm.xml
+++ b/app/src/main/res/layout/dialog_double_confirm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright (c) 2017 Ngewi Fet <ngewif@gmail.com>
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:padding="@dimen/dialog_padding" >
+
+    <CheckBox
+        android:id="@+id/checkbox_confirm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/yes_sure"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,4 +462,5 @@
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>
+    <string name="yes_sure">Yes, I\'m sure</string>
 </resources>

--- a/app/src/test/java/org/gnucash/android/test/unit/model/TransactionTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/TransactionTest.java
@@ -80,6 +80,7 @@ public class TransactionTest {
 	@Test
 	public void testCreateAutoBalanceSplit() {
 		Transaction transactionCredit = new Transaction("Transaction with more credit");
+        transactionCredit.setCommodity(Commodity.getInstance("EUR"));
 		Split creditSplit = new Split(new Money("1", "EUR"), "test-account");
 		creditSplit.setType(TransactionType.CREDIT);
 		transactionCredit.addSplit(creditSplit);
@@ -93,6 +94,7 @@ public class TransactionTest {
 
 
 		Transaction transactionDebit = new Transaction("Transaction with more debit");
+		transactionDebit.setCommodity(Commodity.getInstance("EUR"));
 		Split debitSplit = new Split(new Money("1", "EUR"), "test-account");
 		debitSplit.setType(TransactionType.DEBIT);
 		transactionDebit.addSplit(debitSplit);


### PR DESCRIPTION
I haven't found any other dialog that should have double confirmation, apart from the ones mentioned on the issue, but I might've missed some.

Fixes #544.