### PR TITLE
Fix widget black text on black background on newer Android versions

### DIFF
--- a/app/src/main/res/layout/widget_4x1.xml
+++ b/app/src/main/res/layout/widget_4x1.xml
@@ -36,7 +36,8 @@
 	         android:ellipsize="end"
 	         android:layout_marginLeft="@dimen/edge_padding"
 	         android:textAppearance="?android:attr/textAppearanceLarge"
-	         android:text="@string/label_account_name" /> 
+			 android:textColor="@android:color/white"
+	         android:text="@string/label_account_name" />
 	                
 	    <TextView android:id="@+id/transactions_summary"
 	        android:layout_width="wrap_content"


### PR DESCRIPTION
I haven't done much with themes, styles and alike. So I'm not sure if this is the best way to fix the problem.

Reported on [Google+ group](https://plus.google.com/117605068428491461489/posts/92CVFy3ASzv).