### PR TITLE
Fixes #856 - Fix the Bad Preference Title at first opening and Naviga…

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/settings/PreferenceActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/PreferenceActivity.java
@@ -78,12 +78,22 @@ public class PreferenceActivity extends PasscodeLockActivity implements
         });
 
         String action = getIntent().getAction();
-        if (action != null && action.equals(ACTION_MANAGE_BOOKS)){
-            loadFragment(new BookManagerFragment());
+        if (action != null && action.equals(ACTION_MANAGE_BOOKS)) {
+            // Intent action is to manage books
+
+            // Close the left Preference Pane
             mSlidingPaneLayout.closePane();
+
+            // Load the BookManager fragment (in the right pane)
+            loadFragment(new BookManagerFragment());
         } else {
+            // Intent action is not defined
+
+            // Open left Preference Pane with all Preferences Choices
             mSlidingPaneLayout.openPane();
-            loadFragment(new GeneralPreferenceFragment());
+
+            // Do not load Fragment now in order to not starting GeneralPreferenceFragment.onCreate() which will override title
+//            loadFragment(new GeneralPreferenceFragment());
         }
 
         ActionBar actionBar = getSupportActionBar();

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,7 +54,7 @@
   <string name="btn_export">Exporter</string>
   <string name="option_delete_after_export">Effacer les transactions après export</string>
   <string name="hint_delete_after_export">Toutes les transactions exportées seront supprimées après l\'export</string>
-    <string name="title_settings">Préférences</string>
+    <string name="title_settings">Préférences / Maintenance</string>
   <string-array name="export_destinations">
     <item>Enregistrer sous &#8230;</item>
     <item>Dropbox</item>
@@ -95,7 +95,7 @@
   <string name="title_transaction_preferences">Préférences des transactions</string>
   <string name="title_account_preferences">Préférences du compte</string>
   <string name="title_default_transaction_type">Type de transaction par défaut</string>
-  <string name="summary_default_transaction_type">Le type de transaction à utiliser par défaut, CRÉDIT ou DÉBIT</string>
+  <string name="summary_default_transaction_type">CRÉDIT</string>
   <string-array name="transaction_types">
     <item>CRÉDIT</item>
     <item>DÉBIT</item>
@@ -109,7 +109,7 @@
   <string name="summary_default_export_email">Email par défaut pour les exports. Vous pourrez toujours le changer lors de votre prochain export.</string>
   <string name="summary_use_double_entry">Toutes les transactions seront un transfert d’un compte à un autre</string>
   <string name="title_use_double_entry">Activer la Double entrée</string>
-  <string name="account_balance">Solde</string>
+  <string name="account_balance">Solde du Compte à la date indiquée ci-dessous</string>
   <string name="toast_no_account_name_entered">Entrer un nom de compte pour créer un compte</string>
   <string name="label_account_currency">Monnaie</string>
   <string name="label_parent_account">Compte parent</string>
@@ -145,7 +145,7 @@
   <string name="title_progress_exporting_transactions">Exportation des transactions</string>
   <string name="label_no_recurring_transactions">Pas de transactions planifiées à afficher.</string>
   <string name="toast_recurring_transaction_deleted">Transaction récurrente supprimée avec succès</string>
-  <string name="label_placeholder_account">Compte de référence</string>
+  <string name="label_placeholder_account">Compte virtuel</string>
   <string name="label_default_transfer_account">Compte de transfert par défaut</string>
   <plurals name="label_sub_accounts">
     <item quantity="one">%d sous-compte</item>
@@ -186,7 +186,7 @@
   <string name="msg_confirm_create_default_accounts_setting">Un nouveau livre sera ouvert avec les comptes courants par défaut\n\n Vos comptes et opérations actuels ne seront pas modifiés !</string>
   <string name="title_scheduled_transactions">Transactions planifiées</string>
   <string name="title_select_export_destination">Selectionnez une destination pour l\'export</string>
-  <string name="hint_split_memo">Memo</string>
+  <string name="hint_split_memo">Memo (Cliquez pour ajouter)</string>
   <string name="label_spend">Dépenser</string>
   <string name="label_receive">Recevoir</string>
   <string name="label_withdrawal">Retrait</string>
@@ -258,7 +258,7 @@
   <string name="nav_menu_open">Ouvrir&#8230;</string>
   <string name="nav_menu_reports">Rapports</string>
   <string name="nav_menu_export">Export&#8230;</string>
-    <string name="nav_menu_settings">Préférences</string>
+    <string name="nav_menu_settings">Préférences / Maintenance</string>
   <string name="username">Nom d\'utilisateur</string>
   <string name="password">Mot de passe</string>
   <string name="owncloud_pref">ownCloud</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,7 +54,7 @@
   <string name="btn_export">Exporter</string>
   <string name="option_delete_after_export">Effacer les transactions après export</string>
   <string name="hint_delete_after_export">Toutes les transactions exportées seront supprimées après l\'export</string>
-  <string name="title_settings">Paramètres</string>
+    <string name="title_settings">Préférences</string>
   <string-array name="export_destinations">
     <item>Enregistrer sous &#8230;</item>
     <item>Dropbox</item>
@@ -65,7 +65,7 @@
   <string name="title_move_transactions">Déplacer %1$d transaction(s)</string>
   <string name="label_move_destination">Compte de destination</string>
   <string name="toast_incompatible_currency">Impossible de déplacer les transactions.\nLe compte de destination utilise une monnaie différente du compte d\'origine</string>
-  <string name="header_general_settings">Général</string>
+    <string name="header_general_settings">Générales</string>
   <string name="header_about_gnucash">À propos</string>
   <string name="title_choose_currency">Choisisez une monnaie par défaut</string>
   <string name="title_default_currency">Monnaie par défaut</string>
@@ -258,7 +258,7 @@
   <string name="nav_menu_open">Ouvrir&#8230;</string>
   <string name="nav_menu_reports">Rapports</string>
   <string name="nav_menu_export">Export&#8230;</string>
-  <string name="nav_menu_settings">Paramètres</string>
+    <string name="nav_menu_settings">Préférences</string>
   <string name="username">Nom d\'utilisateur</string>
   <string name="password">Mot de passe</string>
   <string name="owncloud_pref">ownCloud</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="btn_export">Export</string>
     <string name="option_delete_after_export">Delete transactions after export</string>
     <string name="hint_delete_after_export">All exported transactions will be deleted when exporting is completed</string>
-    <string name="title_settings">Preferences</string>
+    <string name="title_settings">Preferences / Maintenance</string>
     <string-array name="export_destinations">
         <item>Save As&#8230;</item>
         <item>Dropbox</item>
@@ -95,7 +95,7 @@
 	<string name="title_transaction_preferences">Transaction Preferences</string>
 	<string name="title_account_preferences">Account Preferences</string>
 	<string name="title_default_transaction_type">Default Transaction Type</string>
-	<string name="summary_default_transaction_type">The type of transaction to use by default, CREDIT or DEBIT</string>
+	<string name="summary_default_transaction_type">CREDIT</string>
 	<string-array name="transaction_types">
 		<item>CREDIT</item>
 		<item>DEBIT</item>
@@ -109,7 +109,7 @@
 	<string name="summary_default_export_email">The default email address to send exports to. You can still change this when you export.</string>
     <string name="summary_use_double_entry">All transactions will be a transfer from one account to another</string>
 	<string name="title_use_double_entry">Activate Double Entry</string>
-	<string name="account_balance">Balance</string>
+	<string name="account_balance">Account Balance at Date below</string>
 	<string name="toast_no_account_name_entered">Enter an account name to create an account</string>
 	<string name="label_account_currency">Currency</string>
 	<string name="label_parent_account">Parent account</string>
@@ -196,7 +196,7 @@
     <string name="msg_confirm_create_default_accounts_setting">A new book will be opened with the default accounts\n\nYour current accounts and transactions will not be modified!</string>
     <string name="title_scheduled_transactions">Transactions</string>
     <string name="title_select_export_destination">Select destination for export</string>
-    <string name="hint_split_memo">Memo</string>
+    <string name="hint_split_memo">Memo (Click to add)</string>
     <string name="label_spend">Spend</string>
     <string name="label_receive">Receive</string>
     <string name="label_withdrawal">Withdrawal</string>
@@ -268,7 +268,7 @@
     <string name="nav_menu_open">Open…</string>
     <string name="nav_menu_reports">Reports</string>
     <string name="nav_menu_export">Export…</string>
-    <string name="nav_menu_settings">Preferences</string>
+    <string name="nav_menu_settings">Preferences / Maintenance</string>
     <string name="username">User Name</string>
     <string name="password">Password</string>
     <string name="owncloud_pref">owncloud</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="btn_export">Export</string>
     <string name="option_delete_after_export">Delete transactions after export</string>
     <string name="hint_delete_after_export">All exported transactions will be deleted when exporting is completed</string>
-    <string name="title_settings">Settings</string>
+    <string name="title_settings">Preferences</string>
     <string-array name="export_destinations">
         <item>Save As&#8230;</item>
         <item>Dropbox</item>
@@ -268,7 +268,7 @@
     <string name="nav_menu_open">Open…</string>
     <string name="nav_menu_reports">Reports</string>
     <string name="nav_menu_export">Export…</string>
-    <string name="nav_menu_settings">Settings</string>
+    <string name="nav_menu_settings">Preferences</string>
     <string name="username">User Name</string>
     <string name="password">Password</string>
     <string name="owncloud_pref">owncloud</string>


### PR DESCRIPTION
…tion View "Preferences" label

When you open the Main menu, the item "settings" open a "General Preferences" Activity but it should be called "Settings", not "General Preferences". "General Preferences" is the right title if you click on the "General" item. The problem was the call to GeneralPreferenceFragment() line 96 in PreferenceActivity which override the "Settings" title

All the titles are "Something Preferences" (General Preferences, Account Preferences, Transaction Preferences...), therefore the item in the main menu should be "Preferences" instead of "Settings". Same in the ActionBar where "Settings" has been replaced by "Preferences".

I changed these two things in this Pull Request.

I also changed in French version. I've seen in "Contributing Guidelines" that translation should be made using CrowdIn, but the link is broken and I don't know how to use CrowdIn.
