### PR TITLE
#855 v2 double back button pressed

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -30,6 +30,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
@@ -42,6 +43,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.PreferenceManager;
 import android.util.Log;
 import android.util.SparseArray;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -130,11 +132,38 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
     private SparseArray<Refreshable> mFragmentPageReferenceMap = new SparseArray<>();
 
     /**
+     * DoubleBackPressed attributes
+     *
+     * @author warrott
+     */
+
+    // true if backPress button has already been pressed recently
+    private boolean mDoubleBackButtonPressedOnce;
+
+    // Runnable to consider BackPress button not more pressed recently
+    private final Runnable mResetDoubleBackPressedStatusRunnable = new Runnable() {
+        @Override
+        public void run() {
+
+            // BackPress button is not more considered pressed recently
+            mDoubleBackButtonPressedOnce = false;
+        }
+    };
+
+    // Android handler to delay actions
+    private Handler mHandler = new Handler();
+
+    // Toast
+    private Toast     mToast;
+    /**
      * ViewPager which manages the different tabs
      */
-    @BindView(R.id.pager) ViewPager mViewPager;
-    @BindView(R.id.fab_create_account) FloatingActionButton mFloatingActionButton;
-    @BindView(R.id.coordinatorLayout) CoordinatorLayout mCoordinatorLayout;
+    @BindView(R.id.pager)
+            ViewPager mViewPager;
+    @BindView(R.id.fab_create_account)
+    FloatingActionButton mFloatingActionButton;
+    @BindView(R.id.coordinatorLayout)
+    CoordinatorLayout mCoordinatorLayout;
 
     /**
      * Configuration for rating the app
@@ -221,6 +250,7 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
     @Override
 	public void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
 
         final Intent intent = getIntent();
@@ -267,6 +297,12 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
                 startActivityForResult(addAccountIntent, AccountsActivity.REQUEST_EDIT_ACCOUNT);
             }
         });
+
+        // Prepare a Toast message
+        mToast = Toast.makeText(getApplicationContext(),
+                                R.string.double_back_press_exit_msg,
+                                Toast.LENGTH_SHORT);
+        mToast.setGravity(Gravity.CENTER,0,0);
 	}
 
     @Override
@@ -344,6 +380,14 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
             //default to using double entry and save the preference explicitly
             prefs.edit().putBoolean(getString(R.string.key_use_double_entry), true).apply();
+
+            // Default preference to use double back button press to exit
+            prefs.edit()
+                 .putBoolean(getString(R.string.key_use_double_back_button_press_to_quit),
+                             true)
+                 .apply();
+
+            // Finish Activity
             finish();
             return;
         }
@@ -357,9 +401,69 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
     @Override
     protected void onDestroy() {
+
         super.onDestroy();
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         preferences.edit().putInt(LAST_OPEN_TAB_INDEX, mViewPager.getCurrentItem()).apply();
+
+        //
+        // Remove callback to avoid memory leak
+        //
+
+        if (mHandler != null) {
+            // There is an Android handler
+
+            mHandler.removeCallbacks(mResetDoubleBackPressedStatusRunnable);
+        }
+
+    }
+
+    /**
+     * Gérer un double BackPressed pour quitter l'application
+     */
+    @Override
+    public void onBackPressed() {
+
+        // Get Preference about double back button press to exit
+        boolean prefShallUseDoubleBackPressToExit = PreferenceManager.getDefaultSharedPreferences(this)
+                                                                     .getBoolean(getString(R.string.key_use_double_back_button_press_to_quit),
+                                                                                 true);
+
+        if (mDoubleBackButtonPressedOnce || !prefShallUseDoubleBackPressToExit) {
+            // BackPress button has already been pressed recently OR shall not use double back press to exit
+
+            //
+            // Do not show the Toast anymore
+            //
+
+            if (mToast != null) {
+                // There is a Toast
+
+                // Do not show the Toast anymore
+                mToast.cancel();
+
+            } else {
+                // There is no Toast
+
+                // NTD
+            }
+
+            // Perform BackPress
+            super.onBackPressed();
+
+        } else {
+            // BackPress button has been pressed for the first time AND shall use double back press to exit
+
+            // Notice that button has been pressed once
+            this.mDoubleBackButtonPressedOnce = true;
+
+            // Show a message to explain that user must press again to exit
+            mToast.show();
+
+            // After two seconds, it is not more considered as already pressed
+            mHandler.postDelayed(mResetDoubleBackPressedStatusRunnable,
+                                 2000);
+        }
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -431,45 +431,55 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
     @Override
     public void onBackPressed() {
 
-        // Get Preference about double back button press to exit
-        boolean prefShallUseDoubleBackPressToExit = PreferenceManager.getDefaultSharedPreferences(this)
-                                                                     .getBoolean(getString(R.string.key_use_double_back_button_press_to_quit),
-                                                                                 true);
+        if (isNavigationViewOpen()) {
+            // The main navigation menu is open
 
-        if (mDoubleBackButtonPressedOnce || !prefShallUseDoubleBackPressToExit) {
-            // BackPress button has already been pressed recently OR shall not use double back press to exit
-
-            //
-            // Do not show the Toast anymore
-            //
-
-            if (mToast != null) {
-                // There is a Toast
-
-                // Do not show the Toast anymore
-                mToast.cancel();
-
-            } else {
-                // There is no Toast
-
-                // NTD
-            }
-
-            // Perform BackPress
+            // Close the main navigation menu
             super.onBackPressed();
 
         } else {
-            // BackPress button has been pressed for the first time AND shall use double back press to exit
+            // The main navigation menu is closed
 
-            // Notice that button has been pressed once
-            this.mDoubleBackButtonPressedOnce = true;
+            // Get Preference about double back button press to exit
+            boolean prefShallUseDoubleBackPressToExit = PreferenceManager.getDefaultSharedPreferences(this)
+                                                                         .getBoolean(getString(R.string.key_use_double_back_button_press_to_quit),
+                                                                                     true);
 
-            // Show a message to explain that user must press again to exit
-            mToast.show();
+            if (mDoubleBackButtonPressedOnce || !prefShallUseDoubleBackPressToExit) {
+                // BackPress button has already been pressed recently OR shall not use double back press to exit
 
-            // After two seconds, it is not more considered as already pressed
-            mHandler.postDelayed(mResetDoubleBackPressedStatusRunnable,
-                                 2000);
+                //
+                // Do not show the Toast anymore
+                //
+
+                if (mToast != null) {
+                    // There is a Toast
+
+                    // Do not show the Toast anymore
+                    mToast.cancel();
+
+                } else {
+                    // There is no Toast
+
+                    // NTD
+                }
+
+                // Perform BackPress
+                super.onBackPressed();
+
+            } else {
+                // BackPress button has been pressed for the first time AND shall use double back press to exit
+
+                // Notice that button has been pressed once
+                this.mDoubleBackButtonPressedOnce = true;
+
+                // Show a message to explain that user must press again to exit
+                mToast.show();
+
+                // After two seconds, it is not more considered as already pressed
+                mHandler.postDelayed(mResetDoubleBackPressedStatusRunnable,
+                                     2000);
+            }
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -49,6 +49,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.crashlytics.android.Crashlytics;
@@ -302,7 +303,13 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
         mToast = Toast.makeText(getApplicationContext(),
                                 R.string.double_back_press_exit_msg,
                                 Toast.LENGTH_SHORT);
-        mToast.setGravity(Gravity.CENTER,0,0);
+
+        // Align-Center text inside the Toast
+        TextView toastTextView = (TextView) mToast.getView()
+                                                  .findViewById(android.R.id.message);
+        if (toastTextView != null) {
+            toastTextView.setGravity(Gravity.CENTER);
+        }
 	}
 
     @Override

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -210,10 +210,11 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home){
-            if (!mDrawerLayout.isDrawerOpen(mNavigationView))
+            if (!isNavigationViewOpen()) {
                 mDrawerLayout.openDrawer(mNavigationView);
-            else
-                mDrawerLayout.closeDrawer(mNavigationView);
+            } else {
+                closeNavigationView();
+            }
             return true;
         }
 
@@ -286,7 +287,7 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
                 UserVoice.launchUserVoice(this);
                 break;
         }
-        mDrawerLayout.closeDrawer(mNavigationView);
+        closeNavigationView();
     }
 
     @Override
