### PR TITLE
Android Studio 3 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ static def gitSha() {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "org.gnucash.android"
         testApplicationId 'org.gnucash.android.test'
@@ -49,9 +49,9 @@ android {
     }
 
     applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            output.outputFile = new File(
-                    output.outputFile.parent, "GnucashAndroid_v${variant.versionName}.apk")
+        variant.outputs.all { output ->
+            //output.outputFile = new File(output.outputFile.parent, "GnucashAndroid_v${variant.versionName}.apk")
+            outputFileName = "GnucashAndroid_v${variant.versionName}.apk"
         }
     }
 
@@ -93,6 +93,8 @@ android {
         abortOnError false
     }
 
+    flavorDimensions "stability"
+
     productFlavors {
         development {
             applicationId 'org.gnucash.android.devel'
@@ -104,6 +106,8 @@ android {
             resValue "string", "dropbox_app_key", "dhjh8ke9wf05948"
             resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
             resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
+
+            dimension "stability"
         }
 
         beta {
@@ -120,6 +124,8 @@ android {
                 resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
                 resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
             }
+
+            dimension "stability"
         }
 
         production {
@@ -135,6 +141,8 @@ android {
                 resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
                 resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
             }
+
+            dimension "stability"
         }
 
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,6 @@ android {
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
-            //output.outputFile = new File(output.outputFile.parent, "GnucashAndroid_v${variant.versionName}.apk")
             outputFileName = "GnucashAndroid_v${variant.versionName}.apk"
         }
     }
@@ -106,8 +105,6 @@ android {
             resValue "string", "dropbox_app_key", "dhjh8ke9wf05948"
             resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
             resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
-
-            dimension "stability"
         }
 
         beta {
@@ -124,8 +121,6 @@ android {
                 resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
                 resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
             }
-
-            dimension "stability"
         }
 
         production {
@@ -141,10 +136,7 @@ android {
                 resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
                 resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
             }
-
-            dimension "stability"
         }
-
     }
 
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
     <style name="ListItemContainerBase">
         <item name="android:minHeight">?android:attr/listPreferredItemHeight</item>
     </style>
-    <style name="ListItem" parent="style/ListItemContainerBase">
+    <style name="ListItem" parent="ListItemContainerBase">
         <item name="android:paddingLeft">@dimen/dialog_padding</item>
         <item name="android:paddingRight">@dimen/dialog_padding</item>
         <item name="android:paddingTop">8dp</item>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.3.3'
+		classpath 'com.android.tools.build:gradle:3.0.0'
 		classpath 'io.fabric.tools:gradle:1.21.6'
 		classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 04 18:07:15 CEST 2017
+#Mon Oct 30 21:17:22 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
A few things to make the project build with Android Studio 3:

-  updating the build tools
- adding flavor dimensions
- handling output file name
- updating Gradle plugin & Gradle
