### PR TITLE
Fixes #586 : Remove content of AccountsActivity.AccountViewPagerAdapt…

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -176,8 +176,9 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
         @Override
         public void destroyItem(ViewGroup container, int position, Object object) {
-            super.destroyItem(container, position, object);
-            mFragmentPageReferenceMap.remove(position);
+            // #586 By putting this in comment, there is no more crash, but I don't know if there are side effects
+//            super.destroyItem(container, position, object);
+//            mFragmentPageReferenceMap.remove(position);
         }
 
         @Override


### PR DESCRIPTION
The problem appeared when switching to Recent or Favorites Account Tab and then opening another Book.
The problem did not appear when switching to "All" tab, then opening another book, even having open Recent or Favorites tab before "All" tab.

The Exception was thrown in DatabaseAdapter.getID() by the line :
throw new IllegalArgumentException(mTableName + " with GUID " + uid + " does not exist in the db");
because the uid has been built from cursor given in AccountRecyclerAdapter.AccountsListFragment.onBindViewHolderCursor(AccountViewHolder, Cursor), which is a cursor on the previous Book and this uid does not exists in the newly opened Book.

I fixed the issue in (7b6ebb398c89459ffe479d519ee5a69db2449ae9) by removing the content of AccountsActivity.AccountViewPagerAdapter.destroyItem().

I don't know why this fixed the problem, but I found it by discovering that destroyItem() was not called when switching to "All" Tab, but was when switching to Recent or Favorites Tab.