@@ -319,7 +320,7 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
             Intent intent = new Intent(this, PreferenceActivity.class);
             intent.setAction(PreferenceActivity.ACTION_MANAGE_BOOKS);
             startActivity(intent);
-            mDrawerLayout.closeDrawer(mNavigationView);
+            closeNavigationView();
             return true;
         }
         BooksDbAdapter booksDbAdapter = BooksDbAdapter.getInstance();
@@ -332,9 +333,17 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
         return true;
     }
 
-    public void onClickAppTitle(View view){
+    protected void onClickAppTitle(View view) {
+
+        closeNavigationView();
+
+        // Do not launch AccountsActivity to stay on current Activity
+//        AccountsActivity.start(this);
+    }
+
+    protected void closeNavigationView() {
+
         mDrawerLayout.closeDrawer(mNavigationView);
-        AccountsActivity.start(this);
     }
 
     public void onClickBook(View view){
@@ -353,5 +362,33 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
         menu.add(0, ID_MANAGE_BOOKS, maxRecent, R.string.menu_manage_books);
 
         popup.show();
+    }
+
+    @Override
+    public void onBackPressed() {
+
+        if (isNavigationViewOpen()) {
+            // The main navigation menu is open
+
+            // Close the main navigation menu
+//            mDrawerLayout.closeDrawer(mNavigationView);
+            onClickAppTitle(getCurrentFocus());
+
+        } else {
+            // The main navigation menu is closed
+
+            // Close the Activity
+            super.onBackPressed();
+        }
+    }
+
+    /**
+     * Return true if main navigation menu is open
+     *
+     * @return true if main navigation menu is open
+     */
+    protected boolean isNavigationViewOpen() {
+
+        return mDrawerLayout.isDrawerOpen(mNavigationView);
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
@@ -125,6 +125,22 @@ public class GeneralPreferenceFragment extends PreferenceFragmentCompat implemen
                     .putBoolean(getString(R.string.key_use_account_color), Boolean.valueOf(newValue.toString()))
                     .commit();
         }
+
+        //
+        // Preference : use_double_back_button_press_to_quit
+        //
+
+        if (preference.getKey()
+                      .equals(getString(R.string.key_use_double_back_button_press_to_quit))) {
+
+            // Store the new value of the Preference
+            getPreferenceManager().getSharedPreferences()
+                                  .edit()
+                                  .putBoolean(getString(R.string.key_use_double_back_button_press_to_quit),
+                                              Boolean.valueOf(newValue.toString()))
+                                  .commit();
+        }
+
         return true;
     }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -446,4 +446,8 @@
   <string name="label_select_destination_after_export">Sélectionnez la destination une fois l\'exportation terminée</string>
   <string name="label_dropbox_export_destination">Exporter dans le dossier \'/Apps/GnuCash Android/\' sur Dropbox</string>
   <string name="title_section_preferences">Préférences</string>
