### PR TITLE
Allow denominators up to 1000000 in QIF export

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/qif/QifExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/qif/QifExporter.java
@@ -213,6 +213,15 @@ public class QifExporter extends Exporter{
                         case 1000:
                             precision = 3;
                             break;
+                        case 10000:
+                            precision = 4;
+                            break;
+                        case 100000:
+                            precision = 5;
+                            break;
+                        case 1000000:
+                            precision = 6;
+                            break;
                         default:
                             throw new ExporterException(mExportParams, "split quantity has illegal denominator: "+ quantity_denom);
                     }


### PR DESCRIPTION
Fixes #771 

I was able to reproduce this issue using the current Play store version:

`04-25 12:54:36.439  7645  8914 E ExportAsyncTask: Error exporting: Failed to generate export with parameters: Export all transactions created since 1970-01-01 00:00:00.000 UTC as QIF to URI (content:/
/com.android.externalstorage.documents/document/primary%3ASync%2F20180425_125428_gnucash_export_finances.gnucash.qif.zip) - split quantity has illegal denominator: 1000000`

`04-25 12:54:36.439  7645  8914 W System.err: org.gnucash.android.export.Exporter$ExporterException: Failed to generate export with parameters: Export all transactions created since 1970-01-01 00:00:00
.000 UTC as QIF to URI (content://com.android.externalstorage.documents/document/primary%3ASync%2F20180425_125428_gnucash_export_finances.gnucash.qif.zip) - split quantity has illegal denominator: 100
0000`

I fixed the `switch` statement mentioned in #771 by adding a couple cases to it for higher precision numbers and installed the dev version to my phone. Using the dev version I'm able to successfully export transactions and import to gnucash 3.0 on mac.

I've ran `gradlew test` and all tests pass:

`BUILD SUCCESSFUL in 4m 1s`
`140 actionable tasks: 62 executed, 78 up-to-date`