### PR TITLE
Recover from empty books database

### DIFF
--- a/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
@@ -150,7 +150,7 @@ public class GnuCashApplication extends MultiDexApplication {
             mDbHelper = new DatabaseHelper(getAppContext(),
                                            mBooksDbAdapter.getActiveBookUID());
         } catch (BooksDbAdapter.NoActiveBookFoundException e) {
-            fixBooksDatabase();
+            mBooksDbAdapter.fixBooksDatabase();
             mDbHelper = new DatabaseHelper(getAppContext(),
                                            mBooksDbAdapter.getActiveBookUID());
         }
@@ -172,13 +172,6 @@ public class GnuCashApplication extends MultiDexApplication {
         mCommoditiesDbAdapter       = new CommoditiesDbAdapter(mainDb);
         mBudgetAmountsDbAdapter     = new BudgetAmountsDbAdapter(mainDb);
         mBudgetsDbAdapter           = new BudgetsDbAdapter(mainDb, mBudgetAmountsDbAdapter, mRecurrenceDbAdapter);
-    }
-
-    /** Sets the first book in the database as active. */
-    private static void fixBooksDatabase() {
-        Book firstBook = BooksDbAdapter.getInstance().getAllRecords().get(0);
-        firstBook.setActive(true);
-        BooksDbAdapter.getInstance().addRecord(firstBook);
     }
 
     public static AccountsDbAdapter getAccountsDbAdapter() {

--- a/app/src/main/java/org/gnucash/android/db/adapter/BooksDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/BooksDbAdapter.java
@@ -190,6 +190,13 @@ public class BooksDbAdapter extends DatabaseAdapter<Book> {
         }
     }
 
+    /** Sets the first book in the database as active. */
+    public void fixBooksDatabase() {
+        Book firstBook = getAllRecords().get(0);
+        firstBook.setActive(true);
+        BooksDbAdapter.getInstance().addRecord(firstBook);
+    }
+
     public @NonNull List<String> getAllBookUIDs(){
         List<String> bookUIDs = new ArrayList<>();
         try (Cursor cursor = mDb.query(true, mTableName, new String[]{BookEntry.COLUMN_UID},

--- a/app/src/main/java/org/gnucash/android/db/adapter/BooksDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/BooksDbAdapter.java
@@ -23,9 +23,11 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.db.DatabaseHelper;
 import org.gnucash.android.db.DatabaseSchema.BookEntry;
 import org.gnucash.android.model.Book;
 import org.gnucash.android.ui.settings.PreferenceActivity;
@@ -190,11 +192,70 @@ public class BooksDbAdapter extends DatabaseAdapter<Book> {
         }
     }
 
-    /** Sets the first book in the database as active. */
+    /** Tries to fix the books database. */
     public void fixBooksDatabase() {
+        Log.w(LOG_TAG, "Looking for books to set as active...");
+        if (getRecordsCount() <= 0) {
+            Log.w(LOG_TAG, "No books found in the database. Recovering books records...");
+            recoverBookRecords();
+        }
+        setFirstBookAsActive();
+    }
+
+    /**
+     * Restores the records in the book database.
+     *
+     * Does so by looking for database files from books.
+     */
+    private void recoverBookRecords() {
+        for (String dbName : getBookDatabases()) {
+            Book book = new Book(getRootAccountUID(dbName));
+            book.setUID(dbName);
+            book.setDisplayName(generateDefaultBookName());
+            addRecord(book);
+            Log.w(LOG_TAG, "Recovered book record: " + book.getUID());
+        }
+    }
+
+    /**
+     * Returns the root account UID from the database with name dbName.
+     */
+    private String getRootAccountUID(String dbName) {
+        Context context = GnuCashApplication.getAppContext();
+        DatabaseHelper databaseHelper = new DatabaseHelper(context, dbName);
+        SQLiteDatabase db = databaseHelper.getReadableDatabase();
+        AccountsDbAdapter accountsDbAdapter = new AccountsDbAdapter(db,
+                new TransactionsDbAdapter(db, new SplitsDbAdapter(db)));
+        String uid = accountsDbAdapter.getOrCreateGnuCashRootAccountUID();
+        db.close();
+        return uid;
+    }
+
+    /**
+     * Sets the first book in the database as active.
+     */
+    private void setFirstBookAsActive() {
         Book firstBook = getAllRecords().get(0);
         firstBook.setActive(true);
-        BooksDbAdapter.getInstance().addRecord(firstBook);
+        addRecord(firstBook);
+        Log.w(LOG_TAG, "Book " + firstBook.getUID() + " set as active.");
+    }
+
+    /**
+     * Returns a list of database names corresponding to book databases.
+     */
+    private List<String> getBookDatabases() {
+        List<String> bookDatabases = new ArrayList<>();
+        for (String database : GnuCashApplication.getAppContext().databaseList()) {
+            if (isBookDatabase(database)) {
+                bookDatabases.add(database);
+            }
+        }
+        return bookDatabases;
+    }
+
+    private boolean isBookDatabase(String databaseName) {
+        return databaseName.matches("[a-z0-9]{32}"); // UID regex
     }
 
     public @NonNull List<String> getAllBookUIDs(){

--- a/app/src/test/java/org/gnucash/android/test/unit/db/BooksDbAdapterTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/db/BooksDbAdapterTest.java
@@ -180,6 +180,22 @@ public class BooksDbAdapterTest {
     }
 
     /**
+     * Tests the recovery from an empty books database.
+     */
+    @Test
+    public void recoverFromEmptyDatabase() {
+        createNewBookWithDefaultAccounts();
+        mBooksDbAdapter.deleteAllRecords();
+        assertThat(mBooksDbAdapter.getRecordsCount()).isZero();
+
+        mBooksDbAdapter.fixBooksDatabase();
+
+        // Should've recovered the one from setUp() plus the one created above
+        assertThat(mBooksDbAdapter.getRecordsCount()).isEqualTo(2);
+        mBooksDbAdapter.getActiveBookUID(); // should not throw exception
+    }
+
+    /**
      * Creates a new database with default accounts
      * @return The book UID for the new database
      * @throws RuntimeException if the new books could not be created

--- a/app/src/test/java/org/gnucash/android/test/unit/db/BooksDbAdapterTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/db/BooksDbAdapterTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -156,6 +157,26 @@ public class BooksDbAdapterTest {
         String generatedName = mBooksDbAdapter.generateDefaultBookName();
         assertThat(generatedName).isNotEqualTo(book3.getDisplayName());
         assertThat(generatedName).isEqualTo("Book 4");
+    }
+
+    @Test
+    public void recoverFromNoActiveBookFound() {
+        Book book1 = new Book(BaseModel.generateUID());
+        book1.setActive(false);
+        mBooksDbAdapter.addRecord(book1);
+
+        Book book2 = new Book(BaseModel.generateUID());
+        book2.setActive(false);
+        mBooksDbAdapter.addRecord(book2);
+
+        try {
+            mBooksDbAdapter.getActiveBookUID();
+            fail("There shouldn't be any active book.");
+        } catch (BooksDbAdapter.NoActiveBookFoundException e) {
+            mBooksDbAdapter.fixBooksDatabase();
+        }
+
+        assertThat(mBooksDbAdapter.getActiveBookUID()).isEqualTo(book1.getUID());
     }
 
     /**


### PR DESCRIPTION
The fix implemented in c27f763 didn't solve the issue. It now fails because the books database is empty. This pull request will hopefully solve the problem, unless there's been real data loss.

Fixes http://crashes.to/s/d7c34870c8d