+    <string name="double_back_press_exit_msg">Cliquez à nouveau sur BACK pour Quitter\n(ou modifiez les Préférences Générales)</string>
+    <string name="prefs_ui_category_title">Préférences d\'ergonomie</string>
+    <string name="prefs_ui_title_use_double_back_button_press_to_quit">Double confirmation pour Quitter</string>
+    <string name="prefs_ui_summary_use_double_back_button_press_to_quit">Appuyer deux fois de suite sur le bouton \"BACK\" pour Quitter l\'application</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -31,6 +31,7 @@
     <string name="key_google_drive_app_folder_id" translatable="false">google_drive_app_folder</string>
     <string name="key_enable_crashlytics" translatable="false">enable_crashlytics</string>
     <string name="key_use_account_color" translatable="false">use_account_color</string>
+    <string name="key_use_double_back_button_press_to_quit" translatable="false">use_double_back_button_press_to_quit</string>
     <string name="key_last_export_destination">last_export_destination</string>
     <string name="key_use_compact_list">use_compact_list</string>
     <string name="key_prefs_header_general">prefs_header_general</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,4 +500,8 @@
         <item>Tax</item>
         <item>Placeholder</item>
     </string-array>
+    <string name="double_back_press_exit_msg">Please click BACK again to Quit\n(or Change General Preferences)</string>
+    <string name="prefs_ui_category_title">User Interface Preferences</string>
+    <string name="prefs_ui_title_use_double_back_button_press_to_quit">Use double back button press to quit</string>
+    <string name="prefs_ui_summary_use_double_back_button_press_to_quit">Shall click twice on back button to actually quit GnuCashAndroid</string>
 </resources>

--- a/app/src/main/res/xml/fragment_general_preferences.xml
+++ b/app/src/main/res/xml/fragment_general_preferences.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory android:title="@string/prefs_ui_category_title">
+        <CheckBoxPreference
+            android:key="@string/key_use_double_back_button_press_to_quit"
+            android:title="@string/prefs_ui_title_use_double_back_button_press_to_quit"
+            android:summary="@string/prefs_ui_summary_use_double_back_button_press_to_quit" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/title_passcode_preferences">
-        <CheckBoxPreference android:key="@string/key_enable_passcode"
-            android:title="@string/title_enable_passcode"/>
-        <Preference android:key="@string/key_change_passcode"
+        <CheckBoxPreference
+            android:key="@string/key_enable_passcode"
+            android:title="@string/title_enable_passcode" />
+        <Preference
+            android:key="@string/key_change_passcode"
             android:title="@string/title_change_passcode"
             android:dependency="@string/key_enable_passcode" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/title_report_prefs">
-        <CheckBoxPreference android:key="@string/key_use_account_color"
+        <CheckBoxPreference
+            android:key="@string/key_use_account_color"
             android:title="@string/title_use_account_color"
             android:summary="@string/summary_use_account_color" />
     </PreferenceCategory>
-
 
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.5.2'
+		classpath 'com.android.tools.build:gradle:3.5.3'
 		classpath 'io.fabric.tools:gradle:1.31.2'
 		classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
 	}


### PR DESCRIPTION
Hi,

This is my first Pull Request, I hope everything is OK.

The purpose of this pull Request is to add a Preference to GnuCashAndroid in order to click the back button twice instead once to quit the app.

By default the "Press back twice mode" is set to true.
You can change it in the "General Preferences".

When you are on the Account Activity and click back button, a toast message appears to ask you clicking again to quit. If you don't click within 3 seconds, the app does not quit.

Let me know if something is missing.

Thanks