### PR TITLE
Use ₽ sign to designate Russian ruble, instead of "руб"

### DIFF
--- a/app/src/main/res/raw/iso_4217_currencies.xml
+++ b/app/src/main/res/raw/iso_4217_currencies.xml
@@ -2161,7 +2161,7 @@
         exchange-code="643"
         parts-per-unit="100"
         smallest-fraction="100"
-        local-symbol="руб"
+        local-symbol="₽"
     />
     <!-- "RWF" - "Rwanda Franc"
     -->


### PR DESCRIPTION
https://github.com/codinguser/gnucash-android/issues/861