### PR TITLE
Removing time zone in TIME_FORMATTER to comply with desktop gnucash's…

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlHelper.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlHelper.java
@@ -147,7 +147,7 @@ public abstract class GncXmlHelper {
 
     public static final String RECURRENCE_VERSION           = "1.0.0";
     public static final String BOOK_VERSION                 = "2.0.0";
-    public static final SimpleDateFormat TIME_FORMATTER     = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US);
+    public static final SimpleDateFormat TIME_FORMATTER     = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
     public static final SimpleDateFormat DATE_FORMATTER     = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
     public static final String KEY_PLACEHOLDER              = "placeholder";


### PR DESCRIPTION
Hello everyone,
I had some issue when importing my account file generated with gnucash on windows, version 3.5 (build 3.5+ (2019-03-30). After doing a debug, it seems that the date format in my xml file doesn't include a timezone while the TIME_FORMATTER value looks for it.
I removed the timezone to make importation working, but I don't know if some other versions would include timezone in the xml file.