### PR TITLE
Misuse of multiple SQL statements in execSQL()

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/BookDbHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/BookDbHelper.java
@@ -64,7 +64,8 @@ public class BookDbHelper extends SQLiteOpenHelper {
             + BookEntry.COLUMN_LAST_SYNC     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + BookEntry.COLUMN_CREATED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + BookEntry.COLUMN_MODIFIED_AT   + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP "
-            + ");" + DatabaseHelper.createUpdatedAtTrigger(BookEntry.TABLE_NAME);
+            + ");";
+    private static final String BOOKS_TABLE_TRIGGER = DatabaseHelper.createUpdatedAtTrigger(BookEntry.TABLE_NAME);
 
     public BookDbHelper(Context context) {
         super(context, DatabaseSchema.BOOK_DATABASE_NAME, null, DatabaseSchema.BOOK_DATABASE_VERSION);
@@ -74,6 +75,7 @@ public class BookDbHelper extends SQLiteOpenHelper {
     @Override
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(BOOKS_TABLE_CREATE);
+        db.execSQL(BOOKS_TABLE_TRIGGER);
 
         if (mContext.getDatabasePath(DatabaseSchema.LEGACY_DATABASE_NAME).exists()){
             Log.d(LOG_TAG, "Legacy database found. Migrating to multibook format");

--- a/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
@@ -79,7 +79,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + AccountEntry.COLUMN_MODIFIED_AT      + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
 //            + "FOREIGN KEY (" 	+ AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE SET NULL, "
             + "FOREIGN KEY (" 	+ AccountEntry.COLUMN_COMMODITY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") "
-			+ ");" + createUpdatedAtTrigger(AccountEntry.TABLE_NAME);
+			+ ");";
+        private static final String ACCOUNTS_TABLE_TRIGGER = createUpdatedAtTrigger(AccountEntry.TABLE_NAME);
 	
 	/**
 	 * SQL statement to create the transactions table in the database
@@ -99,7 +100,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + TransactionEntry.COLUMN_MODIFIED_AT   + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + "FOREIGN KEY (" 	+ TransactionEntry.COLUMN_SCHEDX_ACTION_UID + ") REFERENCES " + ScheduledActionEntry.TABLE_NAME + " (" + ScheduledActionEntry.COLUMN_UID + ") ON DELETE SET NULL, "
             + "FOREIGN KEY (" 	+ TransactionEntry.COLUMN_COMMODITY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") "
-			+ ");" + createUpdatedAtTrigger(TransactionEntry.TABLE_NAME);
+			+ ");";
+         private static final String TRANSACTIONS_TABLE_TRIGGER = createUpdatedAtTrigger(TransactionEntry.TABLE_NAME);
 
     /**
      * SQL statement to create the transaction splits table
@@ -121,7 +123,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + SplitEntry.COLUMN_MODIFIED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
             + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_TRANSACTION_UID + ") REFERENCES " + TransactionEntry.TABLE_NAME + " (" + TransactionEntry.COLUMN_UID + ") ON DELETE CASCADE "
-            + ");" + createUpdatedAtTrigger(SplitEntry.TABLE_NAME);
+            + ");";
+    private static final String SPLITS_TABLE_TRIGGER = createUpdatedAtTrigger(SplitEntry.TABLE_NAME);
 
 
     public static final String SCHEDULED_ACTIONS_TABLE_CREATE = "CREATE TABLE " + ScheduledActionEntry.TABLE_NAME + " ("
@@ -145,7 +148,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + ScheduledActionEntry.COLUMN_CREATED_AT        + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + ScheduledActionEntry.COLUMN_MODIFIED_AT       + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + "FOREIGN KEY (" 	+ ScheduledActionEntry.COLUMN_RECURRENCE_UID + ") REFERENCES " + RecurrenceEntry.TABLE_NAME + " (" + RecurrenceEntry.COLUMN_UID + ") "
-            + ");" + createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME);
+            + ");";
+    public static final String SCHEDULED_ACTIONS_TABLE_TRIGGER = createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME);
 
     public static final String COMMODITIES_TABLE_CREATE = "CREATE TABLE " + DatabaseSchema.CommodityEntry.TABLE_NAME + " ("
             + CommodityEntry._ID                + " integer primary key autoincrement, "
@@ -159,7 +163,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + CommodityEntry.COLUMN_QUOTE_FLAG  + " integer not null, "
             + CommodityEntry.COLUMN_CREATED_AT  + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + CommodityEntry.COLUMN_MODIFIED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP "
-            + ");" + createUpdatedAtTrigger(CommodityEntry.TABLE_NAME);
+            + ");";
+    public static final String COMMODITIES_TABLE_TRIGGER = createUpdatedAtTrigger(CommodityEntry.TABLE_NAME);
 
     /**
      * SQL statement to create the commodity prices table
@@ -179,7 +184,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + "UNIQUE (" + PriceEntry.COLUMN_COMMODITY_UID + ", " + PriceEntry.COLUMN_CURRENCY_UID + ") ON CONFLICT REPLACE, "
             + "FOREIGN KEY (" 	+ PriceEntry.COLUMN_COMMODITY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") ON DELETE CASCADE, "
             + "FOREIGN KEY (" 	+ PriceEntry.COLUMN_CURRENCY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") ON DELETE CASCADE "
-            + ");" + createUpdatedAtTrigger(PriceEntry.TABLE_NAME);
+            + ");";
+    private static final String PRICES_TABLE_TRIGGER = createUpdatedAtTrigger(PriceEntry.TABLE_NAME);
 
 
     private static final String BUDGETS_TABLE_CREATE = "CREATE TABLE " + BudgetEntry.TABLE_NAME + " ("
@@ -192,7 +198,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + BudgetEntry.COLUMN_CREATED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + BudgetEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + "FOREIGN KEY (" 	+ BudgetEntry.COLUMN_RECURRENCE_UID + ") REFERENCES " + RecurrenceEntry.TABLE_NAME + " (" + RecurrenceEntry.COLUMN_UID + ") "
-            + ");" + createUpdatedAtTrigger(BudgetEntry.TABLE_NAME);
+            + ");";
+    private static final String BUDGETS_TABLE_TRIGGER = createUpdatedAtTrigger(BudgetEntry.TABLE_NAME);
 
     private static final String BUDGET_AMOUNTS_TABLE_CREATE = "CREATE TABLE " + BudgetAmountEntry.TABLE_NAME + " ("
             + BudgetAmountEntry._ID                   + " integer primary key autoincrement, "
@@ -206,7 +213,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             + BudgetAmountEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
             + "FOREIGN KEY (" 	+ BudgetAmountEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
             + "FOREIGN KEY (" 	+ BudgetAmountEntry.COLUMN_BUDGET_UID + ") REFERENCES " + BudgetEntry.TABLE_NAME + " (" + BudgetEntry.COLUMN_UID + ") ON DELETE CASCADE "
-            + ");" + createUpdatedAtTrigger(BudgetAmountEntry.TABLE_NAME);
+            + ");";
+    private static final String BUDGET_AMOUNTS_TABLE_TRIGGER = createUpdatedAtTrigger(BudgetAmountEntry.TABLE_NAME);
 
 
     private static final String RECURRENCE_TABLE_CREATE = "CREATE TABLE " + RecurrenceEntry.TABLE_NAME + " ("
@@ -308,14 +316,22 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private void createDatabaseTables(SQLiteDatabase db) {
         Log.i(LOG_TAG, "Creating database tables");
         db.execSQL(ACCOUNTS_TABLE_CREATE);
+        db.execSQL(ACCOUNTS_TABLE_TRIGGER);
         db.execSQL(TRANSACTIONS_TABLE_CREATE);
+        db.execSQL(TRANSACTIONS_TABLE_TRIGGER);
         db.execSQL(SPLITS_TABLE_CREATE);
+        db.execSQL(SPLITS_TABLE_TRIGGER);
         db.execSQL(SCHEDULED_ACTIONS_TABLE_CREATE);
+        db.execSQL(SCHEDULED_ACTIONS_TABLE_TRIGGER);
         db.execSQL(COMMODITIES_TABLE_CREATE);
+        db.execSQL(COMMODITIES_TABLE_TRIGGER);
         db.execSQL(PRICES_TABLE_CREATE);
+        db.execSQL(PRICES_TABLE_TRIGGER;
         db.execSQL(RECURRENCE_TABLE_CREATE);
         db.execSQL(BUDGETS_TABLE_CREATE);
+        db.execSQL(BUDGETS_TABLE_TRIGGER);
         db.execSQL(BUDGET_AMOUNTS_TABLE_CREATE);
+	db.execSQL(BUDGET_AMOUNTS_TABLE_TRIGGER);
 
 
         String createAccountUidIndex = "CREATE UNIQUE INDEX '" + AccountEntry.INDEX_UID + "' ON "

--- a/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
@@ -326,7 +326,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL(COMMODITIES_TABLE_CREATE);
         db.execSQL(COMMODITIES_TABLE_TRIGGER);
         db.execSQL(PRICES_TABLE_CREATE);
-        db.execSQL(PRICES_TABLE_TRIGGER;
+        db.execSQL(PRICES_TABLE_TRIGGER);
         db.execSQL(RECURRENCE_TABLE_CREATE);
         db.execSQL(BUDGETS_TABLE_CREATE);
         db.execSQL(BUDGETS_TABLE_TRIGGER);

--- a/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/DatabaseHelper.java
@@ -331,7 +331,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL(BUDGETS_TABLE_CREATE);
         db.execSQL(BUDGETS_TABLE_TRIGGER);
         db.execSQL(BUDGET_AMOUNTS_TABLE_CREATE);
-	db.execSQL(BUDGET_AMOUNTS_TABLE_TRIGGER);
+        db.execSQL(BUDGET_AMOUNTS_TABLE_TRIGGER);
 
 
         String createAccountUidIndex = "CREATE UNIQUE INDEX '" + AccountEntry.INDEX_UID + "' ON "

--- a/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
@@ -521,7 +521,8 @@ public class MigrationHelper {
                     + ScheduledActionEntry.COLUMN_EXECUTION_COUNT+ " integer default 0, "
                     + ScheduledActionEntry.COLUMN_CREATED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + ScheduledActionEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME));
 
 
             //==============================BEGIN TABLE MIGRATIONS ========================================
@@ -545,7 +546,8 @@ public class MigrationHelper {
                     + AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID + " varchar(255), "
                     + AccountEntry.COLUMN_CREATED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + AccountEntry.COLUMN_MODIFIED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(AccountEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(AccountEntry.TABLE_NAME));
 
             // initialize new account table with data from old table
             db.execSQL("INSERT INTO " + AccountEntry.TABLE_NAME + " ( "
@@ -594,7 +596,8 @@ public class MigrationHelper {
                     + TransactionEntry.COLUMN_CREATED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + TransactionEntry.COLUMN_MODIFIED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" + TransactionEntry.COLUMN_SCHEDX_ACTION_UID + ") REFERENCES " + ScheduledActionEntry.TABLE_NAME + " (" + ScheduledActionEntry.COLUMN_UID + ") ON DELETE SET NULL "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(TransactionEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(TransactionEntry.TABLE_NAME));
 
             // initialize new transaction table with data from old table
             db.execSQL("INSERT INTO " + TransactionEntry.TABLE_NAME + " ( "
@@ -634,7 +637,8 @@ public class MigrationHelper {
                     + SplitEntry.COLUMN_MODIFIED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" + SplitEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
                     + "FOREIGN KEY (" + SplitEntry.COLUMN_TRANSACTION_UID + ") REFERENCES " + TransactionEntry.TABLE_NAME + " (" + TransactionEntry.COLUMN_UID + ") ON DELETE CASCADE "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
 
             // initialize new split table with data from old table
             db.execSQL("INSERT INTO " + SplitEntry.TABLE_NAME + " ( "
@@ -878,7 +882,8 @@ public class MigrationHelper {
                     + CommodityEntry.COLUMN_QUOTE_FLAG  + " integer not null, "
                     + CommodityEntry.COLUMN_CREATED_AT  + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + CommodityEntry.COLUMN_MODIFIED_AT + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(CommodityEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(CommodityEntry.TABLE_NAME));
             db.execSQL("CREATE UNIQUE INDEX '" + CommodityEntry.INDEX_UID
                     + "' ON " + CommodityEntry.TABLE_NAME + "(" + CommodityEntry.COLUMN_UID + ")");
 
@@ -925,7 +930,8 @@ public class MigrationHelper {
                     + "UNIQUE (" + PriceEntry.COLUMN_COMMODITY_UID + ", " + PriceEntry.COLUMN_CURRENCY_UID + ") ON CONFLICT REPLACE, "
                     + "FOREIGN KEY (" 	+ PriceEntry.COLUMN_COMMODITY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") ON DELETE CASCADE, "
                     + "FOREIGN KEY (" 	+ PriceEntry.COLUMN_CURRENCY_UID + ") REFERENCES " + CommodityEntry.TABLE_NAME + " (" + CommodityEntry.COLUMN_UID + ") ON DELETE CASCADE "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(PriceEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(PriceEntry.TABLE_NAME));
             db.execSQL("CREATE UNIQUE INDEX '" + PriceEntry.INDEX_UID
                     + "' ON " + PriceEntry.TABLE_NAME + "(" + PriceEntry.COLUMN_UID + ")");
 
@@ -949,7 +955,8 @@ public class MigrationHelper {
                     + SplitEntry.COLUMN_MODIFIED_AT      + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
                     + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_TRANSACTION_UID + ") REFERENCES " + TransactionEntry.TABLE_NAME + " (" + TransactionEntry.COLUMN_UID + ") ON DELETE CASCADE "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
 
             // initialize new split table with data from old table
             db.execSQL("INSERT INTO " + SplitEntry.TABLE_NAME + " ( "
@@ -1255,8 +1262,8 @@ public class MigrationHelper {
                     + RecurrenceEntry.COLUMN_PERIOD_START   + " timestamp not null, "
                     + RecurrenceEntry.COLUMN_PERIOD_END   + " timestamp, "
                     + RecurrenceEntry.COLUMN_CREATED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
-                    + RecurrenceEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP); "
-                    + DatabaseHelper.createUpdatedAtTrigger(RecurrenceEntry.TABLE_NAME));
+                    + RecurrenceEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP); ");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(RecurrenceEntry.TABLE_NAME));
 
             db.execSQL("CREATE TABLE " + BudgetEntry.TABLE_NAME + " ("
                     + BudgetEntry._ID                   + " integer primary key autoincrement, "
@@ -1268,7 +1275,8 @@ public class MigrationHelper {
                     + BudgetEntry.COLUMN_CREATED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + BudgetEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" 	+ BudgetEntry.COLUMN_RECURRENCE_UID + ") REFERENCES " + RecurrenceEntry.TABLE_NAME + " (" + RecurrenceEntry.COLUMN_UID + ") "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(BudgetEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(BudgetEntry.TABLE_NAME));
 
             db.execSQL("CREATE UNIQUE INDEX '" + BudgetEntry.INDEX_UID
                     + "' ON " + BudgetEntry.TABLE_NAME + "(" + BudgetEntry.COLUMN_UID + ")");
@@ -1285,7 +1293,8 @@ public class MigrationHelper {
                     + BudgetAmountEntry.COLUMN_MODIFIED_AT    + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" 	+ BudgetAmountEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
                     + "FOREIGN KEY (" 	+ BudgetAmountEntry.COLUMN_BUDGET_UID + ") REFERENCES " + BudgetEntry.TABLE_NAME + " (" + BudgetEntry.COLUMN_UID + ") ON DELETE CASCADE "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(BudgetAmountEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(BudgetAmountEntry.TABLE_NAME));
 
             db.execSQL("CREATE UNIQUE INDEX '" + BudgetAmountEntry.INDEX_UID
                     + "' ON " + BudgetAmountEntry.TABLE_NAME + "(" + BudgetAmountEntry.COLUMN_UID + ")");
@@ -1315,7 +1324,8 @@ public class MigrationHelper {
                     + ScheduledActionEntry.COLUMN_CREATED_AT        + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + ScheduledActionEntry.COLUMN_MODIFIED_AT       + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" 	+ ScheduledActionEntry.COLUMN_RECURRENCE_UID + ") REFERENCES " + RecurrenceEntry.TABLE_NAME + " (" + RecurrenceEntry.COLUMN_UID + ") "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(ScheduledActionEntry.TABLE_NAME));
 
 
             // initialize new transaction table with data from old table
@@ -1408,7 +1418,8 @@ public class MigrationHelper {
                     + SplitEntry.COLUMN_MODIFIED_AT     + " TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
                     + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_ACCOUNT_UID + ") REFERENCES " + AccountEntry.TABLE_NAME + " (" + AccountEntry.COLUMN_UID + ") ON DELETE CASCADE, "
                     + "FOREIGN KEY (" 	+ SplitEntry.COLUMN_TRANSACTION_UID + ") REFERENCES " + TransactionEntry.TABLE_NAME + " (" + TransactionEntry.COLUMN_UID + ") ON DELETE CASCADE "
-                    + ");" + DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
+                    + ");");
+            db.execSQL(DatabaseHelper.createUpdatedAtTrigger(SplitEntry.TABLE_NAME));
 
             db.execSQL("INSERT INTO " + SplitEntry.TABLE_NAME + " ( "
                     + SplitEntry._ID                    + " , "


### PR DESCRIPTION
Hello,
I've spotted misuses of multiple SQL statements in some execSQL() calls. In fact, the triggers do not get created by SQLite like this. Please consider reviewing and fixing it.
Best,
Csaba