### PR TITLE
#876 balance liability

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
@@ -74,7 +74,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
 	/**
 	 * Transactions database adapter for manipulating transactions associated with accounts
 	 */
-    private final TransactionsDbAdapter mTransactionsAdapter;
+    private final TransactionsDbAdapter mTransactionsDbAdapter;
 
     /**
      * Commodities database adapter for commodity manipulation
@@ -101,7 +101,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
                 AccountEntry.COLUMN_PARENT_ACCOUNT_UID,
                 AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID
         });
-        mTransactionsAdapter = transactionsDbAdapter;
+        mTransactionsDbAdapter = transactionsDbAdapter;
         mCommoditiesDbAdapter = new CommoditiesDbAdapter(db);
     }
 
@@ -129,7 +129,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
                 AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID
         });
 
-        mTransactionsAdapter = new TransactionsDbAdapter(db, new SplitsDbAdapter(db));
+        mTransactionsDbAdapter = new TransactionsDbAdapter(db, new SplitsDbAdapter(db));
         mCommoditiesDbAdapter = new CommoditiesDbAdapter(db);
     }
 
@@ -150,7 +150,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
 	public void addRecord(@NonNull Account account, UpdateMethod updateMethod){
         Log.d(LOG_TAG, "Replace account to db");
         //in-case the account already existed, we want to update the templates based on it as well
-        List<Transaction> templateTransactions = mTransactionsAdapter.getScheduledTransactionsForAccount(account.getUID());
+        List<Transaction> templateTransactions = mTransactionsDbAdapter.getScheduledTransactionsForAccount(account.getUID());
         super.addRecord(account, updateMethod);
         String accountUID = account.getUID();
 		//now add transactions if there are any
@@ -159,10 +159,10 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
             updateRecord(accountUID, AccountEntry.COLUMN_FULL_NAME, getFullyQualifiedAccountName(accountUID));
             for (Transaction t : account.getTransactions()) {
                 t.setCommodity(account.getCommodity());
-		        mTransactionsAdapter.addRecord(t, updateMethod);
+		        mTransactionsDbAdapter.addRecord(t, updateMethod);
 			}
             for (Transaction transaction : templateTransactions) {
-                mTransactionsAdapter.addRecord(transaction, UpdateMethod.update);
+                mTransactionsDbAdapter.addRecord(transaction, UpdateMethod.update);
             }
         }
 	}
@@ -187,12 +187,12 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         List<Transaction> transactionList = new ArrayList<>(accountList.size()*2);
         for (Account account : accountList) {
             transactionList.addAll(account.getTransactions());
-            transactionList.addAll(mTransactionsAdapter.getScheduledTransactionsForAccount(account.getUID()));
+            transactionList.addAll(mTransactionsDbAdapter.getScheduledTransactionsForAccount(account.getUID()));
         }
         long nRow = super.bulkAddRecords(accountList, updateMethod);
 
         if (nRow > 0 && !transactionList.isEmpty()){
-            mTransactionsAdapter.bulkAddRecords(transactionList, updateMethod);
+            mTransactionsDbAdapter.bulkAddRecords(transactionList, updateMethod);
         }
         return nRow;
     }
@@ -374,7 +374,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         try {
             descendantAccountUIDs.add(accountUID); //add account to descendants list just for convenience
             for (String descendantAccountUID : descendantAccountUIDs) {
-                mTransactionsAdapter.deleteTransactionsForAccount(descendantAccountUID);
+                mTransactionsDbAdapter.deleteTransactionsForAccount(descendantAccountUID);
             }
 
             String accountUIDList = "'" + TextUtils.join("','", descendantAccountUIDs) + "'";
@@ -413,7 +413,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
     @Override
     public Account buildModelInstance(@NonNull final Cursor c){
         Account account = buildSimpleAccountInstance(c);
-        account.setTransactions(mTransactionsAdapter.getAllTransactionsForAccount(account.getUID()));
+        account.setTransactions(mTransactionsDbAdapter.getAllTransactionsForAccount(account.getUID()));
 
         return account;
 	}
@@ -801,7 +801,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         String currencyCode = GnuCashApplication.getDefaultCurrencyCode();
 
         Log.d(LOG_TAG, "all account list : " + accountUidList.size());
-        SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
+        SplitsDbAdapter splitsDbAdapter = mTransactionsDbAdapter.getSplitDbAdapter();
 
         return (startTimestamp == -1 && endTimestamp == -1)
                 ? splitsDbAdapter.computeSplitBalance(accountUidList, currencyCode, hasDebitNormalBalance)
@@ -825,7 +825,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
 
     private Money computeBalance(String accountUID, long startTimestamp, long endTimestamp) {
         Log.d(LOG_TAG, "Computing account balance for account ID " + accountUID);
-        String currencyCode = mTransactionsAdapter.getAccountCurrencyCode(accountUID);
+        String currencyCode = mTransactionsDbAdapter.getAccountCurrencyCode(accountUID);
         boolean hasDebitNormalBalance = getAccountType(accountUID).hasDebitNormalBalance();
 
         List<String> accountsList = getDescendantAccountUIDs(accountUID,
@@ -834,7 +834,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         accountsList.add(0, accountUID);
 
         Log.d(LOG_TAG, "all account list : " + accountsList.size());
-        SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
+        SplitsDbAdapter splitsDbAdapter = mTransactionsDbAdapter.getSplitDbAdapter();
         return (startTimestamp == -1 && endTimestamp == -1)
                 ? splitsDbAdapter.computeSplitBalance(accountsList, currencyCode, hasDebitNormalBalance)
                 : splitsDbAdapter.computeSplitBalance(accountsList, currencyCode, hasDebitNormalBalance, startTimestamp, endTimestamp);
@@ -858,7 +858,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
 
         boolean hasDebitNormalBalance = getAccountType(accountUIDList.get(0)).hasDebitNormalBalance();
 
-        SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
+        SplitsDbAdapter splitsDbAdapter = mTransactionsDbAdapter.getSplitDbAdapter();
         Money splitSum = (startTimestamp == -1 && endTimestamp == -1)
                 ? splitsDbAdapter.computeSplitBalance(accountUIDList, currencyCode, hasDebitNormalBalance)
                 : splitsDbAdapter.computeSplitBalance(accountUIDList, currencyCode, hasDebitNormalBalance, startTimestamp, endTimestamp);
@@ -1145,7 +1145,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         Cursor cursor = fetchAccounts(null, null, null);
         List<Transaction> openingTransactions = new ArrayList<>();
         try {
-            SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
+            SplitsDbAdapter splitsDbAdapter = mTransactionsDbAdapter.getSplitDbAdapter();
             while (cursor.moveToNext()) {
                 long id = cursor.getLong(cursor.getColumnIndexOrThrow(AccountEntry._ID));
                 String accountUID = getUID(id);

--- a/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
@@ -541,7 +541,13 @@ public abstract class DatabaseAdapter<Model extends BaseModel> {
             if (cursor.moveToFirst()) {
                 result = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.CommonColumns._ID));
             } else {
-                throw new IllegalArgumentException(mTableName + " with GUID " + uid + " does not exist in the db");
+                throw new IllegalArgumentException("UID ("
+                                                   + uid
+                                                   + ") does not exist in Table ("
+                                                   + mTableName
+                                                   + ") of db ("
+                                                   + mDb.getPath()
+                                                   + ")");
             }
         } finally {
             cursor.close();

--- a/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
@@ -531,12 +531,15 @@ public abstract class DatabaseAdapter<Model extends BaseModel> {
      * @throws IllegalArgumentException if the GUID does not exist in the database
      */
     public long getID(@NonNull String uid){
+
         Cursor cursor = mDb.query(mTableName,
-                new String[] {DatabaseSchema.CommonColumns._ID},
-                DatabaseSchema.CommonColumns.COLUMN_UID + " = ?",
-                new String[]{uid},
-                null, null, null);
+                                  new String[]{DatabaseSchema.CommonColumns._ID},
+                                  DatabaseSchema.CommonColumns.COLUMN_UID + " = ?",
+                                  new String[]{uid},
+                                  null, null, null);
+
         long result = -1;
+
         try{
             if (cursor.moveToFirst()) {
                 result = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.CommonColumns._ID));

--- a/app/src/main/java/org/gnucash/android/db/adapter/SplitsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/SplitsDbAdapter.java
@@ -220,13 +220,18 @@ public class SplitsDbAdapter extends DatabaseAdapter<Split> {
                            + " = 0";
 
         if (startTimestamp != -1 && endTimestamp != -1) {
+
             selection += " AND " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_TIMESTAMP + " BETWEEN ? AND ? ";
             selectionArgs = new String[]{String.valueOf(startTimestamp),
                                          String.valueOf(endTimestamp)};
+
         } else if (startTimestamp == -1 && endTimestamp != -1) {
+
             selection += " AND " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_TIMESTAMP + " <= ?";
             selectionArgs = new String[]{String.valueOf(endTimestamp)};
+
         } else if (startTimestamp != -1/* && endTimestamp == -1*/) {
+
             selection += " AND " + TransactionEntry.TABLE_NAME + "_" + TransactionEntry.COLUMN_TIMESTAMP + " >= ?";
             selectionArgs = new String[]{String.valueOf(startTimestamp)};
         }

--- a/app/src/main/java/org/gnucash/android/export/csv/CsvTransactionsExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/csv/CsvTransactionsExporter.java
@@ -26,7 +26,6 @@ import com.crashlytics.android.Crashlytics;
 import org.gnucash.android.R;
 import org.gnucash.android.export.ExportParams;
 import org.gnucash.android.export.Exporter;
-import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Split;
 import org.gnucash.android.model.Transaction;
 import org.gnucash.android.model.TransactionType;

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -183,9 +183,7 @@ public enum AccountType {
      *         {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
      */
     public void displayBalance(final TextView balanceTextView,
-                               final Money balance,
-                               // TODO TW C 2020-05-23 : A supprimer
-                               final boolean shallDisplayNegativeSignumInSplits) {
+                               final Money balance) {
 
         displayBalance(balanceTextView,
                        balance,

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -190,14 +190,35 @@ public enum AccountType {
         if ((isCreditAmount && !debitCreditInvertedColorAccountType) || (!isCreditAmount && debitCreditInvertedColorAccountType)) {
             // Credit amount and account like Assets, Bank, Cash..., or Debit amount and account like Expense/Income
 
-            // RED
-            colorRes = R.color.debit_red;
+            if (!isExpenseOrIncomeAccount()) {
+                // It is not an Expense/Income account
+
+                // RED
+                colorRes = R.color.debit_red;
+
+            } else {
+                // It is an Expense/Income account
+
+                // PURPLE
+                colorRes = R.color.debit_expense_income;
+            }
 
         } else {
             // Credit amount and account like Expense/Income, or Debit amount and account like Assets, Bank, Cash...)
 
-            // GREEN
-            colorRes = R.color.credit_green;
+            if (!isExpenseOrIncomeAccount()) {
+                // It is not an Expense/Income account
+
+                // GREEN
+                colorRes = R.color.credit_green;
+
+            } else {
+                // It is an Expense/Income account
+
+                // BLUE
+                colorRes = R.color.credit_expense_income;
+            }
+
         }
 
         return GnuCashApplication.getAppContext()

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -256,44 +256,6 @@ public enum AccountType {
         return mNormalBalance == TransactionType.DEBIT;
     }
 
-    /**
-     * Returns balance with the right signum to be displayed
-     *
-     * A Debit is always the addition of a positive amount
-     * A credit is always the substraction of a positive amount
-     * The balance is always Debit - Credit
-     * Therefore :
-     * Debit > Credit => balance is > 0
-     * Debit < Credit => balance is < 0
-     *
-     * But for display, habit is to reduce the use of negative numbers
-     * To achieve this, for accounts which USUALLY have :
-     * Debit > Credit => compute balance as usual
-     * Debit < Credit => negate balance
-     *
-     * @return
-     *      balance with the right signum to be displayed
-     */
-    public Money getBalanceWithSignumForDisplay(final Money balance) {
-
-        final Money balanceWithSignumForDisplay;
-
-        if (hasDebitNormalBalance()) {
-            // Account usually debitor
-
-            balanceWithSignumForDisplay = balance;
-
-        } else {
-            // account usually creditor
-
-            // Negate
-            balanceWithSignumForDisplay = balance.negate();
-        }
-
-        return balanceWithSignumForDisplay;
-    }
-
-
     //
     // Getters/Setters
     //

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.ui.settings.PreferenceActivity;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -41,9 +42,18 @@ public enum AccountType {
                                                                                                          AccountType.BANK));
 
     public final static List<AccountType> LIABLITY_ACCOUNT_TYPES = new ArrayList<AccountType>(Arrays.asList(AccountType.LIABILITY,
-                                                                                                         AccountType.CREDIT));
+                                                                                                            AccountType.CREDIT));
 
     public final static List<AccountType> EQUITY_ACCOUNT_TYPES = new ArrayList<AccountType>(Arrays.asList(AccountType.EQUITY));
+
+    //
+    // Preference Key (must be the same as in donottranslate.xml)
+    //
+
+    public static final String KEY_USE_NORMAL_BALANCE_EXPENSE = "KEY_USE_NORMAL_BALANCE_EXPENSE";
+    public static final String KEY_USE_NORMAL_BALANCE_INCOME  = "KEY_USE_NORMAL_BALANCE_INCOME";
+    public static final String KEY_DEBIT                      = "KEY_DEBIT";
+    public static final String KEY_CREDIT                     = "KEY_CREDIT";
 
 
     /**
@@ -62,6 +72,45 @@ public enum AccountType {
 
         this(TransactionType.CREDIT);
     }
+
+    /**
+     * @return
+     */
+    public TransactionType getDefaultTransactionType() {
+
+
+        String transactionTypePref = PreferenceActivity.getActiveBookSharedPreferences()
+                                                       .getString(GnuCashApplication.getAppContext()
+                                                                                    .getString(R.string.key_default_transaction_type),
+                                                                  KEY_USE_NORMAL_BALANCE_EXPENSE);
+
+        final TransactionType transactionType;
+
+        if (KEY_USE_NORMAL_BALANCE_EXPENSE.equals(transactionTypePref)) {
+            // Use Normal Balance (Expense Mode)
+
+            // Use Account Normal Balance as default, except for Asset which are CREDIT by default
+            transactionType = isAssetAccount()
+                              ? TransactionType.CREDIT
+                              : getNormalBalanceType();
+
+        } else if (KEY_USE_NORMAL_BALANCE_INCOME.equals(transactionTypePref)) {
+            // Use Normal Balance (Income Mode)
+
+            // Use Account Normal Balance as default
+            transactionType = getNormalBalanceType();
+
+        } else {
+            // Not Automatic mode
+
+            // Convert String to Enum
+            transactionType = KEY_DEBIT.equals(transactionTypePref)
+                              ? TransactionType.DEBIT
+                              : TransactionType.CREDIT;
+        }
+        return transactionType;
+    }
+
 
     /**
      * Display the balance of a transaction in a text view and format the text color to match the sign of the amount

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -220,12 +220,13 @@ public enum AccountType {
      */
     public void displayBalanceWithoutCurrency(final TextView transactionBalanceTextView,
                                               final Money transactionBalance,
-                                              final boolean shallDisplayNegativeSignumInSplits) {
+                                              final boolean shallDisplayNegativeSignumInSplits,
+                                              final boolean shallDisplayZero) {
 
         displayBalance(transactionBalanceTextView,
                        transactionBalance,
                        shallDisplayNegativeSignumInSplits,
-                       false,
+                       shallDisplayZero,
                        false);
     }
     /**

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -246,6 +246,44 @@ public enum AccountType {
         return mNormalBalance == TransactionType.DEBIT;
     }
 
+    /**
+     * Returns balance with the right signum to be displayed
+     *
+     * A Debit is always the addition of a positive amount
+     * A credit is always the substraction of a positive amount
+     * The balance is always Debit - Credit
+     * Therefore :
+     * Debit > Credit => balance is > 0
+     * Debit < Credit => balance is < 0
+     *
+     * But for display, habit is to reduce the use of negative numbers
+     * To achieve this, for accounts which USUALLY have :
+     * Debit > Credit => compute balance as usual
+     * Debit < Credit => negate balance
+     *
+     * @return
+     *      balance with the right signum to be displayed
+     */
+    public Money getBalanceWithSignumForDisplay(final Money balance) {
+
+        final Money balanceWithSignumForDisplay;
+
+        if (hasDebitNormalBalance()) {
+            // Account usually debitor
+
+            balanceWithSignumForDisplay = balance;
+
+        } else {
+            // account usually creditor
+
+            // Negate
+            balanceWithSignumForDisplay = balance.negate();
+        }
+
+        return balanceWithSignumForDisplay;
+    }
+
+
     //
     // Getters/Setters
     //

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -59,23 +59,28 @@ public enum AccountType {
     }
 
     AccountType() {
+
         this(TransactionType.CREDIT);
     }
 
     /**
      * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
+     *
      * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
      * @param balance {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
      */
     public void displayBalance(final TextView balanceTextView,
-                               final Money balance) {
+                               final Money balance,
+                               final boolean shallDisplayAbsValue) {
 
         //
         // Display amount
         //
 
-        // TODO TW C 2020-03-06 : Déterminer qui doit dire s'il faut afficher un nombre négatif ou sa valeur absolue
-        balanceTextView.setText(balance.formattedString());
+        balanceTextView.setText(shallDisplayAbsValue
+                                ? balance.abs()
+                                         .formattedString()
+                                : balance.formattedString());
 
         //
         // Define amount color
@@ -103,6 +108,21 @@ public enum AccountType {
         balanceTextView.setTextColor(fontColor);
     }
 
+    /**
+     * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
+     *
+     * @param balanceTextView
+     *         {@link android.widget.TextView} where balance is to be displayed
+     * @param balance
+     *         {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
+     */
+    public void displayBalance(final TextView balanceTextView,
+                               final Money balance) {
+
+        displayBalance(balanceTextView,
+                       balance,
+                       false);
+    }
     /**
      * Compute red/green color according to accountType and isCreditAmount
      *

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -1,5 +1,11 @@
 package org.gnucash.android.model;
 
+import android.support.annotation.ColorInt;
+import android.support.annotation.ColorRes;
+
+import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
+
 /**
  * The type of account
  * This are the different types specified by the OFX format and
@@ -37,6 +43,48 @@ public enum AccountType {
         //nothing to see here, move along
     }
 
+    // TODO TW C 2020-03-06 : Enlever le static
+
+    /**
+     * Compute red/green color according to accountType and isCredit
+     *
+     * @param isCredit
+     * @param accountType
+     *
+     * @return
+     */
+    @ColorInt
+    public static int getAmountColor(final boolean isCredit,
+                                     final AccountType accountType) {
+
+        AccountType tmpAccountType = ((accountType != null)
+                                      ? accountType
+                                      : AccountType.ASSET);
+
+        @ColorRes final int colorRes;
+
+        // TODO TW C 2020-03-06 : Trouver un meilleur nom
+        final boolean specialAccountType = tmpAccountType.isEquityAccount() || tmpAccountType.isResultAccount();
+
+        if ((!specialAccountType && isCredit) || (specialAccountType && !isCredit)) {
+            // TODO TW C 2020-03-02 : commenter
+            // CREDIT
+
+            // RED
+            colorRes = R.color.debit_red;
+
+        } else {
+            // DEBIT
+
+            // GREEN
+            colorRes = R.color.credit_green;
+        }
+
+        return GnuCashApplication.getAppContext()
+                                 .getResources()
+                                 .getColor(colorRes);
+    }
+
     public boolean hasDebitNormalBalance() {
 
         return mNormalBalance == TransactionType.DEBIT;
@@ -49,6 +97,16 @@ public enum AccountType {
     public TransactionType getNormalBalanceType() {
 
         return mNormalBalance;
+    }
+
+    public boolean isAssetAccount() {
+
+        return ASSET.equals(this) || BANK.equals(this) || CASH.equals(this);
+    }
+
+    public boolean isEquityAccount() {
+
+        return EQUITY.equals(this);
     }
 
     // TODO TW C 2020-03-03 : A renommer en anglais

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -60,17 +60,16 @@ public enum AccountType {
     }
 
     // TODO TW C 2020-03-06 : Enlever le static
-
     /**
-     * Compute red/green color according to accountType and isCredit
+     * Compute red/green color according to accountType and isCreditAmount
      *
-     * @param isCredit
+     * @param isCreditAmount
      * @param accountType
      *
      * @return
      */
     @ColorInt
-    public static int getAmountColor(final boolean isCredit,
+    public static int getAmountColor(final boolean isCreditAmount,
                                      final AccountType accountType) {
 
         AccountType tmpAccountType = ((accountType != null)
@@ -79,18 +78,17 @@ public enum AccountType {
 
         @ColorRes final int colorRes;
 
-        // TODO TW C 2020-03-06 : Trouver un meilleur nom
-        final boolean specialAccountType = tmpAccountType.isEquityAccount() || tmpAccountType.isResultAccount();
+        // Accounts for which
+        final boolean debitCreditInvertedColorAccountType = tmpAccountType.isExpenseOrIncomeAccount() || tmpAccountType.isEquityAccount();
 
-        if ((!specialAccountType && isCredit) || (specialAccountType && !isCredit)) {
-            // TODO TW C 2020-03-02 : commenter
-            // CREDIT
+        if ((isCreditAmount && !debitCreditInvertedColorAccountType) || (!isCreditAmount && debitCreditInvertedColorAccountType)) {
+            // Credit amount and account like Assets, Bank, Cash..., or Debit amount and account like Expense/Income
 
             // RED
             colorRes = R.color.debit_red;
 
         } else {
-            // DEBIT
+            // Credit amount and account like Expense/Income, or Debit amount and account like Assets, Bank, Cash...)
 
             // GREEN
             colorRes = R.color.credit_green;
@@ -125,8 +123,7 @@ public enum AccountType {
         return EQUITY.equals(this);
     }
 
-    // TODO TW C 2020-03-03 : A renommer en anglais
-    public boolean isResultAccount() {
+    public boolean isExpenseOrIncomeAccount() {
 
         return EXPENSE.equals(this) || INCOME.equals(this);
     }

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -6,12 +6,17 @@ import android.support.annotation.ColorRes;
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * The type of account
  * This are the different types specified by the OFX format and
  * they are currently not used except for exporting
  */
 public enum AccountType {
+
     CASH(TransactionType.DEBIT),
     BANK(TransactionType.DEBIT),
     CREDIT,
@@ -28,19 +33,30 @@ public enum AccountType {
     TRADING,
     ROOT;
 
+    public final static List<AccountType> ASSET_ACCOUNT_TYPES = new ArrayList<AccountType>(Arrays.asList(AccountType.ASSET,
+                                                                                                         AccountType.CASH,
+                                                                                                         AccountType.BANK));
+
+    public final static List<AccountType> LIABLITY_ACCOUNT_TYPES = new ArrayList<AccountType>(Arrays.asList(AccountType.LIABILITY,
+                                                                                                         AccountType.CREDIT));
+
+    public final static List<AccountType> EQUITY_ACCOUNT_TYPES = new ArrayList<AccountType>(Arrays.asList(AccountType.EQUITY));
+
+
     /**
      * Indicates that this type of normal balance the account type has
      * <p>To increase the value of an account with normal balance of credit, one would credit the account.
      * To increase the value of an account with normal balance of debit, one would likewise debit the account.</p>
      */
-    private TransactionType mNormalBalance = TransactionType.CREDIT;
+    private TransactionType mNormalBalance;
 
-    AccountType(TransactionType normalBalance){
+    AccountType(TransactionType normalBalance) {
+
         this.mNormalBalance = normalBalance;
     }
 
     AccountType() {
-        //nothing to see here, move along
+        this(TransactionType.CREDIT);
     }
 
     // TODO TW C 2020-03-06 : Enlever le static

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -117,10 +117,16 @@ public enum AccountType {
      *
      * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
      * @param balance {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
+     * @param shallDisplayNegativeSignum if true will display Negative signum (often bind to Preference R.string.key_display_negative_signum_in_splits
+     * @param shallDisplayZero if true will display 0, else will display nothing (usefull when first creation of a Transaction)
+     * @param shallDisplayCurrency if true will display Currency as well as amount (usefull when displaying balance in
+     *                             TransactionListFragment, BalanceSheetFragment...)
+     *                             else will not display Currency (usefull in SplitEditorFragment or TransactionFormFragment)
      */
     public void displayBalance(final TextView balanceTextView,
                                final Money balance,
                                final boolean shallDisplayNegativeSignum,
+                               final boolean shallDisplayZero,
                                final boolean shallDisplayCurrency) {
 
         //
@@ -141,11 +147,23 @@ public enum AccountType {
         } else {
             // Shall not display currency
 
-            // Display value without currency and without decimals
-            balanceTextView.setText(!shallDisplayNegativeSignum
-                                    ? balanceToDisplay.abs()
-                                                      .toShortString()
-                                    : balanceToDisplay.toShortString());
+            // Shall display value in all other cases than zero balance and shall not display zero balance
+            final boolean shallDisplayValue = !(balanceToDisplay.isAmountZero() && !shallDisplayZero);
+
+            if (shallDisplayValue) {
+                // Shall display balance
+
+                // Display value without currency and without decimals
+                balanceTextView.setText(!shallDisplayNegativeSignum
+                                        ? balanceToDisplay.abs()
+                                                          .toShortString()
+                                        : balanceToDisplay.toShortString());
+
+            } else {
+                // Shall not display balance
+
+                balanceTextView.setText("");
+            }
         }
 
         //
@@ -188,6 +206,7 @@ public enum AccountType {
         displayBalance(balanceTextView,
                        balance,
                        true,
+                       true,
                        true);
     }
 
@@ -206,6 +225,7 @@ public enum AccountType {
         displayBalance(transactionBalanceTextView,
                        transactionBalance,
                        shallDisplayNegativeSignumInSplits,
+                       false,
                        false);
     }
     /**

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -65,7 +65,7 @@ public enum AccountType {
     /**
      * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
      * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
-     * @param balance {@link org.gnucash.android.model.Money} balance to display
+     * @param balance {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
      */
     public void displayBalance(final TextView balanceTextView,
                                final Money balance) {
@@ -97,11 +97,6 @@ public enum AccountType {
 
             final boolean isCreditBalance = balance.isNegative();
 
-//         fontColor = isCreditBalance
-//                        ? context.getResources()
-//                                 .getColor(R.color.debit_red)
-//                        : context.getResources()
-//                                 .getColor(R.color.credit_green);
             fontColor = getAmountColor(isCreditBalance);
         }
 

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -1,11 +1,14 @@
 package org.gnucash.android.model;
 
+import android.content.Context;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
+import android.widget.TextView;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -59,27 +62,66 @@ public enum AccountType {
         this(TransactionType.CREDIT);
     }
 
-    // TODO TW C 2020-03-06 : Enlever le static
+    /**
+     * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
+     * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
+     * @param balance {@link org.gnucash.android.model.Money} balance to display
+     */
+    public void displayBalance(final TextView balanceTextView,
+                               final Money balance) {
+
+        //
+        // Display amount
+        //
+
+        // TODO TW C 2020-03-06 : Déterminer qui doit dire s'il faut afficher un nombre négatif ou sa valeur absolue
+        balanceTextView.setText(balance.formattedString());
+
+        //
+        // Define amount color
+        //
+
+        @ColorInt int fontColor;
+
+        if (balance.asBigDecimal()
+                   .compareTo(BigDecimal.ZERO) == 0) {
+            // balance is null
+
+            Context context = GnuCashApplication.getAppContext();
+
+            fontColor = context.getResources()
+                               .getColor(android.R.color.black);
+
+        } else {
+            // balance is not null
+
+            final boolean isCreditBalance = balance.isNegative();
+
+//         fontColor = isCreditBalance
+//                        ? context.getResources()
+//                                 .getColor(R.color.debit_red)
+//                        : context.getResources()
+//                                 .getColor(R.color.credit_green);
+            fontColor = getAmountColor(isCreditBalance);
+        }
+
+        balanceTextView.setTextColor(fontColor);
+    }
+
     /**
      * Compute red/green color according to accountType and isCreditAmount
      *
      * @param isCreditAmount
-     * @param accountType
      *
      * @return
      */
     @ColorInt
-    public static int getAmountColor(final boolean isCreditAmount,
-                                     final AccountType accountType) {
-
-        AccountType tmpAccountType = ((accountType != null)
-                                      ? accountType
-                                      : AccountType.ASSET);
+    public int getAmountColor(final boolean isCreditAmount) {
 
         @ColorRes final int colorRes;
 
         // Accounts for which
-        final boolean debitCreditInvertedColorAccountType = tmpAccountType.isExpenseOrIncomeAccount() || tmpAccountType.isEquityAccount();
+        final boolean debitCreditInvertedColorAccountType = isExpenseOrIncomeAccount() || isEquityAccount();
 
         if ((isCreditAmount && !debitCreditInvertedColorAccountType) || (!isCreditAmount && debitCreditInvertedColorAccountType)) {
             // Credit amount and account like Assets, Bank, Cash..., or Debit amount and account like Expense/Income
@@ -99,20 +141,6 @@ public enum AccountType {
                                  .getColor(colorRes);
     }
 
-    public boolean hasDebitNormalBalance() {
-
-        return mNormalBalance == TransactionType.DEBIT;
-    }
-
-    /**
-     * Returns the type of normal balance this account possesses
-     * @return TransactionType balance of the account type
-     */
-    public TransactionType getNormalBalanceType() {
-
-        return mNormalBalance;
-    }
-
     public boolean isAssetAccount() {
 
         return ASSET.equals(this) || BANK.equals(this) || CASH.equals(this);
@@ -126,6 +154,24 @@ public enum AccountType {
     public boolean isExpenseOrIncomeAccount() {
 
         return EXPENSE.equals(this) || INCOME.equals(this);
+    }
+
+    public boolean hasDebitNormalBalance() {
+
+        return mNormalBalance == TransactionType.DEBIT;
+    }
+
+    //
+    // Getters/Setters
+    //
+
+    /**
+     * Returns the type of normal balance this account possesses
+     * @return TransactionType balance of the account type
+     */
+    public TransactionType getNormalBalanceType() {
+
+        return mNormalBalance;
     }
 
 }

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -190,33 +190,43 @@ public enum AccountType {
         if ((isCreditAmount && !debitCreditInvertedColorAccountType) || (!isCreditAmount && debitCreditInvertedColorAccountType)) {
             // Credit amount and account like Assets, Bank, Cash..., or Debit amount and account like Expense/Income
 
-            if (!isExpenseOrIncomeAccount()) {
+            if (isExpenseOrIncomeAccount()) {
+                // It is an Expense/Income account
+
+                // BLUE
+                colorRes = R.color.debit_expense_income;
+
+            } else if(isEquityAccount()) {
+                // It is an Equity account
+
+                colorRes = R.color.debit_equity;
+
+            } else {
                 // It is not an Expense/Income account
 
                 // RED
                 colorRes = R.color.debit_red;
-
-            } else {
-                // It is an Expense/Income account
-
-                // PURPLE
-                colorRes = R.color.debit_expense_income;
             }
 
         } else {
             // Credit amount and account like Expense/Income, or Debit amount and account like Assets, Bank, Cash...)
 
-            if (!isExpenseOrIncomeAccount()) {
-                // It is not an Expense/Income account
-
-                // GREEN
-                colorRes = R.color.credit_green;
-
-            } else {
+            if (isExpenseOrIncomeAccount()) {
                 // It is an Expense/Income account
 
                 // BLUE
                 colorRes = R.color.credit_expense_income;
+
+            } else if(isEquityAccount()) {
+                // It is an Equity account
+
+                colorRes = R.color.credit_equity;
+
+            } else {
+                // It is not an Expense/Income account
+
+                // GREEN
+                colorRes = R.color.credit_green;
             }
 
         }

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -3,7 +3,6 @@ package org.gnucash.android.model;
 import android.content.Context;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
-import android.support.v7.preference.PreferenceManager;
 import android.widget.TextView;
 
 import org.gnucash.android.R;
@@ -121,7 +120,8 @@ public enum AccountType {
      */
     public void displayBalance(final TextView balanceTextView,
                                final Money balance,
-                               final boolean shallDisplayNegativeSignumInSplits) {
+                               final boolean shallDisplayNegativeSignum,
+                               final boolean shallDisplayCurrency) {
 
         //
         // Display amount
@@ -129,10 +129,24 @@ public enum AccountType {
 
         final Money balanceToDisplay = getBalanceWithSignumForDisplay(balance);
 
-        balanceTextView.setText(!shallDisplayNegativeSignumInSplits
-                                ? balanceToDisplay.abs()
-                                                  .formattedString()
-                                : balanceToDisplay.formattedString());
+        if (shallDisplayCurrency) {
+            // Shall currency
+
+            // Display currency
+            balanceTextView.setText(!shallDisplayNegativeSignum
+                                    ? balanceToDisplay.abs()
+                                                      .formattedString()
+                                    : balanceToDisplay.formattedString());
+
+        } else {
+            // Shall not display currency
+
+            // Display value without currency and without decimals
+            balanceTextView.setText(!shallDisplayNegativeSignum
+                                    ? balanceToDisplay.abs()
+                                                      .toShortString()
+                                    : balanceToDisplay.toShortString());
+        }
 
         //
         // Define amount color
@@ -160,6 +174,42 @@ public enum AccountType {
         balanceTextView.setTextColor(fontColor);
     }
 
+    /**
+     * Display the balance of an account in a text view and format the text color to match the sign of the amount
+     *
+     * @param balanceTextView
+     *         {@link android.widget.TextView} where balance is to be displayed
+     * @param balance
+     *         {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
+     */
+    public void displayBalance(final TextView balanceTextView,
+                               final Money balance,
+                               // TODO TW C 2020-05-23 : A supprimer
+                               final boolean shallDisplayNegativeSignumInSplits) {
+
+        displayBalance(balanceTextView,
+                       balance,
+                       true,
+                       true);
+    }
+
+    /**
+     * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
+     *
+     * @param transactionBalanceTextView
+     *         {@link android.widget.TextView} where balance is to be displayed
+     * @param transactionBalance
+     *         {@link org.gnucash.android.model.Money} balance (>0 or <0) to display
+     */
+    public void displayBalanceWithoutCurrency(final TextView transactionBalanceTextView,
+                                              final Money transactionBalance,
+                                              final boolean shallDisplayNegativeSignumInSplits) {
+
+        displayBalance(transactionBalanceTextView,
+                       transactionBalance,
+                       shallDisplayNegativeSignumInSplits,
+                       false);
+    }
     /**
      * Compute red/green color according to accountType and isCreditAmount
      *

--- a/app/src/main/java/org/gnucash/android/model/AccountType.java
+++ b/app/src/main/java/org/gnucash/android/model/AccountType.java
@@ -1,6 +1,5 @@
 package org.gnucash.android.model;
 
-import android.content.Context;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.widget.TextView;
@@ -9,7 +8,6 @@ import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.ui.settings.PreferenceActivity;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -172,22 +170,9 @@ public enum AccountType {
 
         @ColorInt int fontColor;
 
-        if (balance.asBigDecimal()
-                   .compareTo(BigDecimal.ZERO) == 0) {
-            // balance is null
+        final boolean isCreditBalance = balance.isNegative();
 
-            Context context = GnuCashApplication.getAppContext();
-
-            fontColor = context.getResources()
-                               .getColor(android.R.color.black);
-
-        } else {
-            // balance is not null
-
-            final boolean isCreditBalance = balance.isNegative();
-
-            fontColor = getAmountColor(isCreditBalance);
-        }
+        fontColor = getAmountColor(isCreditBalance);
 
         balanceTextView.setTextColor(fontColor);
     }

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -257,7 +257,8 @@ public final class Money implements Comparable<Money>{
 	public String asString(){
 		return toPlainString();
 	}
-	
+
+	// TODO TW C 2020-03-06 : A factoriser avec Split.getFormattedAmount
 	/**
 	 * Returns a string representation of the Money object formatted according to 
 	 * the <code>locale</code> and includes the currency symbol. 

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -315,6 +315,19 @@ public final class Money implements Comparable<Money>{
 	 * @param amount {@link BigDecimal} amount to be set
 	 */
 	private void setAmount(@NonNull BigDecimal amount) {
+
+		if (amount != null) {
+			// Amount is not null
+
+			// NTD
+
+		} else {
+			// Amount is null
+
+			// init to 0
+			amount = new BigDecimal(0);
+		}
+
 		mAmount = amount.setScale(mCommodity.getSmallestFractionDigits(), ROUNDING_MODE);
 	}
 

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -440,9 +440,19 @@ public final class Money implements Comparable<Money>{
 	 *
 	 * @return String representation of the amount (without currency) of the Money object
 	 */
+	public String toShortString(){
+		return String.format(Locale.getDefault(), "%.0f", asDouble());
+	}
+
+	/**
+	 * Returns a locale-specific representation of the amount of the Money object (excluding the currency)
+	 *
+	 * @return String representation of the amount (without currency) of the Money object
+	 */
 	public String toLocaleString(){
 		return String.format(Locale.getDefault(), "%.2f", asDouble());
 	}
+
 
 	/**
 	 * Returns the string representation of the Money object (value + currency) formatted according

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -50,7 +50,7 @@ public final class Money implements Comparable<Money>{
 	private Commodity mCommodity;
 
 	/**
-	 * Amount value held by this object
+	 * Amount value held by this object (can be > 0 or < 0)
 	 */
 	private BigDecimal mAmount;
 

--- a/app/src/main/java/org/gnucash/android/model/Money.java
+++ b/app/src/main/java/org/gnucash/android/model/Money.java
@@ -258,7 +258,6 @@ public final class Money implements Comparable<Money>{
 		return toPlainString();
 	}
 
-	// TODO TW C 2020-03-06 : A factoriser avec Split.getFormattedAmount
 	/**
 	 * Returns a string representation of the Money object formatted according to 
 	 * the <code>locale</code> and includes the currency symbol. 

--- a/app/src/main/java/org/gnucash/android/model/Split.java
+++ b/app/src/main/java/org/gnucash/android/model/Split.java
@@ -314,31 +314,6 @@ public class Split extends BaseModel implements Parcelable{
                                                                           .equals(other.mSplitType);
     }
 
-    // TODO TW m 2020-03-07 : To clean
-//    /**
-//     * Returns the formatted amount (with or without negation sign) for the split value
-//     * @return Money amount of value
-//     * @see #getFormattedAmount(Money, String, TransactionType)
-//     */
-//    public Money getFormattedAmount() {
-//
-//        return getFormattedAmount(mValue,
-//                                  mAccountUID,
-//                                  mSplitType);
-//    }
-//
-//    /**
-//     * Returns the formatted amount (with or without negation sign) for the quantity
-//     * @return Money amount of quantity
-//     * @see #getFormattedAmount(Money, String, TransactionType)
-//     */
-//    public Money getFormattedQuantity(){
-//
-//        return getFormattedAmount(mQuantity,
-//                                  mAccountUID,
-//                                  mSplitType);
-//    }
-
     /**
      * Return the reconciled state of this split
      * <p>
@@ -357,65 +332,6 @@ public class Split extends BaseModel implements Parcelable{
     public char getReconcileState() {
         return mReconcileState;
     }
-
-    // TODO TW C 2020-03-07 : To Clean
-//    /**
-//     * Splits are saved as absolute values to the database, with no negative numbers.
-//     *
-//     * The type of movement the split causes to the balance of an account determines
-//     * its sign, and that depends on the split type and the account type
-//     *
-//     * @return -{@code amount} if the amount would reduce the balance of
-//     *   {@code account}, otherwise +{@code amount}
-//     */
-//    public Money getFormattedValue() {
-//
-//        // Get absolute value of the split amount
-//        Money amount = getValue();
-//
-//        // TODO TW M 2020-03-07 : Utiliser une Préférence pour afficher ou pas les nombres négatifs dans les Splits
-//        if (true) {
-//            // Preference tells to display only positive amounts in Splits
-//
-//            // NTD
-//
-//        } else {
-//            // Preference tells to display positive or négative amounts in Splits
-//
-//            boolean isDebitSplit = mSplitType == TransactionType.DEBIT;
-//
-////        boolean isDebitAccount = AccountsDbAdapter.getInstance()
-////                                                  .getAccountType(mAccountUID)
-////                                                  .hasDebitNormalBalance();
-////
-////        if (isDebitAccount) {
-////            if (isDebitSplit) {
-////                return amount;
-////            } else {
-////                return amount.negate();
-////            }
-////        } else {
-////            if (isDebitSplit) {
-////                return amount.negate();
-////            } else {
-////                return amount;
-////            }
-////        }
-//
-//            if (isDebitSplit) {
-//                // DEBIT
-//
-//                // NTD
-//
-//            } else {
-//                // CREDIT
-//
-//                amount = amount.negate();
-//            }
-//        }
-//
-//        return amount;
-//    }
 
     /**
      * Check if this split is reconciled

--- a/app/src/main/java/org/gnucash/android/model/Split.java
+++ b/app/src/main/java/org/gnucash/android/model/Split.java
@@ -302,37 +302,6 @@ public class Split extends BaseModel implements Parcelable{
     }
 
     /**
-     * Splits are saved as absolute values to the database, with no negative numbers.
-     * The type of movement the split causes to the balance of an account determines
-     * its sign, and that depends on the split type and the account type
-     * @param amount Money amount to format
-     * @param accountUID GUID of the account
-     * @param splitType Transaction type of the split
-     * @return -{@code amount} if the amount would reduce the balance of
-     *   {@code account}, otherwise +{@code amount}
-     */
-    private static Money getFormattedAmount(Money amount, String accountUID, TransactionType
-            splitType){
-        boolean isDebitAccount = AccountsDbAdapter.getInstance().getAccountType(accountUID).hasDebitNormalBalance();
-        Money absAmount = amount.abs();
-
-        boolean isDebitSplit = splitType == TransactionType.DEBIT;
-        if (isDebitAccount) {
-            if (isDebitSplit) {
-                return absAmount;
-            } else {
-                return absAmount.negate();
-            }
-        } else {
-            if (isDebitSplit) {
-                return absAmount.negate();
-            } else {
-                return absAmount;
-            }
-        }
-    }
-
-    /**
      * Return the reconciled state of this split
      * <p>
      *     The reconciled state is one of the following values:
@@ -349,6 +318,54 @@ public class Split extends BaseModel implements Parcelable{
      */
     public char getReconcileState() {
         return mReconcileState;
+    }
+
+    /**
+     * Splits are saved as absolute values to the database, with no negative numbers.
+     * The type of movement the split causes to the balance of an account determines
+     * its sign, and that depends on the split type and the account type
+     * @param amount Money amount to format
+     * @param accountUID GUID of the account
+     * @param splitType Transaction type of the split
+     * @return -{@code amount} if the amount would reduce the balance of
+     *   {@code account}, otherwise +{@code amount}
+     */
+    private static Money getFormattedAmount(Money amount,
+                                            String accountUID,
+                                            TransactionType splitType) {
+
+//        boolean isDebitAccount = AccountsDbAdapter.getInstance()
+//                                                  .getAccountType(accountUID)
+//                                                  .hasDebitNormalBalance();
+
+        Money   absAmount      = amount.abs();
+
+        boolean isDebitSplit = splitType == TransactionType.DEBIT;
+
+//        if (isDebitAccount) {
+//            if (isDebitSplit) {
+//                return absAmount;
+//            } else {
+//                return absAmount.negate();
+//            }
+//        } else {
+//            if (isDebitSplit) {
+//                return absAmount.negate();
+//            } else {
+//                return absAmount;
+//            }
+//        }
+
+        if (isDebitSplit) {
+            // It is a Debit Split
+
+            return absAmount;
+
+        } else {
+            // It is not a Debit Split
+
+            return absAmount.negate();
+        }
     }
 
     /**
@@ -394,7 +411,16 @@ public class Split extends BaseModel implements Parcelable{
 
     @Override
     public String toString() {
-        return mSplitType.name() + " of " + mValue.toString() + " in account: " + mAccountUID;
+
+        return mSplitType.name()
+               + " of "
+               + mValue.toString()
+               + " in account: "
+               + mAccountUID
+               + " ("
+               + AccountsDbAdapter.getInstance()
+                                  .getAccountFullName(mAccountUID)
+               + ")";
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/model/Split.java
+++ b/app/src/main/java/org/gnucash/android/model/Split.java
@@ -43,12 +43,12 @@ public class Split extends BaseModel implements Parcelable{
     /**
      * Amount absolute value of this split which is in the currency of the transaction
      */
-    private Money mValue;
+    private Money mAmountAbsValue;
 
     /**
      * Amount of the split in the currency of the account to which the split belongs
      */
-    private Money mQuantity;
+    private Money mQuantityAbsValue;
 
     /**
      * Transaction UID which this split belongs to
@@ -88,8 +88,11 @@ public class Split extends BaseModel implements Parcelable{
      * @param accountUID String UID of transfer account
      */
     public Split(@NonNull Money value, @NonNull Money quantity, String accountUID){
-        setQuantity(quantity);
+
+        // Store absolute value
         setValue(value);
+        setQuantity(quantity);
+
         setAccountUID(accountUID);
     }
 
@@ -110,6 +113,7 @@ public class Split extends BaseModel implements Parcelable{
 
     /**
      * Clones the <code>sourceSplit</code> to create a new instance with same fields
+     *
      * @param sourceSplit Split to be cloned
      * @param generateUID Determines if the clone should have a new UID or should
      *                    maintain the one from source
@@ -119,8 +123,8 @@ public class Split extends BaseModel implements Parcelable{
         this.mAccountUID    = sourceSplit.mAccountUID;
         this.mSplitType     = sourceSplit.mSplitType;
         this.mTransactionUID = sourceSplit.mTransactionUID;
-        this.mValue         = new Money(sourceSplit.mValue);
-        this.mQuantity      = new Money(sourceSplit.mQuantity);
+        setValue(new Money(sourceSplit.mAmountAbsValue));
+        setQuantity(new Money(sourceSplit.mQuantityAbsValue));
 
         //todo: clone reconciled status
         if (generateUID){
@@ -131,12 +135,32 @@ public class Split extends BaseModel implements Parcelable{
     }
 
     /**
-     * Returns the value amount of the split
+     * Returns the value (= signed amount) of the split
+     *
+     * @return Money amount of the split with the currency of the transaction
+     *
+     * @see #getQuantity()
+     */
+    public Money getValueWithSignum() {
+
+        // splitAmount (positive or negative number)
+        Money signedValue = TransactionType.DEBIT.equals(getType())
+                            ? getValue()
+                            : getValue().negate();
+
+        return signedValue;
+    }
+
+
+    /**
+     * Returns the absolute value of the amount of the split
+     *
      * @return Money amount of the split with the currency of the transaction
      * @see #getQuantity()
      */
     public Money getValue() {
-        return mValue;
+
+        return mAmountAbsValue;
     }
 
     /**
@@ -145,11 +169,12 @@ public class Split extends BaseModel implements Parcelable{
      * <p>The value is in the currency of the containing transaction.
      * It's stored unsigned.</p>
      *
-     * @param value Money value of this split
+     * @param amountValue Money value of this split
      * @see #setQuantity(Money)
      */
-    public void setValue(Money value) {
-        mValue = value.abs();
+    public void setValue(Money amountValue) {
+
+        mAmountAbsValue = amountValue.abs();
     }
 
     /**
@@ -159,7 +184,8 @@ public class Split extends BaseModel implements Parcelable{
      * @see #getValue()
      */
     public Money getQuantity() {
-        return mQuantity;
+
+        return mQuantityAbsValue;
     }
 
     /**
@@ -168,11 +194,12 @@ public class Split extends BaseModel implements Parcelable{
      * <p>The quantity is in the currency of the owning account.
      * It will be stored unsigned.</p>
      *
-     * @param quantity Money quantity amount
+     * @param quantityAbsValue Money quantity amount
      * @see #setValue(Money)
      */
-    public void setQuantity(Money quantity) {
-        this.mQuantity = quantity.abs();
+    public void setQuantity(Money quantityAbsValue) {
+
+        this.mQuantityAbsValue = quantityAbsValue.abs();
     }
 
     /**
@@ -247,12 +274,14 @@ public class Split extends BaseModel implements Parcelable{
      * @return New split pair of current split
      * @see TransactionType#invert()
      */
-    public Split createPair(String accountUID){
-        Split pair = new Split(mValue, accountUID);
+    public Split createPair(String accountUID) {
+
+        Split pair = new Split(mAmountAbsValue,
+                               accountUID);
         pair.setType(mSplitType.invert());
         pair.setMemo(mMemo);
         pair.setTransactionUID(mTransactionUID);
-        pair.setQuantity(mQuantity);
+        pair.setQuantity(mQuantityAbsValue);
         return pair;
     }
 
@@ -262,12 +291,13 @@ public class Split extends BaseModel implements Parcelable{
      */
     protected Split clone() throws CloneNotSupportedException {
         super.clone();
-        Split split = new Split(mValue, mAccountUID);
+        Split split = new Split(mAmountAbsValue,
+                                mAccountUID);
         split.setUID(getUID());
         split.setType(mSplitType);
         split.setMemo(mMemo);
         split.setTransactionUID(mTransactionUID);
-        split.setQuantity(mQuantity);
+        split.setQuantity(mQuantityAbsValue);
         return split;
     }
 
@@ -279,27 +309,35 @@ public class Split extends BaseModel implements Parcelable{
      * @return whether the two splits are a pair
      */
     public boolean isPairOf(Split other) {
-        return mValue.equals(other.mValue)
-                && mSplitType.invert().equals(other.mSplitType);
+
+        return mAmountAbsValue.equals(other.mAmountAbsValue) && mSplitType.invert()
+                                                                          .equals(other.mSplitType);
     }
 
-    /**
-     * Returns the formatted amount (with or without negation sign) for the split value
-     * @return Money amount of value
-     * @see #getFormattedAmount(Money, String, TransactionType)
-     */
-    public Money getFormattedValue(){
-        return getFormattedAmount(mValue, mAccountUID, mSplitType);
-    }
-
-    /**
-     * Returns the formatted amount (with or without negation sign) for the quantity
-     * @return Money amount of quantity
-     * @see #getFormattedAmount(Money, String, TransactionType)
-     */
-    public Money getFormattedQuantity(){
-        return getFormattedAmount(mQuantity, mAccountUID, mSplitType);
-    }
+    // TODO TW m 2020-03-07 : To clean
+//    /**
+//     * Returns the formatted amount (with or without negation sign) for the split value
+//     * @return Money amount of value
+//     * @see #getFormattedAmount(Money, String, TransactionType)
+//     */
+//    public Money getFormattedAmount() {
+//
+//        return getFormattedAmount(mValue,
+//                                  mAccountUID,
+//                                  mSplitType);
+//    }
+//
+//    /**
+//     * Returns the formatted amount (with or without negation sign) for the quantity
+//     * @return Money amount of quantity
+//     * @see #getFormattedAmount(Money, String, TransactionType)
+//     */
+//    public Money getFormattedQuantity(){
+//
+//        return getFormattedAmount(mQuantity,
+//                                  mAccountUID,
+//                                  mSplitType);
+//    }
 
     /**
      * Return the reconciled state of this split
@@ -320,53 +358,64 @@ public class Split extends BaseModel implements Parcelable{
         return mReconcileState;
     }
 
-    /**
-     * Splits are saved as absolute values to the database, with no negative numbers.
-     * The type of movement the split causes to the balance of an account determines
-     * its sign, and that depends on the split type and the account type
-     * @param amount Money amount to format
-     * @param accountUID GUID of the account
-     * @param splitType Transaction type of the split
-     * @return -{@code amount} if the amount would reduce the balance of
-     *   {@code account}, otherwise +{@code amount}
-     */
-    private static Money getFormattedAmount(Money amount,
-                                            String accountUID,
-                                            TransactionType splitType) {
-
-//        boolean isDebitAccount = AccountsDbAdapter.getInstance()
-//                                                  .getAccountType(accountUID)
-//                                                  .hasDebitNormalBalance();
-
-        Money   absAmount      = amount.abs();
-
-        boolean isDebitSplit = splitType == TransactionType.DEBIT;
-
-//        if (isDebitAccount) {
-//            if (isDebitSplit) {
-//                return absAmount;
-//            } else {
-//                return absAmount.negate();
-//            }
+    // TODO TW C 2020-03-07 : To Clean
+//    /**
+//     * Splits are saved as absolute values to the database, with no negative numbers.
+//     *
+//     * The type of movement the split causes to the balance of an account determines
+//     * its sign, and that depends on the split type and the account type
+//     *
+//     * @return -{@code amount} if the amount would reduce the balance of
+//     *   {@code account}, otherwise +{@code amount}
+//     */
+//    public Money getFormattedValue() {
+//
+//        // Get absolute value of the split amount
+//        Money amount = getValue();
+//
+//        // TODO TW M 2020-03-07 : Utiliser une Préférence pour afficher ou pas les nombres négatifs dans les Splits
+//        if (true) {
+//            // Preference tells to display only positive amounts in Splits
+//
+//            // NTD
+//
 //        } else {
+//            // Preference tells to display positive or négative amounts in Splits
+//
+//            boolean isDebitSplit = mSplitType == TransactionType.DEBIT;
+//
+////        boolean isDebitAccount = AccountsDbAdapter.getInstance()
+////                                                  .getAccountType(mAccountUID)
+////                                                  .hasDebitNormalBalance();
+////
+////        if (isDebitAccount) {
+////            if (isDebitSplit) {
+////                return amount;
+////            } else {
+////                return amount.negate();
+////            }
+////        } else {
+////            if (isDebitSplit) {
+////                return amount.negate();
+////            } else {
+////                return amount;
+////            }
+////        }
+//
 //            if (isDebitSplit) {
-//                return absAmount.negate();
+//                // DEBIT
+//
+//                // NTD
+//
 //            } else {
-//                return absAmount;
+//                // CREDIT
+//
+//                amount = amount.negate();
 //            }
 //        }
-
-        if (isDebitSplit) {
-            // It is a Debit Split
-
-            return absAmount;
-
-        } else {
-            // It is not a Debit Split
-
-            return absAmount.negate();
-        }
-    }
+//
+//        return amount;
+//    }
 
     /**
      * Check if this split is reconciled
@@ -412,9 +461,7 @@ public class Split extends BaseModel implements Parcelable{
     @Override
     public String toString() {
 
-        return mSplitType.name()
-               + " of "
-               + mValue.toString()
+        return mSplitType.name() + " of " + mAmountAbsValue.toString()
                + " in account: "
                + mAccountUID
                + " ("
@@ -438,10 +485,27 @@ public class Split extends BaseModel implements Parcelable{
     public String toCsv(){
         String sep = ";";
         //TODO: add reconciled state and date
-        String splitString = getUID() + sep + mValue.getNumerator() + sep + mValue.getDenominator()
-                + sep + mValue.getCommodity().getCurrencyCode() + sep + mQuantity.getNumerator()
-                + sep + mQuantity.getDenominator() + sep + mQuantity.getCommodity().getCurrencyCode()
-                + sep + mTransactionUID + sep + mAccountUID + sep + mSplitType.name();
+        String splitString = getUID()
+                             + sep
+                             + mAmountAbsValue.getNumerator()
+                             + sep
+                             + mAmountAbsValue.getDenominator()
+                             + sep
+                             + mAmountAbsValue.getCommodity()
+                                              .getCurrencyCode()
+                             + sep
+                             + mQuantityAbsValue.getNumerator()
+                             + sep
+                             + mQuantityAbsValue.getDenominator()
+                             + sep
+                             + mQuantityAbsValue.getCommodity()
+                                                .getCurrencyCode()
+                             + sep
+                             + mTransactionUID
+                             + sep
+                             + mAccountUID
+                             + sep
+                             + mSplitType.name();
         if (mMemo != null){
             splitString = splitString + sep + mMemo;
         }
@@ -515,8 +579,12 @@ public class Split extends BaseModel implements Parcelable{
         if (super.equals(split)) return true;
 
         if (mReconcileState != split.mReconcileState) return false;
-        if (!mValue.equals(split.mValue)) return false;
-        if (!mQuantity.equals(split.mQuantity)) return false;
+        if (!mAmountAbsValue.equals(split.mAmountAbsValue)) {
+            return false;
+        }
+        if (!mQuantityAbsValue.equals(split.mQuantityAbsValue)) {
+            return false;
+        }
         if (!mTransactionUID.equals(split.mTransactionUID)) return false;
         if (!mAccountUID.equals(split.mAccountUID)) return false;
         if (mSplitType != split.mSplitType) return false;
@@ -540,8 +608,12 @@ public class Split extends BaseModel implements Parcelable{
         Split split = (Split) o;
 
         if (mReconcileState != split.mReconcileState) return false;
-        if (!mValue.equals(split.mValue)) return false;
-        if (!mQuantity.equals(split.mQuantity)) return false;
+        if (!mAmountAbsValue.equals(split.mAmountAbsValue)) {
+            return false;
+        }
+        if (!mQuantityAbsValue.equals(split.mQuantityAbsValue)) {
+            return false;
+        }
         if (!mTransactionUID.equals(split.mTransactionUID)) return false;
         if (!mAccountUID.equals(split.mAccountUID)) return false;
         if (mSplitType != split.mSplitType) return false;
@@ -551,8 +623,8 @@ public class Split extends BaseModel implements Parcelable{
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + mValue.hashCode();
-        result = 31 * result + mQuantity.hashCode();
+        result = 31 * result + mAmountAbsValue.hashCode();
+        result = 31 * result + mQuantityAbsValue.hashCode();
         result = 31 * result + mTransactionUID.hashCode();
         result = 31 * result + mAccountUID.hashCode();
         result = 31 * result + mSplitType.hashCode();
@@ -573,13 +645,15 @@ public class Split extends BaseModel implements Parcelable{
         dest.writeString(mTransactionUID);
         dest.writeString(mSplitType.name());
 
-        dest.writeLong(mValue.getNumerator());
-        dest.writeLong(mValue.getDenominator());
-        dest.writeString(mValue.getCommodity().getCurrencyCode());
+        dest.writeLong(mAmountAbsValue.getNumerator());
+        dest.writeLong(mAmountAbsValue.getDenominator());
+        dest.writeString(mAmountAbsValue.getCommodity()
+                                        .getCurrencyCode());
 
-        dest.writeLong(mQuantity.getNumerator());
-        dest.writeLong(mQuantity.getDenominator());
-        dest.writeString(mQuantity.getCommodity().getCurrencyCode());
+        dest.writeLong(mQuantityAbsValue.getNumerator());
+        dest.writeLong(mQuantityAbsValue.getDenominator());
+        dest.writeString(mQuantityAbsValue.getCommodity()
+                                          .getCurrencyCode());
 
         dest.writeString(mMemo == null ? "" : mMemo);
         dest.writeString(String.valueOf(mReconcileState));
@@ -600,12 +674,16 @@ public class Split extends BaseModel implements Parcelable{
         long valueNum = source.readLong();
         long valueDenom = source.readLong();
         String valueCurrency = source.readString();
-        mValue = new Money(valueNum, valueDenom, valueCurrency).abs();
+        setValue(new Money(valueNum,
+                           valueDenom,
+                           valueCurrency));
 
         long qtyNum = source.readLong();
         long qtyDenom = source.readLong();
         String qtyCurrency = source.readString();
-        mQuantity = new Money(qtyNum, qtyDenom, qtyCurrency).abs();
+        setQuantity(new Money(qtyNum,
+                              qtyDenom,
+                              qtyCurrency));
 
         String memo = source.readString();
         mMemo = memo.isEmpty() ? null : memo;

--- a/app/src/main/java/org/gnucash/android/model/Transaction.java
+++ b/app/src/main/java/org/gnucash/android/model/Transaction.java
@@ -289,39 +289,51 @@ public class Transaction extends BaseModel{
      * @param splitList List of splits
      * @return Money list of splits
      */
+    // TODO TW C 2020-04-07 : A renommer computeSplitListBalance()
     public static Money computeBalance(String accountUID, List<Split> splitList) {
 
         AccountsDbAdapter accountsDbAdapter = AccountsDbAdapter.getInstance();
-        AccountType accountType = accountsDbAdapter.getAccountType(accountUID);
-        String accountCurrencyCode = accountsDbAdapter.getAccountCurrencyCode(accountUID);
 
-//        boolean isDebitAccount = accountType.hasDebitNormalBalance();
+        String accountCurrencyCode = accountsDbAdapter.getAccountCurrencyCode(accountUID);
 
         Money balance = Money.createZeroInstance(accountCurrencyCode);
 
         for (Split split : splitList) {
 
-            if (!split.getAccountUID().equals(accountUID))
+            if (!split.getAccountUID()
+                      .equals(accountUID)) {
+
+                // TODO TW M 2020-05-23 : Pourrait être supprimé ?
                 continue;
 
-            //
-            // Get Amount absolute value
-            //
+            } else {
 
-            Money amount;
-            if (split.getValue().getCommodity().getCurrencyCode().equals(accountCurrencyCode)){
-                amount = split.getValue();
-            } else { //if this split belongs to the account, then either its value or quantity is in the account currency
-                amount = split.getQuantity();
-            }
+                //
+                // Get Amount absolute value
+                //
 
-            //
-            // Compute balance
-            //
+                Money amount;
 
-            boolean isDebitSplit = split.getType() == TransactionType.DEBIT;
+                if (split.getValue()
+                         .getCommodity()
+                         .getCurrencyCode()
+                         .equals(accountCurrencyCode)) {
 
-            // #876
+                    amount = split.getValue();
+
+                } else {
+                    // this split belongs to the account, then either its value or quantity is in the account currency
+
+                    amount = split.getQuantity();
+                }
+
+                //
+                // Compute balance
+                //
+
+                boolean isDebitSplit = (split.getType() == TransactionType.DEBIT);
+
+                // #876
 //            if (isDebitAccount) {
 //                if (isDebitSplit) {
 //                    balance = balance.add(amount);
@@ -335,18 +347,28 @@ public class Transaction extends BaseModel{
 //                    balance = balance.add(amount);
 //                }
 //            }
-            if (isDebitSplit) {
-                // DEBIT
 
-                balance = balance.add(amount);
+                if (isDebitSplit) {
+                    // DEBIT
 
-            } else {
-                // CREDIT
+                    balance = balance.add(amount);
 
-                balance = balance.subtract(amount);
+                } else {
+                    // CREDIT
+
+                    balance = balance.subtract(amount);
+                }
             }
 
         } // for
+
+//        //
+//        // Negate balance if account is usually creditor
+//        //
+//
+//        AccountType accountType = accountsDbAdapter.getAccountType(accountUID);
+//
+//        balance = accountType.getBalanceWithSignumForDisplay(balance);
 
         return balance;
     }

--- a/app/src/main/java/org/gnucash/android/model/Transaction.java
+++ b/app/src/main/java/org/gnucash/android/model/Transaction.java
@@ -289,7 +289,6 @@ public class Transaction extends BaseModel{
      * @param splitList List of splits
      * @return Money list of splits
      */
-    // TODO TW C 2020-04-07 : A renommer computeSplitListBalance()
     public static Money computeBalance(String accountUID, List<Split> splitList) {
 
         AccountsDbAdapter accountsDbAdapter = AccountsDbAdapter.getInstance();
@@ -303,7 +302,6 @@ public class Transaction extends BaseModel{
             if (!split.getAccountUID()
                       .equals(accountUID)) {
 
-                // TODO TW M 2020-05-23 : Pourrait être supprimé ?
                 continue;
 
             } else {
@@ -479,17 +477,6 @@ public class Transaction extends BaseModel{
     public static boolean wouldDecreaseBalance(AccountType accountType,
                                                TransactionType transactionType) {
 
-        // TODO TW M 2020-03-02 : TBC
-//        if (accountType.hasDebitNormalBalance()) {
-//            // Account usually with DEBIT > CREDIT
-//
-//            return transactionType == TransactionType.CREDIT;
-//
-//        } else {
-//            // Account usually with DEBIT < CREDIT
-//
-//            return transactionType == TransactionType.DEBIT;
-//        }
         return transactionType == TransactionType.CREDIT;
     }
 

--- a/app/src/main/java/org/gnucash/android/model/TransactionType.java
+++ b/app/src/main/java/org/gnucash/android/model/TransactionType.java
@@ -24,7 +24,7 @@ package org.gnucash.android.model;
  * @author Ngewi Fet <ngewif@gmail.com>
  * @author Jesse Shieh <jesse.shieh.pub@gmail.com>
  */
-// TODO TW m 2020-03-03 : Should be named SplitType
+// TW m 2020-03-03 : Should be named SplitType
 public enum TransactionType {
     DEBIT,
     CREDIT;

--- a/app/src/main/java/org/gnucash/android/model/TransactionType.java
+++ b/app/src/main/java/org/gnucash/android/model/TransactionType.java
@@ -22,7 +22,7 @@ package org.gnucash.android.model;
  * @author Ngewi Fet <ngewif@gmail.com>
  * @author Jesse Shieh <jesse.shieh.pub@gmail.com>
  */
-// TODO TW C 2020-03-03 : A renommer SplitType (AC)
+// TODO TW m 2020-03-03 : Should be named SplitType
 public enum TransactionType {
     DEBIT, CREDIT;
 

--- a/app/src/main/java/org/gnucash/android/model/TransactionType.java
+++ b/app/src/main/java/org/gnucash/android/model/TransactionType.java
@@ -17,14 +17,17 @@
 package org.gnucash.android.model;
 
 /**
- * Type of transaction, a credit or a debit
+ * Type of a Split of a Transaction
+ *
+ * It is a credit or a debit
  *
  * @author Ngewi Fet <ngewif@gmail.com>
  * @author Jesse Shieh <jesse.shieh.pub@gmail.com>
  */
 // TODO TW m 2020-03-03 : Should be named SplitType
 public enum TransactionType {
-    DEBIT, CREDIT;
+    DEBIT,
+    CREDIT;
 
     private TransactionType opposite;
 

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -154,7 +154,9 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
         @Override
         public Fragment getItem(int i) {
             AccountsListFragment currentFragment = (AccountsListFragment) mFragmentPageReferenceMap.get(i);
+
             if (currentFragment == null) {
+
                 switch (i) {
                     case INDEX_RECENT_ACCOUNTS_FRAGMENT:
                         currentFragment = AccountsListFragment.newInstance(AccountsListFragment.DisplayMode.RECENT);
@@ -169,13 +171,16 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
                         currentFragment = AccountsListFragment.newInstance(AccountsListFragment.DisplayMode.TOP_LEVEL);
                         break;
                 }
+
                 mFragmentPageReferenceMap.put(i, currentFragment);
+
             }
             return currentFragment;
         }
 
         @Override
         public void destroyItem(ViewGroup container, int position, Object object) {
+//             #586 By putting this in comment, there is no more crash, but I don't know if there are side effects
             super.destroyItem(container, position, object);
             mFragmentPageReferenceMap.remove(position);
         }
@@ -376,6 +381,7 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
     @Override
     protected void onDestroy() {
         super.onDestroy();
+
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         preferences.edit().putInt(LAST_OPEN_TAB_INDEX, mViewPager.getCurrentItem()).apply();
     }

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -221,6 +221,7 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
     @Override
 	public void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
 
         final Intent intent = getIntent();
@@ -333,18 +334,29 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
      * <p>Also handles displaying the What's New dialog</p>
      */
     private void init() {
-        PreferenceManager.setDefaultValues(this, BooksDbAdapter.getInstance().getActiveBookUID(),
-                Context.MODE_PRIVATE, R.xml.fragment_transaction_preferences, true);
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        boolean firstRun = prefs.getBoolean(getString(R.string.key_first_run), true);
+        PreferenceManager.setDefaultValues(this,
+                                           BooksDbAdapter.getInstance()
+                                                         .getActiveBookUID(),
+                                           Context.MODE_PRIVATE,
+                                           R.xml.fragment_transaction_preferences,
+                                           true);
+
+        SharedPreferences prefs    = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean           firstRun = prefs.getBoolean(getString(R.string.key_first_run),
+                                                      true);
 
         if (firstRun){
             startActivity(new Intent(GnuCashApplication.getAppContext(), FirstRunWizardActivity.class));
 
-            //default to using double entry and save the preference explicitly
+            // Default Preference to using double entry and save the preference explicitly
             prefs.edit().putBoolean(getString(R.string.key_use_double_entry), true).apply();
+
+            // Default preference not to show negative number in splits
+            prefs.edit().putBoolean(getString(R.string.key_display_negative_signum_in_splits), false).apply();
+
             finish();
+
             return;
         }
 

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -281,6 +281,7 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
 
     @Override
     protected void onStart() {
+
         super.onStart();
 
         if (BuildConfig.CAN_REQUEST_RATING) {
@@ -288,6 +289,11 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
             RateThisApp.onStart(this);
             RateThisApp.showRateDialogIfNeeded(this);
         }
+
+        Log.i(LOG_TAG,
+              "New active db (" + GnuCashApplication.getActiveDb()
+                                              .getPath() + ")");
+
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -499,13 +499,8 @@ public class AccountsListFragment extends Fragment implements
 
             // add a summary of transactions to the account view
 
-            // Get Preference about showing signum in Splits
-            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                      false);
                 // Make sure the balance task is truly multithread
-            new AccountBalanceTask(holder.accountBalance,
-                                   shallDisplayNegativeSignumInSplits).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+            new AccountBalanceTask(holder.accountBalance).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
                                                                                          accountUID);
 
             String accountColor = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_COLOR_CODE));

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -32,7 +32,6 @@ import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
@@ -484,27 +483,39 @@ public class AccountsListFragment extends Fragment implements
 
         @Override
         public void onBindViewHolderCursor(final AccountViewHolder holder, final Cursor cursor) {
-            final String accountUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_UID));
-            mAccountsDbAdapter = AccountsDbAdapter.getInstance();
-            holder.accoundId = mAccountsDbAdapter.getID(accountUID);
 
+            final String accountUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_UID));
+
+            mAccountsDbAdapter = AccountsDbAdapter.getInstance();
+
+            holder.accoundId = mAccountsDbAdapter.getID(accountUID);
             holder.accountName.setText(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_NAME)));
+
             int subAccountCount = mAccountsDbAdapter.getSubAccountCount(accountUID);
+
             if (subAccountCount > 0) {
                 holder.description.setVisibility(View.VISIBLE);
-                String text = getResources().getQuantityString(R.plurals.label_sub_accounts, subAccountCount, subAccountCount);
+                String text = getResources().getQuantityString(R.plurals.label_sub_accounts,
+                                                               subAccountCount,
+                                                               subAccountCount);
                 holder.description.setText(text);
-            } else
+
+            } else {
                 holder.description.setVisibility(View.GONE);
+            }
 
             // add a summary of transactions to the account view
 
-                // Make sure the balance task is truly multithread
+            // Make sure the balance task is truly multithread
             new AccountBalanceTask(holder.accountBalance).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                                                                                         accountUID);
+                                                                            accountUID);
 
             String accountColor = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_COLOR_CODE));
-            int colorCode = accountColor == null ? Color.TRANSPARENT : Color.parseColor(accountColor);
+
+            int    colorCode    = accountColor == null
+                                  ? Color.TRANSPARENT
+                                  : Color.parseColor(accountColor);
+
             holder.colorStripView.setBackgroundColor(colorCode);
 
             boolean isPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(accountUID);
@@ -515,21 +526,30 @@ public class AccountsListFragment extends Fragment implements
 
                     @Override
                     public void onClick(View v) {
-                        Intent intent = new Intent(getActivity(), FormActivity.class);
+
+                        Intent intent = new Intent(getActivity(),
+                                                   FormActivity.class);
                         intent.setAction(Intent.ACTION_INSERT_OR_EDIT);
-                        intent.putExtra(UxArgument.SELECTED_ACCOUNT_UID, accountUID);
-                        intent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.TRANSACTION.name());
+                        intent.putExtra(UxArgument.SELECTED_ACCOUNT_UID,
+                                        accountUID);
+                        intent.putExtra(UxArgument.FORM_TYPE,
+                                        FormActivity.FormType.TRANSACTION.name());
                         getActivity().startActivity(intent);
                     }
                 });
             }
 
-            List<Budget> budgets = BudgetsDbAdapter.getInstance().getAccountBudgets(accountUID);
+            List<Budget> budgets = BudgetsDbAdapter.getInstance()
+                                                   .getAccountBudgets(accountUID);
             //TODO: include fetch only active budgets
-            if (budgets.size() == 1){
-                Budget budget = budgets.get(0);
-                Money balance = mAccountsDbAdapter.getAccountBalance(accountUID, budget.getStartofCurrentPeriod(), budget.getEndOfCurrentPeriod());
-                double budgetProgress = balance.divide(budget.getAmount(accountUID)).asBigDecimal().doubleValue() * 100;
+            if (budgets.size() == 1) {
+                Budget budget         = budgets.get(0);
+                Money  balance        = mAccountsDbAdapter.getAccountBalance(accountUID,
+                                                                             budget.getStartofCurrentPeriod(),
+                                                                             budget.getEndOfCurrentPeriod());
+                double budgetProgress = balance.divide(budget.getAmount(accountUID))
+                                               .asBigDecimal()
+                                               .doubleValue() * 100;
 
                 holder.budgetIndicator.setVisibility(View.VISIBLE);
                 holder.budgetIndicator.setProgress((int) budgetProgress);
@@ -538,7 +558,7 @@ public class AccountsListFragment extends Fragment implements
             }
 
 
-            if (mAccountsDbAdapter.isFavoriteAccount(accountUID)){
+            if (mAccountsDbAdapter.isFavoriteAccount(accountUID)) {
                 holder.favoriteStatus.setImageResource(R.drawable.ic_star_black_24dp);
             } else {
                 holder.favoriteStatus.setImageResource(R.drawable.ic_star_border_black_24dp);
@@ -547,23 +567,29 @@ public class AccountsListFragment extends Fragment implements
             holder.favoriteStatus.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+
                     boolean isFavoriteAccount = mAccountsDbAdapter.isFavoriteAccount(accountUID);
 
                     ContentValues contentValues = new ContentValues();
-                    contentValues.put(DatabaseSchema.AccountEntry.COLUMN_FAVORITE, !isFavoriteAccount);
-                    mAccountsDbAdapter.updateRecord(accountUID, contentValues);
+                    contentValues.put(DatabaseSchema.AccountEntry.COLUMN_FAVORITE,
+                                      !isFavoriteAccount);
+                    mAccountsDbAdapter.updateRecord(accountUID,
+                                                    contentValues);
 
-                    int drawableResource = !isFavoriteAccount ?
-                            R.drawable.ic_star_black_24dp : R.drawable.ic_star_border_black_24dp;
+                    int drawableResource = !isFavoriteAccount
+                                           ? R.drawable.ic_star_black_24dp
+                                           : R.drawable.ic_star_border_black_24dp;
                     holder.favoriteStatus.setImageResource(drawableResource);
-                    if (mDisplayMode == DisplayMode.FAVORITES)
+                    if (mDisplayMode == DisplayMode.FAVORITES) {
                         refresh();
+                    }
                 }
             });
 
             holder.itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+
                     onListItemClick(accountUID);
                 }
             });

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -25,7 +25,6 @@ import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
@@ -33,6 +32,7 @@ import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
@@ -499,8 +499,14 @@ public class AccountsListFragment extends Fragment implements
 
             // add a summary of transactions to the account view
 
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
                 // Make sure the balance task is truly multithread
-            new AccountBalanceTask(holder.accountBalance).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, accountUID);
+            new AccountBalanceTask(holder.accountBalance,
+                                   shallDisplayNegativeSignumInSplits).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                                                                                         accountUID);
 
             String accountColor = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_COLOR_CODE));
             int colorCode = accountColor == null ? Color.TRANSPARENT : Color.parseColor(accountColor);

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -314,21 +314,45 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
-        long id = item.getItemId();
-        if (id == ID_MANAGE_BOOKS){
+
+        long itemId = item.getItemId();
+
+        if (itemId == ID_MANAGE_BOOKS){
+            // Click on "Manage books..." item
+
+            // Start "Manage books" Activity
             Intent intent = new Intent(this, PreferenceActivity.class);
             intent.setAction(PreferenceActivity.ACTION_MANAGE_BOOKS);
             startActivity(intent);
+
             mDrawerLayout.closeDrawer(mNavigationView);
-            return true;
+
+        } else {
+            // Click on an existing book item
+
+            BooksDbAdapter booksDbAdapter = BooksDbAdapter.getInstance();
+
+            String selectedBookUID = booksDbAdapter.getUID(itemId);
+
+            if (!selectedBookUID.equals(booksDbAdapter.getActiveBookUID())){
+                // Selected Book is not the active one
+
+                // Close current Activity
+                finish();
+
+                // load book and Start Account Activity and reset Activity Stack
+                BookUtils.loadBook(selectedBookUID);
+
+            } else {
+                // Selected Book is the current one
+
+                // Start Account Activity and reset Activity Stack
+                AccountsActivity.start(GnuCashApplication.getAppContext());
+            }
+
         }
-        BooksDbAdapter booksDbAdapter = BooksDbAdapter.getInstance();
-        String bookUID = booksDbAdapter.getUID(id);
-        if (!bookUID.equals(booksDbAdapter.getActiveBookUID())){
-            BookUtils.loadBook(bookUID);
-            finish();
-        }
-        AccountsActivity.start(GnuCashApplication.getAppContext());
+
+
         return true;
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -356,7 +356,9 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
                 List<ActivityManager.RunningTaskInfo> taskList         = mngr.getRunningTasks(10);
                 final ActivityManager.RunningTaskInfo task0RunningInfo = taskList.get(0);
 
-                if (task0RunningInfo.numActivities <= 1) {
+                if (task0RunningInfo.numActivities <= 1 || task0RunningInfo.baseActivity.getClassName()
+                                                                                        .equals(this.getClass()
+                                                                                                    .getName())) {
                     // This is the first Activity
 
                     // Close current Activity (pop Activity stack)

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -372,15 +372,15 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
                     // This is not the first Activity
 
                     Toast toast = Toast.makeText(this,
-                                                         "You must be on the Account Page to change Book",
-                                                         Toast.LENGTH_LONG);
+                                                 R.string.toast_must_be_on_account_page_to_change_book,
+                                                 Toast.LENGTH_LONG);
 
                     //
                     // Align-Center text inside the Toast
                     //
 
                     TextView toastTextView = (TextView) toast.getView()
-                                                              .findViewById(android.R.id.message);
+                                                             .findViewById(android.R.id.message);
                     if (toastTextView != null) {
                         toastTextView.setGravity(Gravity.CENTER);
                     }

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -16,6 +16,7 @@
 package org.gnucash.android.ui.common;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -32,11 +33,14 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.uservoice.uservoicesdk.UserVoice;
 
@@ -50,6 +54,8 @@ import org.gnucash.android.ui.report.ReportsActivity;
 import org.gnucash.android.ui.settings.PreferenceActivity;
 import org.gnucash.android.ui.transaction.ScheduledActionsActivity;
 import org.gnucash.android.util.BookUtils;
+
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -210,10 +216,11 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home){
-            if (!mDrawerLayout.isDrawerOpen(mNavigationView))
+            if (!isNavigationViewOpen()) {
                 mDrawerLayout.openDrawer(mNavigationView);
-            else
-                mDrawerLayout.closeDrawer(mNavigationView);
+            } else {
+                closeNavigationView();
+            }
             return true;
         }
 
@@ -286,7 +293,7 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
                 UserVoice.launchUserVoice(this);
                 break;
         }
-        mDrawerLayout.closeDrawer(mNavigationView);
+        closeNavigationView();
     }
 
     @Override
@@ -315,6 +322,8 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
     @Override
     public boolean onMenuItemClick(MenuItem item) {
 
+        closeNavigationView();
+
         long itemId = item.getItemId();
 
         if (itemId == ID_MANAGE_BOOKS){
@@ -325,8 +334,6 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
             intent.setAction(PreferenceActivity.ACTION_MANAGE_BOOKS);
             startActivity(intent);
 
-            mDrawerLayout.closeDrawer(mNavigationView);
-
         } else {
             // Click on an existing book item
 
@@ -334,14 +341,67 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
 
             String selectedBookUID = booksDbAdapter.getUID(itemId);
 
-            if (!selectedBookUID.equals(booksDbAdapter.getActiveBookUID())){
+            if (!selectedBookUID.equals(booksDbAdapter.getActiveBookUID())) {
                 // Selected Book is not the active one
 
-                // Close current Activity
-                finish();
+                //
+                // Check if current Activity is the first Activity
+                //
 
-                // load book and Start Account Activity and reset Activity Stack
-                BookUtils.loadBook(selectedBookUID);
+                Log.d("BaseDrawerActivity",
+                      "This is  (" + this.getClass()
+                                         .getName() + ")");
+
+                ActivityManager                       mngr             = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+                List<ActivityManager.RunningTaskInfo> taskList         = mngr.getRunningTasks(10);
+                final ActivityManager.RunningTaskInfo task0RunningInfo = taskList.get(0);
+
+                if (task0RunningInfo.numActivities <= 1) {
+                    // This is the first Activity
+
+                    // Close current Activity (pop Activity stack)
+                    finish();
+
+                    //
+                    // load selected book and Start Account Activity and reset Activity Stack
+                    //
+
+                    BookUtils.loadBook(selectedBookUID);
+
+                } else {
+                    // This is not the first Activity
+
+                    Toast toast = Toast.makeText(this,
+                                                         "You must be on the Account Page to change Book",
+                                                         Toast.LENGTH_LONG);
+
+                    //
+                    // Align-Center text inside the Toast
+                    //
+
+                    TextView toastTextView = (TextView) toast.getView()
+                                                              .findViewById(android.R.id.message);
+                    if (toastTextView != null) {
+                        toastTextView.setGravity(Gravity.CENTER);
+                    }
+
+                    // Show toast
+                    toast.show();
+                }
+
+//                // Android handler to delay actions
+//                Handler handler = new Handler();
+//
+//                // After two seconds, it is not more considered as already pressed
+//                handler.postDelayed(new Runnable() {
+//                                        @Override
+//                                        public void run() {
+//
+//                                            // load book and Start Account Activity and reset Activity Stack
+//                                            BookUtils.loadBook(selectedBookUID);
+//                                        }
+//                                    },
+//                                    5000);
 
             } else {
                 // Selected Book is the current one
@@ -356,9 +416,17 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
         return true;
     }
 
-    public void onClickAppTitle(View view){
+    protected void onClickAppTitle(View view) {
+
+        closeNavigationView();
+
+        // Do not launch AccountsActivity to stay on current Activity
+//        AccountsActivity.start(this);
+    }
+
+    protected void closeNavigationView() {
+
         mDrawerLayout.closeDrawer(mNavigationView);
-        AccountsActivity.start(this);
     }
 
     public void onClickBook(View view){
@@ -377,5 +445,15 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
         menu.add(0, ID_MANAGE_BOOKS, maxRecent, R.string.menu_manage_books);
 
         popup.show();
+    }
+
+    /**
+     * Return true if main navigation menu is open
+     *
+     * @return true if main navigation menu is open
+     */
+    protected boolean isNavigationViewOpen() {
+
+        return mDrawerLayout.isDrawerOpen(mNavigationView);
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
@@ -213,9 +213,10 @@ public class ReportsOverviewFragment extends BaseReportFragment {
         mChart.highlightValues(null);
         mChart.invalidate();
 
-        TransactionsActivity.displayBalance(mTotalAssets, mAssetsBalance);
-        TransactionsActivity.displayBalance(mTotalLiabilities, mLiabilitiesBalance);
-        TransactionsActivity.displayBalance(mNetWorth, mAssetsBalance.subtract(mLiabilitiesBalance));
+        TransactionsActivity.displayBalance(mTotalAssets, mAssetsBalance, AccountType.ASSET);
+        TransactionsActivity.displayBalance(mTotalLiabilities, mLiabilitiesBalance, AccountType.LIABILITY);
+        // #8xx
+        TransactionsActivity.displayBalance(mNetWorth, mAssetsBalance.add(mLiabilitiesBalance), null);
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
@@ -22,6 +22,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.AppCompatButton;
 import android.view.Menu;
 import android.view.View;
@@ -44,7 +45,6 @@ import org.gnucash.android.ui.report.barchart.StackedBarChartFragment;
 import org.gnucash.android.ui.report.linechart.CashFlowLineChartFragment;
 import org.gnucash.android.ui.report.piechart.PieChartFragment;
 import org.gnucash.android.ui.report.sheet.BalanceSheetFragment;
-import org.gnucash.android.ui.transaction.TransactionsActivity;
 import org.joda.time.LocalDate;
 
 import java.util.ArrayList;
@@ -213,10 +213,21 @@ public class ReportsOverviewFragment extends BaseReportFragment {
         mChart.highlightValues(null);
         mChart.invalidate();
 
-        AccountType.ASSET.displayBalance(mTotalAssets, mAssetsBalance);
-        AccountType.LIABILITY.displayBalance(mTotalLiabilities, mLiabilitiesBalance);
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
+
+        AccountType.ASSET.displayBalance(mTotalAssets,
+                                         mAssetsBalance,
+                                         shallDisplayNegativeSignumInSplits);
+        AccountType.LIABILITY.displayBalance(mTotalLiabilities,
+                                             mLiabilitiesBalance,
+                                             shallDisplayNegativeSignumInSplits);
         // #8xx
-        AccountType.ASSET.displayBalance(mNetWorth, mAssetsBalance.add(mLiabilitiesBalance));
+        AccountType.ASSET.displayBalance(mNetWorth,
+                                         mAssetsBalance.add(mLiabilitiesBalance),
+                                         shallDisplayNegativeSignumInSplits);
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
@@ -213,10 +213,10 @@ public class ReportsOverviewFragment extends BaseReportFragment {
         mChart.highlightValues(null);
         mChart.invalidate();
 
-        TransactionsActivity.displayBalance(mTotalAssets, mAssetsBalance, AccountType.ASSET);
-        TransactionsActivity.displayBalance(mTotalLiabilities, mLiabilitiesBalance, AccountType.LIABILITY);
+        AccountType.ASSET.displayBalance(mTotalAssets, mAssetsBalance);
+        AccountType.LIABILITY.displayBalance(mTotalLiabilities, mLiabilitiesBalance);
         // #8xx
-        TransactionsActivity.displayBalance(mNetWorth, mAssetsBalance.add(mLiabilitiesBalance), null);
+        AccountType.ASSET.displayBalance(mNetWorth, mAssetsBalance.add(mLiabilitiesBalance));
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/ReportsOverviewFragment.java
@@ -213,21 +213,13 @@ public class ReportsOverviewFragment extends BaseReportFragment {
         mChart.highlightValues(null);
         mChart.invalidate();
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
-
         AccountType.ASSET.displayBalance(mTotalAssets,
-                                         mAssetsBalance,
-                                         shallDisplayNegativeSignumInSplits);
+                                         mAssetsBalance);
         AccountType.LIABILITY.displayBalance(mTotalLiabilities,
-                                             mLiabilitiesBalance,
-                                             shallDisplayNegativeSignumInSplits);
+                                             mLiabilitiesBalance);
         // #8xx
         AccountType.ASSET.displayBalance(mNetWorth,
-                                         mAssetsBalance.add(mLiabilitiesBalance),
-                                         shallDisplayNegativeSignumInSplits);
+                                         mAssetsBalance.add(mLiabilitiesBalance));
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
@@ -19,7 +19,6 @@ import android.database.Cursor;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -103,14 +102,9 @@ public class BalanceSheetFragment extends BaseReportFragment {
         loadAccountViews(LIABLITY_ACCOUNT_TYPES, mLiabilitiesTableLayout);
         loadAccountViews(EQUITY_ACCOUNT_TYPES, mEquityTableLayout);
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
         AccountType.ASSET.displayBalance(mNetWorth,
                                          // #8xx
-                                         mAssetsBalance.add(mLiabilitiesBalance),
-                                         shallDisplayNegativeSignumInSplits);
+                                         mAssetsBalance.add(mLiabilitiesBalance));
     }
 
     @Override
@@ -144,14 +138,8 @@ public class BalanceSheetFragment extends BaseReportFragment {
             TextView    balanceTextView = (TextView) view.findViewById(R.id.account_balance);
             accountType     = AccountType.valueOf(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_TYPE)));
 
-            // Get Preference about showing signum in Splits
-            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                      false);
-
             accountType.displayBalance(balanceTextView,
-                                       balance,
-                                       shallDisplayNegativeSignumInSplits);
+                                       balance);
 
             tableLayout.addView(view);
         }
@@ -168,15 +156,10 @@ public class BalanceSheetFragment extends BaseReportFragment {
         accountBalance.setTextSize(16);
         accountBalance.setTypeface(null, Typeface.BOLD);
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
         accountType.displayBalance(accountBalance,
                                    mAccountsDbAdapter.getAccountBalance(accountTypes,
                                                                         -1,
-                                                                        System.currentTimeMillis()),
-                                   shallDisplayNegativeSignumInSplits);
+                                                                        System.currentTimeMillis()));
 
         tableLayout.addView(totalView);
     }

--- a/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
@@ -33,9 +33,7 @@ import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.ui.report.BaseReportFragment;
 import org.gnucash.android.ui.report.ReportType;
-import org.gnucash.android.ui.transaction.TransactionsActivity;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import butterknife.BindView;
@@ -104,10 +102,9 @@ public class BalanceSheetFragment extends BaseReportFragment {
         loadAccountViews(LIABLITY_ACCOUNT_TYPES, mLiabilitiesTableLayout);
         loadAccountViews(EQUITY_ACCOUNT_TYPES, mEquityTableLayout);
 
-        TransactionsActivity.displayBalance(mNetWorth,
-                                            // #8xx
-                                            mAssetsBalance.add(mLiabilitiesBalance),
-                                            null);
+        AccountType.ASSET.displayBalance(mNetWorth,
+                                         // #8xx
+                                         mAssetsBalance.add(mLiabilitiesBalance));
     }
 
     @Override
@@ -140,9 +137,8 @@ public class BalanceSheetFragment extends BaseReportFragment {
             ((TextView)view.findViewById(R.id.account_name)).setText(name);
             TextView    balanceTextView = (TextView) view.findViewById(R.id.account_balance);
             accountType     = AccountType.valueOf(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_TYPE)));
-            TransactionsActivity.displayBalance(balanceTextView,
-                                                balance,
-                                                accountType);
+            accountType.displayBalance(balanceTextView,
+                                       balance);
             tableLayout.addView(view);
         }
 
@@ -157,11 +153,10 @@ public class BalanceSheetFragment extends BaseReportFragment {
         TextView accountBalance = (TextView) totalView.findViewById(R.id.account_balance);
         accountBalance.setTextSize(16);
         accountBalance.setTypeface(null, Typeface.BOLD);
-        TransactionsActivity.displayBalance(accountBalance,
-                                            mAccountsDbAdapter.getAccountBalance(accountTypes,
-                                                                                 -1,
-                                                                                 System.currentTimeMillis()),
-                                            accountType);
+        accountType.displayBalance(accountBalance,
+                                   mAccountsDbAdapter.getAccountBalance(accountTypes,
+                                                                        -1,
+                                                                        System.currentTimeMillis()));
 
         tableLayout.addView(totalView);
     }

--- a/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
@@ -19,6 +19,7 @@ import android.database.Cursor;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -102,9 +103,14 @@ public class BalanceSheetFragment extends BaseReportFragment {
         loadAccountViews(LIABLITY_ACCOUNT_TYPES, mLiabilitiesTableLayout);
         loadAccountViews(EQUITY_ACCOUNT_TYPES, mEquityTableLayout);
 
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
         AccountType.ASSET.displayBalance(mNetWorth,
                                          // #8xx
-                                         mAssetsBalance.add(mLiabilitiesBalance));
+                                         mAssetsBalance.add(mLiabilitiesBalance),
+                                         shallDisplayNegativeSignumInSplits);
     }
 
     @Override
@@ -137,8 +143,16 @@ public class BalanceSheetFragment extends BaseReportFragment {
             ((TextView)view.findViewById(R.id.account_name)).setText(name);
             TextView    balanceTextView = (TextView) view.findViewById(R.id.account_balance);
             accountType     = AccountType.valueOf(cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_TYPE)));
+
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
+
             accountType.displayBalance(balanceTextView,
-                                       balance);
+                                       balance,
+                                       shallDisplayNegativeSignumInSplits);
+
             tableLayout.addView(view);
         }
 
@@ -153,10 +167,16 @@ public class BalanceSheetFragment extends BaseReportFragment {
         TextView accountBalance = (TextView) totalView.findViewById(R.id.account_balance);
         accountBalance.setTextSize(16);
         accountBalance.setTypeface(null, Typeface.BOLD);
+
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
         accountType.displayBalance(accountBalance,
                                    mAccountsDbAdapter.getAccountBalance(accountTypes,
                                                                         -1,
-                                                                        System.currentTimeMillis()));
+                                                                        System.currentTimeMillis()),
+                                   shallDisplayNegativeSignumInSplits);
 
         tableLayout.addView(totalView);
     }

--- a/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/sheet/BalanceSheetFragment.java
@@ -40,6 +40,10 @@ import java.util.List;
 
 import butterknife.BindView;
 
+import static org.gnucash.android.model.AccountType.ASSET_ACCOUNT_TYPES;
+import static org.gnucash.android.model.AccountType.EQUITY_ACCOUNT_TYPES;
+import static org.gnucash.android.model.AccountType.LIABLITY_ACCOUNT_TYPES;
+
 /**
  * Balance sheet report fragment
  * @author Ngewi Fet <ngewif@gmail.com>
@@ -56,9 +60,6 @@ public class BalanceSheetFragment extends BaseReportFragment {
 
     private Money mAssetsBalance;
     private Money mLiabilitiesBalance;
-    private List<AccountType> mAssetAccountTypes;
-    private List<AccountType> mLiabilityAccountTypes;
-    private List<AccountType> mEquityAccountTypes;
 
     @Override
     public int getLayoutResource() {
@@ -78,19 +79,6 @@ public class BalanceSheetFragment extends BaseReportFragment {
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
-        // TODO TW C 2020-03-06 : A mettre dans AccountType sous formes de constantes
-        mAssetAccountTypes = new ArrayList<>();
-        mAssetAccountTypes.add(AccountType.ASSET);
-        mAssetAccountTypes.add(AccountType.CASH);
-        mAssetAccountTypes.add(AccountType.BANK);
-
-        mLiabilityAccountTypes = new ArrayList<>();
-        mLiabilityAccountTypes.add(AccountType.LIABILITY);
-        mLiabilityAccountTypes.add(AccountType.CREDIT);
-
-        mEquityAccountTypes = new ArrayList<>();
-        mEquityAccountTypes.add(AccountType.EQUITY);
     }
 
     @Override
@@ -105,16 +93,16 @@ public class BalanceSheetFragment extends BaseReportFragment {
 
     @Override
     protected void generateReport() {
-        mAssetsBalance = mAccountsDbAdapter.getAccountBalance(mAssetAccountTypes, -1, System.currentTimeMillis());
-        mLiabilitiesBalance = mAccountsDbAdapter.getAccountBalance(mLiabilityAccountTypes, -1, System.currentTimeMillis());
+        mAssetsBalance = mAccountsDbAdapter.getAccountBalance(ASSET_ACCOUNT_TYPES, -1, System.currentTimeMillis());
+        mLiabilitiesBalance = mAccountsDbAdapter.getAccountBalance(LIABLITY_ACCOUNT_TYPES, -1, System.currentTimeMillis());
     }
 
     @Override
     protected void displayReport() {
 
-        loadAccountViews(mAssetAccountTypes, mAssetsTableLayout);
-        loadAccountViews(mLiabilityAccountTypes, mLiabilitiesTableLayout);
-        loadAccountViews(mEquityAccountTypes, mEquityTableLayout);
+        loadAccountViews(ASSET_ACCOUNT_TYPES, mAssetsTableLayout);
+        loadAccountViews(LIABLITY_ACCOUNT_TYPES, mLiabilitiesTableLayout);
+        loadAccountViews(EQUITY_ACCOUNT_TYPES, mEquityTableLayout);
 
         TransactionsActivity.displayBalance(mNetWorth,
                                             // #8xx

--- a/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
@@ -107,24 +107,58 @@ public class GeneralPreferenceFragment extends PreferenceFragmentCompat implemen
     }
 
     @Override
-    public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (preference.getKey().equals(getString(R.string.key_enable_passcode))) {
+    public boolean onPreferenceChange(Preference preference,
+                                      Object newValue) {
+
+        if (preference.getKey()
+                      .equals(getString(R.string.key_enable_passcode))) {
+
             if ((Boolean) newValue) {
-                startActivityForResult(new Intent(getActivity(), PasscodePreferenceActivity.class),
-                        GeneralPreferenceFragment.PASSCODE_REQUEST_CODE);
+
+                startActivityForResult(new Intent(getActivity(),
+                                                  PasscodePreferenceActivity.class),
+                                       GeneralPreferenceFragment.PASSCODE_REQUEST_CODE);
+
             } else {
-                Intent passIntent = new Intent(getActivity(), PasscodeLockScreenActivity.class);
-                passIntent.putExtra(UxArgument.DISABLE_PASSCODE, UxArgument.DISABLE_PASSCODE);
-                startActivityForResult(passIntent, GeneralPreferenceFragment.REQUEST_DISABLE_PASSCODE);
+
+                Intent passIntent = new Intent(getActivity(),
+                                               PasscodeLockScreenActivity.class);
+                passIntent.putExtra(UxArgument.DISABLE_PASSCODE,
+                                    UxArgument.DISABLE_PASSCODE);
+                startActivityForResult(passIntent,
+                                       GeneralPreferenceFragment.REQUEST_DISABLE_PASSCODE);
             }
         }
 
-        if (preference.getKey().equals(getString(R.string.key_use_account_color))) {
+        //
+        // Set Preference : use_color_in_reports
+        //
+
+        if (preference.getKey()
+                      .equals(getString(R.string.key_use_account_color))) {
+
             getPreferenceManager().getSharedPreferences()
-                    .edit()
-                    .putBoolean(getString(R.string.key_use_account_color), Boolean.valueOf(newValue.toString()))
-                    .commit();
+                                  .edit()
+                                  .putBoolean(getString(R.string.key_use_account_color),
+                                              Boolean.valueOf(newValue.toString()))
+                                  .commit();
         }
+
+        //
+        // Preference : key_display_negative_signum_in_splits
+        //
+
+        if (preference.getKey()
+                      .equals(getString(R.string.key_display_negative_signum_in_splits))) {
+
+            // Store the new value of the Preference
+            getPreferenceManager().getSharedPreferences()
+                                  .edit()
+                                  .putBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                              Boolean.valueOf(newValue.toString()))
+                                  .commit();
+        }
+
         return true;
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/GeneralPreferenceFragment.java
@@ -144,21 +144,6 @@ public class GeneralPreferenceFragment extends PreferenceFragmentCompat implemen
                                   .commit();
         }
 
-        //
-        // Preference : key_display_negative_signum_in_splits
-        //
-
-        if (preference.getKey()
-                      .equals(getString(R.string.key_display_negative_signum_in_splits))) {
-
-            // Store the new value of the Preference
-            getPreferenceManager().getSharedPreferences()
-                                  .edit()
-                                  .putBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                              Boolean.valueOf(newValue.toString()))
-                                  .commit();
-        }
-
         return true;
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/TransactionsPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/TransactionsPreferenceFragment.java
@@ -22,17 +22,17 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.preference.SwitchPreferenceCompat;
 
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.BooksDbAdapter;
-import org.gnucash.android.db.adapter.CommoditiesDbAdapter;
 import org.gnucash.android.model.Commodity;
 import org.gnucash.android.ui.settings.dialog.DeleteAllTransactionsConfirmationDialog;
 
-import java.util.Currency;
 import java.util.List;
 
 /**
@@ -44,6 +44,7 @@ public class TransactionsPreferenceFragment extends PreferenceFragmentCompat imp
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
+
 		super.onCreate(savedInstanceState);
 
 		getPreferenceManager().setSharedPreferencesName(BooksDbAdapter.getInstance().getActiveBookUID());
@@ -55,28 +56,41 @@ public class TransactionsPreferenceFragment extends PreferenceFragmentCompat imp
 	}
 
 	@Override
-	public void onCreatePreferences(Bundle bundle, String s) {
+	public void onCreatePreferences(Bundle bundle,
+									String s) {
+
 		addPreferencesFromResource(R.xml.fragment_transaction_preferences);
 	}
 
 	@Override
 	public void onResume() {
-		super.onResume();
-		
-		SharedPreferences sharedPreferences = getPreferenceManager().getSharedPreferences();
-		String defaultTransactionType = sharedPreferences.getString(
-				getString(R.string.key_default_transaction_type),
-				getString(R.string.label_debit));
-		Preference pref = findPreference(getString(R.string.key_default_transaction_type));		
-		setLocalizedSummary(pref, defaultTransactionType);
-		pref.setOnPreferenceChangeListener(this);
 
-        pref = findPreference(getString(R.string.key_use_double_entry));
+		super.onResume();
+
+//		SharedPreferences sharedPreferences = getPreferenceManager().getSharedPreferences();
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(GnuCashApplication.getAppContext());
+
+		String keyDefaultTransactionType = getString(R.string.key_default_transaction_type_switch);
+		boolean isCredit = sharedPreferences.getBoolean(keyDefaultTransactionType,
+														true);
+		SwitchPreferenceCompat switchPref = (SwitchPreferenceCompat) findPreference(keyDefaultTransactionType);
+		setLocalizedSummary(switchPref,
+							isCredit);
+		switchPref.setChecked(isCredit);
+		switchPref.setOnPreferenceChangeListener(this);
+
+		Preference pref = findPreference(getString(R.string.key_use_double_entry));
         pref.setOnPreferenceChangeListener(this);
 
 		String keyCompactView = getString(R.string.key_use_compact_list);
-		SwitchPreferenceCompat switchPref = (SwitchPreferenceCompat) findPreference(keyCompactView);
+		switchPref = (SwitchPreferenceCompat) findPreference(keyCompactView);
 		switchPref.setChecked(sharedPreferences.getBoolean(keyCompactView, false));
+
+		String keyDisplayNegativeSignumInSplits = getString(R.string.key_display_negative_signum_in_splits);
+		switchPref = (SwitchPreferenceCompat) findPreference(keyDisplayNegativeSignumInSplits);
+		switchPref.setChecked(sharedPreferences.getBoolean(keyDisplayNegativeSignumInSplits,
+														   false));
+		switchPref.setOnPreferenceChangeListener(this);
 
 		String keySaveBalance = getString(R.string.key_save_opening_balances);
 		switchPref = (SwitchPreferenceCompat) findPreference(keySaveBalance);
@@ -97,13 +111,54 @@ public class TransactionsPreferenceFragment extends PreferenceFragmentCompat imp
 	}
 
 	@Override
-	public boolean onPreferenceChange(Preference preference, Object newValue) {
-		if (preference.getKey().equals(getString(R.string.key_use_double_entry))){
+	public boolean onPreferenceChange(Preference preference,
+									  Object newValue) {
+
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(GnuCashApplication.getAppContext());
+
+		//
+		// Preference : key_default_transaction_type
+		//
+
+		if (preference.getKey()
+					  .equals(getString(R.string.key_default_transaction_type_switch))) {
+
+			// Store the new value of the Preference
+			sharedPreferences.edit()
+							 .putBoolean(getString(R.string.key_default_transaction_type_switch),
+										 Boolean.valueOf(newValue.toString()))
+							 .commit();
+
+			setLocalizedSummary(preference,
+								((boolean) newValue));
+		}
+
+		//
+		// Preference : key_use_double_entry
+		//
+
+		if (preference.getKey()
+					  .equals(getString(R.string.key_use_double_entry))) {
+
 			boolean useDoubleEntry = (Boolean) newValue;
 			setImbalanceAccountsHidden(useDoubleEntry);
-        } else {
-            setLocalizedSummary(preference, newValue.toString());
-        }
+
+		}
+
+		//
+		// Preference : key_display_negative_signum_in_splits
+		//
+
+		if (preference.getKey()
+					  .equals(getString(R.string.key_display_negative_signum_in_splits))) {
+
+			// Store the new value of the Preference
+			sharedPreferences.edit()
+							 .putBoolean(getString(R.string.key_display_negative_signum_in_splits),
+										 Boolean.valueOf(newValue.toString()))
+							 .commit();
+		}
+
 		return true;
 	}
 
@@ -135,10 +190,15 @@ public class TransactionsPreferenceFragment extends PreferenceFragmentCompat imp
     /**
      * Localizes the label for DEBIT/CREDIT in the settings summary
      * @param preference Preference whose summary is to be localized
-     * @param value New value for the preference summary
+	 * @param isCredit New isCredit for the preference summary
      */
-	private void setLocalizedSummary(Preference preference, String value){
-		String localizedLabel = value.equals("DEBIT") ? getString(R.string.label_debit) : getActivity().getString(R.string.label_credit);
+	private void setLocalizedSummary(Preference preference,
+									 boolean isCredit) {
+
+		String localizedLabel = isCredit
+								? getString(R.string.label_credit)
+								: getString(R.string.label_debit);
+
 		preference.setSummary(localizedLabel);
 	}
 	

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -475,7 +475,7 @@ public class SplitEditorFragment extends Fragment {
             splitUidTextView.setText(BaseModel.generateUID());
 
             //
-            // Handle split
+            // Fill views from Split data
             //
 
             if (split != null) {
@@ -484,8 +484,10 @@ public class SplitEditorFragment extends Fragment {
                 splitAmountEditText.setCommodity(split.getValue()
                                                       .getCommodity());
 
-                splitAmountEditText.setValue(split.getFormattedValue()
-                                                  .asBigDecimal());
+                // TODO TW C 2020-03-07 : Mettre une préférence pour le signe
+                // Display abs value because switch button is visible
+                splitAmountEditText.setValue(split.getValueWithSignum()
+                                                  .asBigDecimal().abs());
 
                 splitCurrencyTextView.setText(split.getValue()
                                                    .getCommodity()

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -483,6 +483,7 @@ public class SplitEditorFragment extends Fragment {
 
                 splitAmountEditText.setCommodity(split.getValue()
                                                       .getCommodity());
+
                 splitAmountEditText.setValue(split.getFormattedValue()
                                                   .asBigDecimal());
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -641,7 +641,7 @@ public class SplitEditorFragment extends Fragment {
     private class SplitTransferAccountSelectedListener
             implements AdapterView.OnItemSelectedListener {
 
-        private TransactionTypeSwitch mTypeToggleButton;
+        private TransactionTypeSwitch mTransactionTypeSwitch;
         private SplitViewHolder       mSplitViewHolder;
 
         /**
@@ -649,14 +649,14 @@ public class SplitEditorFragment extends Fragment {
          */
         boolean userInteraction = false;
 
-        public SplitTransferAccountSelectedListener(TransactionTypeSwitch typeToggleButton,
+        public SplitTransferAccountSelectedListener(TransactionTypeSwitch transactionTypeSwitch,
                                                     SplitViewHolder viewHolder) {
 
             this.mSplitViewHolder = viewHolder;
 
-            this.mTypeToggleButton = typeToggleButton;
-            this.mTypeToggleButton.setViewsToColorize(mSplitViewHolder.splitAmountEditText,
-                                                      mSplitViewHolder.splitCurrencyTextView);
+            this.mTransactionTypeSwitch = transactionTypeSwitch;
+            this.mTransactionTypeSwitch.setViewsToColorize(mSplitViewHolder.splitAmountEditText,
+                                                           mSplitViewHolder.splitCurrencyTextView);
         }
 
         /**
@@ -676,8 +676,7 @@ public class SplitEditorFragment extends Fragment {
 
             AccountType accountType = mAccountsDbAdapter.getAccountType(id);
 
-            // TODO TW C 2020-03-03 : A renommer mTransactionTypeSwitch ou mSplitTypeSwitch
-            mTypeToggleButton.setAccountType(accountType);
+            mTransactionTypeSwitch.setAccountType(accountType);
 
             //refresh the imbalance amount if we change the account
             mImbalanceWatcher.afterTextChanged(null);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -154,14 +154,10 @@ public class SplitEditorFragment extends Fragment {
             view.findViewById(R.id.input_accounts_spinner).setEnabled(false);
             view.findViewById(R.id.btn_remove_split).setVisibility(View.GONE);
 
-            // Get Preference about showing signum in Splits
-            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                      false);
-            accountType.displayBalance(mImbalanceTextView,
+            // Display imbalance with signum and currency as if it was an asset
+            AccountType.ASSET.displayBalance(mImbalanceTextView,
                                        new Money(mBaseAmount.negate(),
-                                                 mCommodity),
-                                       shallDisplayNegativeSignumInSplits);
+                                                 mCommodity));
         }
 
     }
@@ -660,15 +656,12 @@ public class SplitEditorFragment extends Fragment {
 
             } // for
 
-            // Get Preference about showing signum in Splits
-            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                      false);
+//            AccountType accountType = mAccountsDbAdapter.getAccountType(mAccountUID);
 
+            // Display imbalance with signum and currency as if it was an asset
             AccountType.ASSET.displayBalance(mImbalanceTextView,
                                              new Money(imbalance,
-                                                       mCommodity),
-                                             shallDisplayNegativeSignumInSplits);
+                                                       mCommodity));
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -151,7 +151,11 @@ public class SplitEditorFragment extends Fragment {
             View view = addSplitView(split);
             view.findViewById(R.id.input_accounts_spinner).setEnabled(false);
             view.findViewById(R.id.btn_remove_split).setVisibility(View.GONE);
-            TransactionsActivity.displayBalance(mImbalanceTextView, new Money(mBaseAmount.negate(), mCommodity));
+
+            TransactionsActivity.displayBalance(mImbalanceTextView,
+                                                new Money(mBaseAmount.negate(),
+                                                          mCommodity),
+                                                accountType);
         }
 
     }
@@ -580,6 +584,7 @@ public class SplitEditorFragment extends Fragment {
             BigDecimal imbalance = BigDecimal.ZERO;
 
             for (View splitItem : mSplitItemViewList) {
+
                 SplitViewHolder viewHolder = (SplitViewHolder) splitItem.getTag();
 
                 // Get the absolute value of the amount
@@ -626,7 +631,8 @@ public class SplitEditorFragment extends Fragment {
 
             TransactionsActivity.displayBalance(mImbalanceTextView,
                                                 new Money(imbalance,
-                                                          mCommodity));
+                                                          mCommodity),
+                                                null);
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -454,7 +454,6 @@ public class SplitEditorFragment extends Fragment {
             splitTypeSwitch.setViewsToColorize(splitAmountEditText,
                                                splitCurrencyTextView);
 
-            // TODO TW C 2020-03-03 : A enlever ou mettre dans un else ?
             // Switch on/off according to amount signum
             splitTypeSwitch.setChecked(mBaseAmount.signum() > 0);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -442,14 +442,23 @@ public class SplitEditorFragment extends Fragment {
                 public void onCheckedChanged(CompoundButton buttonView,
                                              boolean isChecked) {
 
-                    // Change Transaction Type according to splitTypeSwitch
-                    split.setType(splitTypeSwitch.getTransactionType());
+                    if (split != null) {
+                        // Split not null
 
-                    // Update Split Amount Signum
-                    updateSplitAmountEditText(split);
+                        // Change Transaction Type according to splitTypeSwitch
+                        split.setType(splitTypeSwitch.getTransactionType());
 
-                    // Recompute Split List Balance
-                    mImbalanceWatcher.afterTextChanged(null);
+                        // Update Split Amount Signum
+                        updateSplitAmountEditText(split);
+
+                        // Recompute Split List Balance
+                        mImbalanceWatcher.afterTextChanged(null);
+
+                    } else {
+                        // Split is null
+
+                        // RAF
+                    }
                 }
             });
         }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -25,6 +25,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -484,9 +485,16 @@ public class SplitEditorFragment extends Fragment {
                 splitAmountEditText.setCommodity(split.getValue()
                                                       .getCommodity());
 
-                // TODO TW C 2020-03-07 : Mettre une préférence pour le signe
+                // Get Preference about showing signum in Splits
+                boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                              .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                          false);
+
                 // Display abs value because switch button is visible
-                splitAmountEditText.setValue(split.getValueWithSignum()
+                splitAmountEditText.setValue(shallDisplayNegativeSignumInSplits
+                                             ? split.getValueWithSignum()
+                                                    .asBigDecimal()
+                                             : split.getValueWithSignum()
                                                   .asBigDecimal().abs());
 
                 splitCurrencyTextView.setText(split.getValue()

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -152,10 +152,9 @@ public class SplitEditorFragment extends Fragment {
             view.findViewById(R.id.input_accounts_spinner).setEnabled(false);
             view.findViewById(R.id.btn_remove_split).setVisibility(View.GONE);
 
-            TransactionsActivity.displayBalance(mImbalanceTextView,
-                                                new Money(mBaseAmount.negate(),
-                                                          mCommodity),
-                                                accountType);
+            accountType.displayBalance(mImbalanceTextView,
+                                       new Money(mBaseAmount.negate(),
+                                                 mCommodity));
         }
 
     }
@@ -628,10 +627,9 @@ public class SplitEditorFragment extends Fragment {
 
             } // for
 
-            TransactionsActivity.displayBalance(mImbalanceTextView,
-                                                new Money(imbalance,
-                                                          mCommodity),
-                                                null);
+            AccountType.ASSET.displayBalance(mImbalanceTextView,
+                                             new Money(imbalance,
+                                                       mCommodity));
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -539,7 +539,8 @@ public class SplitEditorFragment extends Fragment {
             // Display abs value because switch button is visible
             accountType.displayBalanceWithoutCurrency(splitAmountEditText,
                                                       splitValueWithSignum,
-                                                      shallDisplayNegativeSignumInSplits);
+                                                      shallDisplayNegativeSignumInSplits,
+                                                      false);
         }
 
         /**

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -60,7 +60,6 @@ import org.gnucash.android.model.TransactionType;
 import org.gnucash.android.ui.common.FormActivity;
 import org.gnucash.android.ui.common.UxArgument;
 import org.gnucash.android.ui.transaction.dialog.TransferFundsDialogFragment;
-import org.gnucash.android.ui.util.AccountUtils;
 import org.gnucash.android.ui.util.widget.CalculatorEditText;
 import org.gnucash.android.ui.util.widget.CalculatorKeyboard;
 import org.gnucash.android.ui.util.widget.TransactionTypeSwitch;
@@ -430,8 +429,7 @@ public class SplitEditorFragment extends Fragment {
             //
 
             // Set a ColorizeOnTransactionTypeChange listener
-            splitTypeSwitch.setColorizeOnCheckedChangeListener(splitAmountEditText,
-                                                               splitCurrencyTextView);
+            splitTypeSwitch.setColorizeOnCheckedChangeListener();
 
             splitTypeSwitch.addOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
@@ -448,6 +446,9 @@ public class SplitEditorFragment extends Fragment {
             //
             // splitTypeSwitch
             //
+
+            splitTypeSwitch.setViewsToColorize(splitAmountEditText,
+                                               splitCurrencyTextView);
 
             // TODO TW C 2020-03-03 : A enlever ou mettre dans un else ?
             // Switch on/off according to amount signum
@@ -651,8 +652,11 @@ public class SplitEditorFragment extends Fragment {
         public SplitTransferAccountSelectedListener(TransactionTypeSwitch typeToggleButton,
                                                     SplitViewHolder viewHolder) {
 
-            this.mTypeToggleButton = typeToggleButton;
             this.mSplitViewHolder = viewHolder;
+
+            this.mTypeToggleButton = typeToggleButton;
+            this.mTypeToggleButton.setViewsToColorize(mSplitViewHolder.splitAmountEditText,
+                                                      mSplitViewHolder.splitCurrencyTextView);
         }
 
         /**

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -386,7 +386,7 @@ public class SplitEditorFragment extends Fragment {
             this.splitView = splitView;
 
             // Set Listeners
-            setListeners();
+            setListeners(split);
 
             if (split != null && !split.getQuantity()
                                        .equals(split.getValue())) {
@@ -397,7 +397,7 @@ public class SplitEditorFragment extends Fragment {
             initViews(split);
         }
 
-        private void setListeners() {
+        private void setListeners(Split split) {
 
             //
             // Listeners on splitAmountEditText
@@ -440,6 +440,13 @@ public class SplitEditorFragment extends Fragment {
                 public void onCheckedChanged(CompoundButton buttonView,
                                              boolean isChecked) {
 
+                    // Change Transaction Type according to splitTypeSwitch
+                    split.setType(splitTypeSwitch.getTransactionType());
+
+                    // Update Split Amount Signum
+                    updateSplitAmountEditText(split);
+
+                    // Recompute Split List Balance
                     mImbalanceWatcher.afterTextChanged(null);
                 }
             });
@@ -485,17 +492,8 @@ public class SplitEditorFragment extends Fragment {
                 splitAmountEditText.setCommodity(split.getValue()
                                                       .getCommodity());
 
-                // Get Preference about showing signum in Splits
-                boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                              .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                          false);
-
-                // Display abs value because switch button is visible
-                splitAmountEditText.setValue(shallDisplayNegativeSignumInSplits
-                                             ? split.getValueWithSignum()
-                                                    .asBigDecimal()
-                                             : split.getValueWithSignum()
-                                                  .asBigDecimal().abs());
+                // Update Split Amount EditText
+                updateSplitAmountEditText(split);
 
                 splitCurrencyTextView.setText(split.getValue()
                                                    .getCommodity()
@@ -513,6 +511,22 @@ public class SplitEditorFragment extends Fragment {
 
                 splitTypeSwitch.setChecked(split.getType());
             }
+        }
+
+        private void updateSplitAmountEditText(final Split split) {
+
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
+
+            final Money splitValueWithSignum = split.getValueWithSignum();
+
+            // Display abs value because switch button is visible
+            splitAmountEditText.setValue(!shallDisplayNegativeSignumInSplits
+                                         ? splitValueWithSignum.asBigDecimal()
+                                                               .abs()
+                                         : splitValueWithSignum.asBigDecimal());
         }
 
         /**
@@ -562,7 +576,7 @@ public class SplitEditorFragment extends Fragment {
     //
 
     /**
-     * Updates the displayed balance of the accounts when the amount of a split is changed
+     * Updates the displayed balance of the list of Splits when the amount of a split is changed
      */
     private class BalanceTextWatcher
             implements TextWatcher {

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -153,9 +153,14 @@ public class SplitEditorFragment extends Fragment {
             view.findViewById(R.id.input_accounts_spinner).setEnabled(false);
             view.findViewById(R.id.btn_remove_split).setVisibility(View.GONE);
 
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
             accountType.displayBalance(mImbalanceTextView,
                                        new Money(mBaseAmount.negate(),
-                                                 mCommodity));
+                                                 mCommodity),
+                                       shallDisplayNegativeSignumInSplits);
         }
 
     }
@@ -652,9 +657,15 @@ public class SplitEditorFragment extends Fragment {
 
             } // for
 
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
+
             AccountType.ASSET.displayBalance(mImbalanceTextView,
                                              new Money(imbalance,
-                                                       mCommodity));
+                                                       mCommodity),
+                                             shallDisplayNegativeSignumInSplits);
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/SplitEditorFragment.java
@@ -48,6 +48,7 @@ import net.objecthunter.exp4j.Expression;
 import net.objecthunter.exp4j.ExpressionBuilder;
 
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.CommoditiesDbAdapter;
@@ -527,11 +528,13 @@ public class SplitEditorFragment extends Fragment {
 
             final Money splitValueWithSignum = split.getValueWithSignum();
 
+            AccountType accountType = GnuCashApplication.getAccountsDbAdapter()
+                                                        .getAccountType(split.getAccountUID());
+
             // Display abs value because switch button is visible
-            splitAmountEditText.setValue(!shallDisplayNegativeSignumInSplits
-                                         ? splitValueWithSignum.asBigDecimal()
-                                                               .abs()
-                                         : splitValueWithSignum.asBigDecimal());
+            accountType.displayBalanceWithoutCurrency(splitAmountEditText,
+                                                      splitValueWithSignum,
+                                                      shallDisplayNegativeSignumInSplits);
         }
 
         /**

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -27,7 +27,6 @@ import org.gnucash.android.model.Transaction;
 import org.gnucash.android.ui.common.FormActivity;
 import org.gnucash.android.ui.common.UxArgument;
 import org.gnucash.android.ui.passcode.PasscodeLockActivity;
-import org.gnucash.android.ui.util.AccountTypeUtils;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -67,7 +66,7 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
             // splitSignedAmount (positive or negative number)
             Money splitSignedAmount = split.getValueWithSignum();
 
-            // Define debit or credit view
+            // Use debit or credit view
             TextView balanceView = splitSignedAmount.isNegative()
                                    ? splitCreditView
                                    : splitDebitView;
@@ -83,7 +82,7 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
             // Display absolute value because it is displayed either in debit or credit column
             accountType.displayBalance(balanceView,
                                        splitSignedAmount,
-                                       !shallDisplayNegativeSignumInSplits);
+                                       shallDisplayNegativeSignumInSplits);
         }
 
     } // Class SplitAmountViewHolder
@@ -235,8 +234,13 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
 
         final AccountType accountType = accountsDbAdapter.getAccountType(mAccountUID);
 
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
         accountType.displayBalance(balanceTextView,
-                                   accountBalance);
+                                   accountBalance,
+                                   shallDisplayNegativeSignumInSplits);
 
         //
         // Date

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -74,15 +74,11 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
             final AccountType accountType = AccountsDbAdapter.getInstance()
                                                              .getAccountType(split.getAccountUID());
 
-            // Get Preference about showing signum in Splits
-            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(GnuCashApplication.getAppContext())
-                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                      false);
-
             // Display absolute value because it is displayed either in debit or credit column
             accountType.displayBalance(balanceView,
                                        splitSignedAmount,
-                                       shallDisplayNegativeSignumInSplits);
+                                       false,
+                                       true);
         }
 
     } // Class SplitAmountViewHolder
@@ -227,20 +223,18 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
                                                                    transaction.getTimeMillis());
 
         // #8xx
-        // Define in which field (Debit or Credit) the balance shall be displayed
-        TextView balanceTextView = accountBalance.isNegative()
-                                   ? mCreditBalance
-                                   : mDebitBalance;
+        // Use Debit TextView to display the account balance (with signum)
+//        TextView balanceTextView = accountBalance.isNegative()
+//                                   ? mCreditBalance
+//                                   : mDebitBalance;
+        TextView balanceTextView = mDebitBalance;
 
         final AccountType accountType = accountsDbAdapter.getAccountType(mAccountUID);
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
         accountType.displayBalance(balanceTextView,
                                    accountBalance,
-                                   shallDisplayNegativeSignumInSplits);
+                                   true,
+                                   true);
 
         //
         // Date

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -78,6 +78,7 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
             accountType.displayBalance(balanceView,
                                        splitSignedAmount,
                                        false,
+                                       true,
                                        true);
         }
 
@@ -233,6 +234,7 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
 
         accountType.displayBalance(balanceTextView,
                                    accountBalance,
+                                   true,
                                    true,
                                    true);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -18,6 +18,7 @@ import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.ScheduledActionDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
+import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.model.ScheduledAction;
 import org.gnucash.android.model.Split;
@@ -26,7 +27,6 @@ import org.gnucash.android.model.TransactionType;
 import org.gnucash.android.ui.common.FormActivity;
 import org.gnucash.android.ui.common.UxArgument;
 import org.gnucash.android.ui.passcode.PasscodeLockActivity;
-import org.gnucash.android.ui.util.AccountUtils;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -75,10 +75,11 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
                                    ? splitCreditView
                                    : splitDebitView;
 
-            TransactionsActivity.displayBalance(balanceView,
-                                                quantity,
-                                                AccountsDbAdapter.getInstance()
-                                                                 .getAccountType(split.getAccountUID()));
+            final AccountType accountType = AccountsDbAdapter.getInstance()
+                                                             .getAccountType(split.getAccountUID());
+
+            accountType.displayBalance(balanceView,
+                                       quantity);
         }
 
     } // Class SplitAmountViewHolder
@@ -161,9 +162,10 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
         // Define in which field (Debit or Credit) the balance shall be displayed
         TextView balanceTextView = accountBalance.isNegative() ? mCreditBalance : mDebitBalance ;
 
-        TransactionsActivity.displayBalance(balanceTextView,
-                                            accountBalance,
-                                            accountsDbAdapter.getAccountType(mAccountUID));
+        final AccountType accountType = accountsDbAdapter.getAccountType(mAccountUID);
+
+        accountType.displayBalance(balanceTextView,
+                                   accountBalance);
 
         //
         // Détails

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -27,6 +27,7 @@ import org.gnucash.android.model.Transaction;
 import org.gnucash.android.ui.common.FormActivity;
 import org.gnucash.android.ui.common.UxArgument;
 import org.gnucash.android.ui.passcode.PasscodeLockActivity;
+import org.gnucash.android.ui.util.AccountTypeUtils;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -186,9 +187,30 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
 
             } else {
 
+//                //
+//                // Add Account Specific Debit/Credit Labels
+//                //
+//
+//                view = inflater.inflate(R.layout.item_split_amount_info,
+//                                        mDetailTableLayout,
+//                                        false);
+//
+//                AccountType accountType = AccountsDbAdapter.getInstance().getAccountType(split.getAccountUID());
+//
+//                ((TextView) view.findViewById(R.id.split_debit)).setText(AccountTypeUtils.getLabelDebit(accountType));
+//                ((TextView) view.findViewById(R.id.split_credit)).setText(AccountTypeUtils.getLabelCredit(accountType));
+//
+//                mDetailTableLayout.addView(view,
+//                                           index++);
+
+                //
+                // Display Debit/Credit amount
+                //
+
                 view = inflater.inflate(R.layout.item_split_amount_info,
                                         mDetailTableLayout,
                                         false);
+
                 SplitAmountViewHolder viewHolder = new SplitAmountViewHolder(view,
                                                                              split);
                 mDetailTableLayout.addView(viewHolder.itemView,

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -73,11 +74,15 @@ public class TransactionDetailActivity extends PasscodeLockActivity {
             final AccountType accountType = AccountsDbAdapter.getInstance()
                                                              .getAccountType(split.getAccountUID());
 
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(GnuCashApplication.getAppContext())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
+
             // Display absolute value because it is displayed either in debit or credit column
             accountType.displayBalance(balanceView,
                                        splitSignedAmount,
-                                       // TODO TW C 2020-03-07 : Mettre une préférence pour le signe
-                                       true);
+                                       !shallDisplayNegativeSignumInSplits);
         }
 
     } // Class SplitAmountViewHolder

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -869,6 +869,18 @@ public class TransactionFormFragment extends Fragment implements
 
         BigDecimal amountBigD = mAmountEditText.getValue();
 
+        if (amountBigD != null) {
+            // Amount is null
+
+            // RAF
+
+        } else {
+            // Amount is not null
+
+            // init to 0
+            amountBigD=new BigDecimal(0);
+        }
+
         String baseCurrencyCode = mTransactionsDbAdapter.getAccountCurrencyCode(mAccountUID);
 
         // Store signed amount

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -602,6 +602,7 @@ public class TransactionFormFragment extends Fragment implements
 	 * Initialize views with default data for new transactions
 	 */
 	private void initalizeViews() {
+
 		Date time = new Date(System.currentTimeMillis());
 		mDateTextView.setText(DATE_FORMATTER.format(time));
 		mTimeTextView.setText(TIME_FORMATTER.format(time));
@@ -612,10 +613,14 @@ public class TransactionFormFragment extends Fragment implements
 
         mTransactionTypeSwitch.setAccountType(mAccountType);
 
-        Boolean isCredit = PreferenceActivity.getActiveBookSharedPreferences()
-                                            .getBoolean(getString(R.string.key_default_transaction_type_switch),
-                                                       true);
-        mTransactionTypeSwitch.setChecked(isCredit);
+        //
+        // According to the Default Transaction Type Preference and the AccountType
+        // Check or Uncheck the TransactionTypeSwitch
+        //
+
+        final TransactionType transactionType = mAccountType.getDefaultTransactionType();
+
+        mTransactionTypeSwitch.setChecked(transactionType);
 
 		String code = GnuCashApplication.getDefaultCurrencyCode();
 		if (mAccountUID != null){

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -604,9 +604,10 @@ public class TransactionFormFragment extends Fragment implements
                                                   ? signedTransactionBalance.negate()
                                                   : signedTransactionBalance;
 
-        accountType.displayBalance(mAmountEditText,
-                                   newSignedTransactionBalance,
-                                   shallDisplayNegativeSignumInSplits);
+        accountType.displayBalanceWithoutCurrency(mAmountEditText,
+                                                  newSignedTransactionBalance,
+                                                  shallDisplayNegativeSignumInSplits || (mTransactionTypeSwitch.getVisibility()
+                                                                                         == View.GONE));
     }
 
     private void setDoubleEntryViewsVisibility(int visibility) {

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -605,10 +605,12 @@ public class TransactionFormFragment extends Fragment implements
                                                   ? signedTransactionBalance.negate()
                                                   : signedTransactionBalance;
 
+        final boolean isTransactionTypeSwitchVisible = mTransactionTypeSwitch.getVisibility() != View.GONE;
+
         accountType.displayBalanceWithoutCurrency(mAmountEditText,
                                                   newSignedTransactionBalance,
-                                                  shallDisplayNegativeSignumInSplits || (mTransactionTypeSwitch.getVisibility()
-                                                                                         == View.GONE));
+                                                  shallDisplayNegativeSignumInSplits || !isTransactionTypeSwitchVisible,
+                                                  !isTransactionTypeSwitchVisible);
     }
 
     private void setDoubleEntryViewsVisibility(int visibility) {
@@ -1271,12 +1273,13 @@ public class TransactionFormFragment extends Fragment implements
 
         if (resultCode == Activity.RESULT_OK){
 
+            // Once split editor has been used and saved, only allow editing through it
+            toggleAmountInputEntryMode(false);
+            setDoubleEntryViewsVisibility(View.GONE);
+
             List<Split> splitList = data.getParcelableArrayListExtra(UxArgument.SPLIT_LIST);
             setSplitList(splitList);
 
-            //once split editor has been used and saved, only allow editing through it
-            toggleAmountInputEntryMode(false);
-            setDoubleEntryViewsVisibility(View.GONE);
             mOpenSplitEditor.setVisibility(View.VISIBLE);
         }
     }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -465,6 +465,9 @@ public class TransactionFormFragment extends Fragment implements
 		mDescriptionEditText.setText(mTransaction.getDescription());
         mDescriptionEditText.setSelection(mDescriptionEditText.getText().length());
 
+        mTransactionTypeSwitch.setViewsToColorize(mAmountEditText,
+                                                  mCurrencyTextView);
+
         mTransactionTypeSwitch.setAccountType(mAccountType);
         mTransactionTypeSwitch.setChecked(mTransaction.getBalance(mAccountUID).isNegative());
 
@@ -552,7 +555,11 @@ public class TransactionFormFragment extends Fragment implements
 		mTimeTextView.setText(TIME_FORMATTER.format(time));
 		mTime = mDate = Calendar.getInstance();
 
+        mTransactionTypeSwitch.setViewsToColorize(mAmountEditText,
+                                                  mCurrencyTextView);
+
         mTransactionTypeSwitch.setAccountType(mAccountType);
+
 		String typePref = PreferenceActivity.getActiveBookSharedPreferences().getString(getString(R.string.key_default_transaction_type), "DEBIT");
         mTransactionTypeSwitch.setChecked(TransactionType.valueOf(typePref));
 
@@ -663,8 +670,7 @@ public class TransactionFormFragment extends Fragment implements
 	 */
 	private void setListeners() {
 
-        mTransactionTypeSwitch.setColorizeOnCheckedChangeListener(mAmountEditText,
-                                                                  mCurrencyTextView);
+        mTransactionTypeSwitch.setColorizeOnCheckedChangeListener();
 
 		mDateTextView.setOnClickListener(new View.OnClickListener() {
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -551,7 +551,11 @@ public class TransactionFormFragment extends Fragment implements
         if (!mAmountEditText.isInputModified()) {
             //when autocompleting, only change the amount if the user has not manually changed it already
 
-            updateAmountEditText();
+            // Compute balance signed value of saved transaction
+            final Money signedTransactionBalance = Transaction.computeBalance(mAccountUID,
+                                                                              mSplitsList);
+
+            updateAmountEditText(signedTransactionBalance);
         }
 
         String    currencyCode     = mTransactionsDbAdapter.getAccountCurrencyCode(mAccountUID);
@@ -580,15 +584,12 @@ public class TransactionFormFragment extends Fragment implements
 
     }
 
-    private void updateAmountEditText() {
+    private void updateAmountEditText(final Money signedTransactionBalance) {
 
         // Get Preference about showing signum in Splits
         boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
                                                                       .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
                                                                                   false);
-
-        // Compute balance signed value of saved transaction
-        final Money signedTransactionBalance = mTransaction.getBalance(mAccountUID);
 
         final boolean isCredit = signedTransactionBalance.isNegative();
 
@@ -782,8 +783,11 @@ public class TransactionFormFragment extends Fragment implements
             public void onCheckedChanged(CompoundButton buttonView,
                                          boolean isChecked) {
 
+                // Compute balance signed value of saved transaction
+                final Money signedTransactionBalance = mTransaction.getBalance(mAccountUID);
+
                 // Update Amount Signum
-                updateAmountEditText();
+                updateAmountEditText(signedTransactionBalance);
             }
         });
 
@@ -1014,6 +1018,7 @@ public class TransactionFormFragment extends Fragment implements
 	 * and save a transaction
 	 */
 	private void saveNewTransaction() {
+
         mAmountEditText.getCalculatorKeyboard().hideCustomKeyboard();
 
         //determine whether we need to do currency conversion
@@ -1165,8 +1170,7 @@ public class TransactionFormFragment extends Fragment implements
 
         mTransactionTypeSwitch.setChecked(balance.isNegative());
 
-//        mAmountEditText.setValue(balance.asBigDecimal());
-        updateAmountEditText();
+        updateAmountEditText(balance);
     }
 
 
@@ -1259,7 +1263,9 @@ public class TransactionFormFragment extends Fragment implements
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+
         if (resultCode == Activity.RESULT_OK){
+
             List<Split> splitList = data.getParcelableArrayListExtra(UxArgument.SPLIT_LIST);
             setSplitList(splitList);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -716,59 +716,51 @@ public class TransactionFormFragment extends Fragment implements
      */
     private void openSplitEditor() {
 
-        if (mAmountEditText.getValue() == null) {
+        String baseAmountString;
 
-            Toast.makeText(getActivity(),
-                           R.string.toast_enter_amount_to_split,
-                           Toast.LENGTH_SHORT)
-                 .show();
+        if (mTransaction == null) {
+            // we are creating a new transaction (not editing an existing one)
+
+            BigDecimal enteredAmount = mAmountEditText.getValue() != null
+                                       ? mAmountEditText.getValue()
+                                       : new BigDecimal(0);
+
+            baseAmountString = enteredAmount.toPlainString();
 
         } else {
+            // we are editing an existing transaction
 
-            String baseAmountString;
+            //
+            // Find splits biggest amount (in absolute value)
+            //
 
-            if (mTransaction == null) {
-                // we are creating a new transaction (not editing an existing one)
+            Money biggestAmount = Money.createZeroInstance(mTransaction.getCurrencyCode());
 
-                BigDecimal enteredAmount = mAmountEditText.getValue();
+            for (Split split : mTransaction.getSplits()) {
+                if (split.getValue()
+                         .asBigDecimal()
+                         .compareTo(biggestAmount.asBigDecimal()) > 0) {
+                    biggestAmount = split.getValue();
+                }
+            } // for
 
-                baseAmountString = enteredAmount.toPlainString();
-
-            } else {
-                // we are editing an existing transaction
-
-                //
-                // Find splits biggest amount (in absolute value)
-                //
-
-                Money biggestAmount = Money.createZeroInstance(mTransaction.getCurrencyCode());
-
-                for (Split split : mTransaction.getSplits()) {
-                    if (split.getValue()
-                             .asBigDecimal()
-                             .compareTo(biggestAmount.asBigDecimal()) > 0) {
-                        biggestAmount = split.getValue();
-                    }
-                } // for
-
-                baseAmountString = biggestAmount.toPlainString();
-            }
-
-            Intent intent = new Intent(getActivity(),
-                                       FormActivity.class);
-            intent.putExtra(UxArgument.FORM_TYPE,
-                            FormActivity.FormType.SPLIT_EDITOR.name());
-            intent.putExtra(UxArgument.SELECTED_ACCOUNT_UID,
-                            mAccountUID);
-            intent.putExtra(UxArgument.AMOUNT_STRING,
-                            baseAmountString);
-
-            intent.putParcelableArrayListExtra(UxArgument.SPLIT_LIST,
-                                               (ArrayList<Split>) extractSplitsFromView());
-
-            startActivityForResult(intent,
-                                   REQUEST_SPLIT_EDITOR);
+            baseAmountString = biggestAmount.toPlainString();
         }
+
+        Intent intent = new Intent(getActivity(),
+                                   FormActivity.class);
+        intent.putExtra(UxArgument.FORM_TYPE,
+                        FormActivity.FormType.SPLIT_EDITOR.name());
+        intent.putExtra(UxArgument.SELECTED_ACCOUNT_UID,
+                        mAccountUID);
+        intent.putExtra(UxArgument.AMOUNT_STRING,
+                        baseAmountString);
+
+        intent.putParcelableArrayListExtra(UxArgument.SPLIT_LIST,
+                                           (ArrayList<Split>) extractSplitsFromView());
+
+        startActivityForResult(intent,
+                               REQUEST_SPLIT_EDITOR);
     }
 
 	/**
@@ -868,18 +860,6 @@ public class TransactionFormFragment extends Fragment implements
         }
 
         BigDecimal amountBigD = mAmountEditText.getValue();
-
-        if (amountBigD != null) {
-            // Amount is null
-
-            // RAF
-
-        } else {
-            // Amount is not null
-
-            // init to 0
-            amountBigD=new BigDecimal(0);
-        }
 
         String baseCurrencyCode = mTransactionsDbAdapter.getAccountCurrencyCode(mAccountUID);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -29,6 +29,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.text.format.DateUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -258,6 +259,7 @@ public class TransactionFormFragment extends Fragment implements
         View v = inflater.inflate(R.layout.fragment_transaction_form,
                                   container,
                                   false);
+
         ButterKnife.bind(this,
                          v);
 
@@ -271,7 +273,7 @@ public class TransactionFormFragment extends Fragment implements
             }
         });
         return v;
-	}
+    }
 
     /**
      * Starts the transfer of funds from one currency to another
@@ -304,7 +306,9 @@ public class TransactionFormFragment extends Fragment implements
 
     @Override
 	public void onActivityCreated(Bundle savedInstanceState) {
+
 		super.onActivityCreated(savedInstanceState);
+
 		setHasOptionsMenu(true);
 
 		SharedPreferences sharedPrefs = PreferenceActivity.getActiveBookSharedPreferences();
@@ -538,8 +542,12 @@ public class TransactionFormFragment extends Fragment implements
             final BigDecimal signedTransactionBalance = mTransaction.getBalance(mAccountUID)
                                                                     .asBigDecimal();
 
-            // TODO TW C 2020-03-07 : Mettre une préférence pour le signe
-            mAmountEditText.setValue(isSimpleSplit
+            // Get Preference about showing signum in Splits
+            boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                          .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                      false);
+
+            mAmountEditText.setValue(isSimpleSplit && !shallDisplayNegativeSignumInSplits
                                      ? signedTransactionBalance.abs() // Display abs value because switch button is visible
                                      : signedTransactionBalance); // Display signed value because switch button is hidden
         }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -783,8 +783,11 @@ public class TransactionFormFragment extends Fragment implements
             public void onCheckedChanged(CompoundButton buttonView,
                                          boolean isChecked) {
 
-                // Compute balance signed value of saved transaction
-                final Money signedTransactionBalance = mTransaction.getBalance(mAccountUID);
+                // UI to Transaction
+                Transaction transaction = extractTransactionFromView();
+
+                // Compute balance signed value of transaction
+                final Money signedTransactionBalance = transaction.getBalance(mAccountUID);
 
                 // Update Amount Signum
                 updateAmountEditText(signedTransactionBalance);
@@ -984,6 +987,13 @@ public class TransactionFormFragment extends Fragment implements
         transaction.setSplits(splits);
         transaction.setExported(false); //not necessary as exports use timestamps now. Because, legacy
 
+        if (mEditMode) {
+            // Editing an existing transaction
+
+            // reset the transaction UID
+            transaction.setUID(mTransaction.getUID());
+        }
+
         return transaction;
     }
 
@@ -1029,13 +1039,16 @@ public class TransactionFormFragment extends Fragment implements
             return;
         }
 
-        Transaction transaction = extractTransactionFromView();
+        //
+        // UI to Transaction, with same UID if transaction edit mode
+        //
 
-        if (mEditMode) { //if editing an existing transaction
-            transaction.setUID(mTransaction.getUID());
-        }
+        mTransaction = extractTransactionFromView();
 
-        mTransaction = transaction;
+        //
+        // Save transaction in DB
+        //
+
         mAccountsDbAdapter.beginTransaction();
 
         try {

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -612,8 +612,10 @@ public class TransactionFormFragment extends Fragment implements
 
         mTransactionTypeSwitch.setAccountType(mAccountType);
 
-		String typePref = PreferenceActivity.getActiveBookSharedPreferences().getString(getString(R.string.key_default_transaction_type), "DEBIT");
-        mTransactionTypeSwitch.setChecked(TransactionType.valueOf(typePref));
+        Boolean isCredit = PreferenceActivity.getActiveBookSharedPreferences()
+                                            .getBoolean(getString(R.string.key_default_transaction_type_switch),
+                                                       true);
+        mTransactionTypeSwitch.setChecked(isCredit);
 
 		String code = GnuCashApplication.getDefaultCurrencyCode();
 		if (mAccountUID != null){

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -521,7 +521,7 @@ public class TransactionFormFragment extends Fragment implements
 
         final boolean isSimpleSplit = mSplitsList.size() <= 2;
 
-        toggleAmountInputEntryMode(isSimpleSplit);
+        setAllowAmountEdit(isSimpleSplit);
 
         if (mSplitsList.size() == 2){
             for (Split split : mSplitsList) {
@@ -618,15 +618,25 @@ public class TransactionFormFragment extends Fragment implements
         mTransactionTypeSwitch.setVisibility(visibility);
     }
 
-    private void toggleAmountInputEntryMode(boolean enabled){
-        if (enabled){
+    private void setAllowAmountEdit(boolean isAmountEditAllowed){
+
+        if (isAmountEditAllowed){
+            // Amount is allowed to be edited using keyboard
+
             mAmountEditText.setFocusable(true);
+
+            // Use Keyboard to edit amount
             mAmountEditText.bindListeners(mKeyboardView);
+
         } else {
+            // Amount is not allowed to be edited, but can be clicked to open SplitEditor
+
             mAmountEditText.setFocusable(false);
+
             mAmountEditText.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
+
                     openSplitEditor();
                 }
             });
@@ -1272,15 +1282,22 @@ public class TransactionFormFragment extends Fragment implements
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
 
         if (resultCode == Activity.RESULT_OK){
+            // Splits have been saved => Use
 
             // Once split editor has been used and saved, only allow editing through it
-            toggleAmountInputEntryMode(false);
+
+            // Do not allow keyboard anymore to edit amount
+            setAllowAmountEdit(false);
+
+            // Display Split Editor button
+            mOpenSplitEditor.setVisibility(View.VISIBLE);
+
+            // Hide double Entry
             setDoubleEntryViewsVisibility(View.GONE);
 
+            // Set Split list from intent data coming from Split Editor
             List<Split> splitList = data.getParcelableArrayListExtra(UxArgument.SPLIT_LIST);
             setSplitList(splitList);
-
-            mOpenSplitEditor.setVisibility(View.VISIBLE);
         }
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -587,24 +587,26 @@ public class TransactionFormFragment extends Fragment implements
                                                                       .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
                                                                                   false);
 
-        // Compute balance signed value and display it
+        // Compute balance signed value of saved transaction
         final Money signedTransactionBalance = mTransaction.getBalance(mAccountUID);
 
-        // Unsigned transaction balance
-        final Money unsignedTransactionBalance = signedTransactionBalance.abs();
+        final boolean isCredit = signedTransactionBalance.isNegative();
 
-        // signed ou unsigned transaction balance to display
-        final Money signedTransactionBalanceToDisplay;
+        //
+        // Negate balance if account is usually creditor
+        //
 
-        signedTransactionBalanceToDisplay = mTransactionTypeSwitch.isChecked()
-                                            ? unsignedTransactionBalance.negate()
-                                            : unsignedTransactionBalance;
+        AccountType accountType = GnuCashApplication.getAccountsDbAdapter()
+                                                    .getAccountType(mAccountUID);
 
-        mAmountEditText.setValue(!shallDisplayNegativeSignumInSplits
-                                 ? signedTransactionBalanceToDisplay.asBigDecimal()
-                                                                    .abs()
-                                 // Display abs value because switch button is visible
-                                 : signedTransactionBalanceToDisplay.asBigDecimal()); // Display signed value because switch button is hidden
+        // New signed transaction balance if typeSwitch has changed
+        final Money newSignedTransactionBalance = mTransactionTypeSwitch.isChecked() != isCredit
+                                                  ? signedTransactionBalance.negate()
+                                                  : signedTransactionBalance;
+
+        accountType.displayBalance(mAmountEditText,
+                                   newSignedTransactionBalance,
+                                   shallDisplayNegativeSignumInSplits);
     }
 
     private void setDoubleEntryViewsVisibility(int visibility) {

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -469,10 +469,9 @@ public class TransactionFormFragment extends Fragment implements
                     if (!amountEntered) {
                         // user already entered an amount
 
-                        // TODO TW C 2020-05-23 : Il faudrait homogénéïser en appelant updateAmountEditText ?
-                        mAmountEditText.setValue(splitList.get(0)
-                                                          .getValue()
-                                                          .asBigDecimal());
+                        final Money firstSplitAmount = splitList.get(0)
+                                                                .getValue();
+                        updateAmountEditText(firstSplitAmount);
                     }
 
                 } else {

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -24,6 +24,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
@@ -50,6 +51,7 @@ import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
 import org.gnucash.android.model.Account;
+import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.ui.account.AccountsActivity;
 import org.gnucash.android.ui.account.AccountsListFragment;
@@ -78,7 +80,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 	/**
 	 * Logging tag
 	 */
-	protected static final String TAG = "TransactionsActivity";
+    protected static final String LOG_TAG = "TransactionsActivity";
 
     /**
      * ViewPager index for sub-accounts fragment
@@ -120,7 +122,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
     private SparseArray<Refreshable> mFragmentPageReferenceMap = new SparseArray<>();
 
     /**
-     * Flag for determining is the currently displayed account is a placeholder account or not.
+     * Flag for determining if the currently displayed account is a placeholder account or not.
      * This will determine if the transactions tab is displayed or not
      */
     private boolean mIsPlaceholderAccount;
@@ -128,10 +130,18 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 	private AdapterView.OnItemSelectedListener mTransactionListNavigationListener = new AdapterView.OnItemSelectedListener() {
 
         @Override
-        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+        public void onItemSelected(AdapterView<?> parent, View spinnerSelectedItemView, int position, long id) {
+
             mAccountUID = mAccountsDbAdapter.getUID(id);
-            getIntent().putExtra(UxArgument.SELECTED_ACCOUNT_UID, mAccountUID); //update the intent in case the account gets rotated
-            mIsPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(mAccountUID);
+            getIntent().putExtra(UxArgument.SELECTED_ACCOUNT_UID,
+                                 getCurrentAccountUID()); //update the intent in case the account gets rotated
+
+            //
+            // Show Transaction Page if not a PlaceHolder, hide otherwise
+            //
+
+            mIsPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(getCurrentAccountUID());
+
             if (mIsPlaceholderAccount){
                 if (mTabLayout.getTabCount() > 1) {
                     mPagerAdapter.notifyDataSetChanged();
@@ -143,9 +153,9 @@ public class TransactionsActivity extends BaseDrawerActivity implements
                     mTabLayout.addTab(mTabLayout.newTab().setText(R.string.section_header_transactions));
                 }
             }
-            if (view != null) {
+            if (spinnerSelectedItemView != null) {
                 // Hide the favorite icon of the selected account to avoid clutter
-                ((TextView) view).setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+                ((TextView) spinnerSelectedItemView).setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
             }
             //refresh any fragments in the tab with the new account UID
             refresh();
@@ -229,7 +239,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         private AccountsListFragment prepareSubAccountsListFragment(){
             AccountsListFragment subAccountsListFragment = new AccountsListFragment();
             Bundle args = new Bundle();
-            args.putString(UxArgument.PARENT_ACCOUNT_UID, mAccountUID);
+            args.putString(UxArgument.PARENT_ACCOUNT_UID,
+                           getCurrentAccountUID());
             subAccountsListFragment.setArguments(args);
             return subAccountsListFragment;
         }
@@ -238,12 +249,17 @@ public class TransactionsActivity extends BaseDrawerActivity implements
          * Creates and initializes fragment for displaying transactions
          * @return {@link TransactionsListFragment} initialized with the current account transactions
          */
-        private TransactionsListFragment prepareTransactionsListFragment(){
+        private TransactionsListFragment prepareTransactionsListFragment() {
+
             TransactionsListFragment transactionsListFragment = new TransactionsListFragment();
-            Bundle args = new Bundle();
-            args.putString(UxArgument.SELECTED_ACCOUNT_UID, mAccountUID);
+            Bundle                   args                     = new Bundle();
+            args.putString(UxArgument.SELECTED_ACCOUNT_UID,
+                           getCurrentAccountUID());
             transactionsListFragment.setArguments(args);
-            Log.i(TAG, "Opening transactions for account:  " +  mAccountUID);
+
+            Log.i(LOG_TAG,
+                  "Opening transactions for account:  " + getCurrentAccountUID());
+
             return transactionsListFragment;
         }
     }
@@ -260,13 +276,15 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         if (mPagerAdapter != null)
             mPagerAdapter.notifyDataSetChanged();
 
-        new AccountBalanceTask(mSumTextView).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mAccountUID);
+        new AccountBalanceTask(mSumTextView).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                                                               getCurrentAccountUID());
 
     }
 
     @Override
     public void refresh(){
-        refresh(mAccountUID);
+
+        refresh(getCurrentAccountUID());
         setTitleIndicatorColor();
     }
 
@@ -282,6 +300,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 
     @Override
 	protected void onCreate(Bundle savedInstanceState) {
+
         super.onCreate(savedInstanceState);
 
         getSupportActionBar().setDisplayShowTitleEnabled(false);
@@ -289,7 +308,11 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 		mAccountUID = getIntent().getStringExtra(UxArgument.SELECTED_ACCOUNT_UID);
         mAccountsDbAdapter = AccountsDbAdapter.getInstance();
 
-        mIsPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(mAccountUID);
+        //
+        // Add Tranbsaction Page
+        //
+
+        mIsPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(getCurrentAccountUID());
 
         mTabLayout.addTab(mTabLayout.newTab().setText(R.string.section_header_subaccounts));
         if (!mIsPlaceholderAccount) {
@@ -320,8 +343,9 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         });
 
         //if there are no transactions, and there are sub-accounts, show the sub-accounts
-        if (TransactionsDbAdapter.getInstance().getTransactionsCount(mAccountUID) == 0
-                && mAccountsDbAdapter.getSubAccountCount(mAccountUID) > 0){
+        if (TransactionsDbAdapter.getInstance()
+                                 .getTransactionsCount(getCurrentAccountUID()) == 0
+            && mAccountsDbAdapter.getSubAccountCount(getCurrentAccountUID()) > 0) {
             mViewPager.setCurrentItem(INDEX_SUB_ACCOUNTS_FRAGMENT);
         } else {
             mViewPager.setCurrentItem(INDEX_TRANSACTIONS_FRAGMENT);
@@ -335,13 +359,14 @@ public class TransactionsActivity extends BaseDrawerActivity implements
                         Intent addAccountIntent = new Intent(TransactionsActivity.this, FormActivity.class);
                         addAccountIntent.setAction(Intent.ACTION_INSERT_OR_EDIT);
                         addAccountIntent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.ACCOUNT.name());
-                        addAccountIntent.putExtra(UxArgument.PARENT_ACCOUNT_UID, mAccountUID);
+                        addAccountIntent.putExtra(UxArgument.PARENT_ACCOUNT_UID,
+                                                  getCurrentAccountUID());
                         startActivityForResult(addAccountIntent, AccountsActivity.REQUEST_EDIT_ACCOUNT);
                         ;
                         break;
 
                     case INDEX_TRANSACTIONS_FRAGMENT:
-                        createNewTransaction(mAccountUID);
+                        createNewTransaction(getCurrentAccountUID());
                         break;
 
                 }
@@ -359,7 +384,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
      * Sets the color for the ViewPager title indicator to match the account color
      */
     private void setTitleIndicatorColor() {
-        int iColor = AccountsDbAdapter.getActiveAccountColorResource(mAccountUID);
+
+        int iColor = AccountsDbAdapter.getActiveAccountColorResource(getCurrentAccountUID());
 
         mTabLayout.setBackgroundColor(iColor);
 
@@ -374,7 +400,11 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 	 * Set up action bar navigation list and listener callbacks
 	 */
 	private void setupActionBarNavigation() {
+
+	    //
 		// set up spinner adapter for navigation list
+        //
+
         if (mAccountsCursor != null) {
             mAccountsCursor.close();
         }
@@ -387,17 +417,17 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         mToolbarSpinner.setOnItemSelectedListener(mTransactionListNavigationListener);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-		updateNavigationSelection();
+		selectCurrentAccountInToolbarSpinner();
 	}
 	
 	/**
 	 * Updates the action bar navigation list selection to that of the current account
 	 * whose transactions are being displayed/manipulated
 	 */
-	public void updateNavigationSelection() {
-		// set the selected item in the spinner
-		int i = 0;
-		Cursor accountsCursor = mAccountsDbAdapter.fetchAllRecordsOrderedByFullName();
+    public void selectCurrentAccountInToolbarSpinner() {
+        // set the selected item in the spinner
+        int i = 0;
+        Cursor accountsCursor = mAccountsDbAdapter.fetchAllRecordsOrderedByFullName();
         while (accountsCursor.moveToNext()) {
             String uid = accountsCursor.getString(accountsCursor.getColumnIndexOrThrow(DatabaseSchema.AccountEntry.COLUMN_UID));
             if (mAccountUID.equals(uid)) {
@@ -407,7 +437,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
             ++i;
         }
         accountsCursor.close();
-	}
+    }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
@@ -416,7 +446,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         if (favoriteAccountMenuItem == null) //when the activity is used to edit a transaction
             return super.onPrepareOptionsMenu(menu);
 
-        boolean isFavoriteAccount = AccountsDbAdapter.getInstance().isFavoriteAccount(mAccountUID);
+        boolean isFavoriteAccount = AccountsDbAdapter.getInstance()
+                                                     .isFavoriteAccount(getCurrentAccountUID());
 
         int favoriteIcon = isFavoriteAccount ? R.drawable.ic_star_white_24dp : R.drawable.ic_star_border_white_24dp;
         favoriteAccountMenuItem.setIcon(favoriteIcon);
@@ -432,8 +463,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 
             case R.id.menu_favorite_account:
                 AccountsDbAdapter accountsDbAdapter = AccountsDbAdapter.getInstance();
-                long accountId = accountsDbAdapter.getID(mAccountUID);
-                boolean isFavorite = accountsDbAdapter.isFavoriteAccount(mAccountUID);
+                long accountId = accountsDbAdapter.getID(getCurrentAccountUID());
+                boolean isFavorite = accountsDbAdapter.isFavoriteAccount(getCurrentAccountUID());
                 //toggle favorite preference
                 accountsDbAdapter.updateAccount(accountId, DatabaseSchema.AccountEntry.COLUMN_FAVORITE, isFavorite ? "0" : "1");
                 supportInvalidateOptionsMenu();
@@ -442,7 +473,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
             case R.id.menu_edit_account:
                 Intent editAccountIntent = new Intent(this, FormActivity.class);
                 editAccountIntent.setAction(Intent.ACTION_INSERT_OR_EDIT);
-                editAccountIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID, mAccountUID);
+                editAccountIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID,
+                                           getCurrentAccountUID());
                 editAccountIntent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.ACCOUNT.name());
                 startActivityForResult(editAccountIntent, AccountsActivity.REQUEST_EDIT_ACCOUNT);
                 return true;
@@ -465,7 +497,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
     @Override
 	protected void onDestroy() {
 		super.onDestroy();
-        mAccountsCursor.close();
+        getAccountsCursor().close();
 	}
 
 	/**
@@ -476,28 +508,55 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 		return mAccountUID;
 	}
 
+    public Cursor getAccountsCursor() {
+
+        return mAccountsCursor;
+    }
+
+    // TODO TW C 2020-03-06 : A mettre ailleurs, car c'est pas spécifique de cette Activité
     /**
      * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
      * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
      * @param balance {@link org.gnucash.android.model.Money} balance to display
      */
-    public static void displayBalance(TextView balanceTextView,
-                                      Money balance) {
+    public static void displayBalance(final TextView balanceTextView,
+                                      final Money balance,
+                                      final AccountType accountType) {
 
+        //
+        // Display amount
+        //
+
+        // TODO TW C 2020-03-06 : Déterminer qui doit dire s'il faut afficher un nombre négatif ou sa valeur absolue
         balanceTextView.setText(balance.formattedString());
 
-        Context context = GnuCashApplication.getAppContext();
+        //
+        // Define amount color
+        //
 
-        int fontColor = balance.isNegative()
-                        ? context.getResources()
-                                 .getColor(R.color.debit_red)
-                        : context.getResources()
-                                 .getColor(R.color.credit_green);
+        @ColorInt int fontColor;
 
         if (balance.asBigDecimal()
                    .compareTo(BigDecimal.ZERO) == 0) {
+            // balance is null
+
+            Context context = GnuCashApplication.getAppContext();
+
             fontColor = context.getResources()
                                .getColor(android.R.color.black);
+
+        } else {
+            // balance is not null
+
+            final boolean isCredit = balance.isNegative();
+
+//         fontColor = isCredit
+//                        ? context.getResources()
+//                                 .getColor(R.color.debit_red)
+//                        : context.getResources()
+//                                 .getColor(R.color.credit_green);
+            fontColor = AccountType.getAmountColor(isCredit,
+                                                             accountType);
         }
 
         balanceTextView.setTextColor(fontColor);
@@ -539,7 +598,8 @@ public class TransactionsActivity extends BaseDrawerActivity implements
 	public void editTransaction(String transactionUID){
         Intent createTransactionIntent = new Intent(this.getApplicationContext(), FormActivity.class);
         createTransactionIntent.setAction(Intent.ACTION_INSERT_OR_EDIT);
-        createTransactionIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID, mAccountUID);
+        createTransactionIntent.putExtra(UxArgument.SELECTED_ACCOUNT_UID,
+                                         getCurrentAccountUID());
         createTransactionIntent.putExtra(UxArgument.SELECTED_TRANSACTION_UID, transactionUID);
         createTransactionIntent.putExtra(UxArgument.FORM_TYPE, FormActivity.FormType.TRANSACTION.name());
         startActivity(createTransactionIntent);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -306,7 +306,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         mAccountsDbAdapter = AccountsDbAdapter.getInstance();
 
         //
-        // Add Tranbsaction Page
+        // Add Transaction Page
         //
 
         mIsPlaceholderAccount = mAccountsDbAdapter.isPlaceholderAccount(getCurrentAccountUID());

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -513,55 +513,6 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         return mAccountsCursor;
     }
 
-    // TODO TW C 2020-03-06 : A mettre ailleurs, car c'est pas spécifique de cette Activité
-    /**
-     * Display the balance of a transaction in a text view and format the text color to match the sign of the amount
-     * @param balanceTextView {@link android.widget.TextView} where balance is to be displayed
-     * @param balance {@link org.gnucash.android.model.Money} balance to display
-     */
-    public static void displayBalance(final TextView balanceTextView,
-                                      final Money balance,
-                                      final AccountType accountType) {
-
-        //
-        // Display amount
-        //
-
-        // TODO TW C 2020-03-06 : Déterminer qui doit dire s'il faut afficher un nombre négatif ou sa valeur absolue
-        balanceTextView.setText(balance.formattedString());
-
-        //
-        // Define amount color
-        //
-
-        @ColorInt int fontColor;
-
-        if (balance.asBigDecimal()
-                   .compareTo(BigDecimal.ZERO) == 0) {
-            // balance is null
-
-            Context context = GnuCashApplication.getAppContext();
-
-            fontColor = context.getResources()
-                               .getColor(android.R.color.black);
-
-        } else {
-            // balance is not null
-
-            final boolean isCredit = balance.isNegative();
-
-//         fontColor = isCredit
-//                        ? context.getResources()
-//                                 .getColor(R.color.debit_red)
-//                        : context.getResources()
-//                                 .getColor(R.color.credit_green);
-            fontColor = AccountType.getAmountColor(isCredit,
-                                                             accountType);
-        }
-
-        balanceTextView.setTextColor(fontColor);
-    }
-
     /**
      * Formats the date to show the the day of the week if the {@code dateMillis} is within 7 days
      * of today. Else it shows the actual date formatted as short string. <br>

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -382,7 +382,9 @@ public class TransactionsActivity extends BaseDrawerActivity implements
      */
     private void setTitleIndicatorColor() {
 
-        int iColor = AccountsDbAdapter.getActiveAccountColorResource(getCurrentAccountUID());
+        final String currentAccountUID = getCurrentAccountUID();
+
+        int          iColor            = AccountsDbAdapter.getActiveAccountColorResource(currentAccountUID);
 
         mTabLayout.setBackgroundColor(iColor);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -24,7 +24,6 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
@@ -33,6 +32,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.support.v7.preference.PreferenceManager;
 import android.text.format.DateUtils;
 import android.util.Log;
 import android.util.SparseArray;
@@ -51,8 +51,6 @@ import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
 import org.gnucash.android.model.Account;
-import org.gnucash.android.model.AccountType;
-import org.gnucash.android.model.Money;
 import org.gnucash.android.ui.account.AccountsActivity;
 import org.gnucash.android.ui.account.AccountsListFragment;
 import org.gnucash.android.ui.account.OnAccountClickedListener;
@@ -64,7 +62,6 @@ import org.gnucash.android.ui.util.AccountBalanceTask;
 import org.gnucash.android.util.QualifiedAccountNameCursorAdapter;
 import org.joda.time.LocalDate;
 
-import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -276,8 +273,13 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         if (mPagerAdapter != null)
             mPagerAdapter.notifyDataSetChanged();
 
-        new AccountBalanceTask(mSumTextView).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                                                               getCurrentAccountUID());
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
+        new AccountBalanceTask(mSumTextView,
+                               shallDisplayNegativeSignumInSplits).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                                                                                     getCurrentAccountUID());
 
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.java
@@ -273,12 +273,7 @@ public class TransactionsActivity extends BaseDrawerActivity implements
         if (mPagerAdapter != null)
             mPagerAdapter.notifyDataSetChanged();
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
-        new AccountBalanceTask(mSumTextView,
-                               shallDisplayNegativeSignumInSplits).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+        new AccountBalanceTask(mSumTextView).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
                                                                                      getCurrentAccountUID());
 
     }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -49,6 +49,7 @@ import org.gnucash.android.db.adapter.AccountsDbAdapter;
 import org.gnucash.android.db.adapter.DatabaseAdapter;
 import org.gnucash.android.db.adapter.SplitsDbAdapter;
 import org.gnucash.android.db.adapter.TransactionsDbAdapter;
+import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.model.Split;
 import org.gnucash.android.model.Transaction;
@@ -275,10 +276,12 @@ public class TransactionsListFragment extends Fragment implements
 
 			final String transactionUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_UID));
 			Money amount = mTransactionsDbAdapter.getBalance(transactionUID, mAccountUID);
-			TransactionsActivity.displayBalance(holder.transactionAmount,
-												amount,
-												GnuCashApplication.getAccountsDbAdapter()
-																  .getAccountType(mAccountUID));
+
+			final AccountType accountType = GnuCashApplication.getAccountsDbAdapter()
+															  .getAccountType(mAccountUID);
+
+			accountType.displayBalance(holder.transactionAmount,
+									   amount);
 
 			long dateMillis = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP));
 			String dateText = TransactionsActivity.getPrettyDateFormat(getActivity(), dateMillis);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -281,14 +281,8 @@ public class TransactionsListFragment extends Fragment implements
 			final AccountType accountType = GnuCashApplication.getAccountsDbAdapter()
 															  .getAccountType(mAccountUID);
 
-			// Get Preference about showing signum in Splits
-			boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-																		  .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-																					  false);
-
 			accountType.displayBalance(holder.transactionAmount,
-									   amount,
-									   shallDisplayNegativeSignumInSplits);
+									   amount);
 
 			long dateMillis = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP));
 			String dateText = TransactionsActivity.getPrettyDateFormat(getActivity(), dateMillis);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -27,6 +27,7 @@ import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
@@ -280,8 +281,14 @@ public class TransactionsListFragment extends Fragment implements
 			final AccountType accountType = GnuCashApplication.getAccountsDbAdapter()
 															  .getAccountType(mAccountUID);
 
+			// Get Preference about showing signum in Splits
+			boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+																		  .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+																					  false);
+
 			accountType.displayBalance(holder.transactionAmount,
-									   amount);
+									   amount,
+									   shallDisplayNegativeSignumInSplits);
 
 			long dateMillis = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP));
 			String dateText = TransactionsActivity.getPrettyDateFormat(getActivity(), dateMillis);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -270,6 +270,7 @@ public class TransactionsListFragment extends Fragment implements
 
 		@Override
 		public void onBindViewHolderCursor(ViewHolder holder, Cursor cursor) {
+
 			holder.transactionId = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry._ID));
 
 			String description = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_DESCRIPTION));

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -165,7 +165,7 @@ public class TransactionsListFragment extends Fragment implements
 	@Override
 	public void onResume() {
 		super.onResume();
-		((TransactionsActivity)getActivity()).updateNavigationSelection();
+		((TransactionsActivity)getActivity()).selectCurrentAccountInToolbarSpinner();
 		refresh();
 	}
 
@@ -275,7 +275,10 @@ public class TransactionsListFragment extends Fragment implements
 
 			final String transactionUID = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_UID));
 			Money amount = mTransactionsDbAdapter.getBalance(transactionUID, mAccountUID);
-			TransactionsActivity.displayBalance(holder.transactionAmount, amount);
+			TransactionsActivity.displayBalance(holder.transactionAmount,
+												amount,
+												GnuCashApplication.getAccountsDbAdapter()
+																  .getAccountType(mAccountUID));
 
 			long dateMillis = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseSchema.TransactionEntry.COLUMN_TIMESTAMP));
 			String dateText = TransactionsActivity.getPrettyDateFormat(getActivity(), dateMillis);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
@@ -98,14 +98,8 @@ public class TransferFundsDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_transfer_funds, container, false);
         ButterKnife.bind(this, view);
 
-        // Get Preference about showing signum in Splits
-        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
-                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
-                                                                                  false);
-
         AccountType.ASSET.displayBalance(mStartAmountLabel,
-                                         mOriginAmount,
-                                         shallDisplayNegativeSignumInSplits);
+                                         mOriginAmount);
 
         String fromCurrencyCode = mOriginAmount.getCommodity().getCurrencyCode();
         mFromCurrencyLabel.setText(fromCurrencyCode);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
@@ -97,7 +97,6 @@ public class TransferFundsDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_transfer_funds, container, false);
         ButterKnife.bind(this, view);
 
-        // TODO TW C 2020-03-05 : A vérifier
         AccountType.ASSET.displayBalance(mStartAmountLabel,
                                          mOriginAmount);
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.preference.PreferenceManager;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Pair;
@@ -97,8 +98,14 @@ public class TransferFundsDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_transfer_funds, container, false);
         ButterKnife.bind(this, view);
 
+        // Get Preference about showing signum in Splits
+        boolean shallDisplayNegativeSignumInSplits = PreferenceManager.getDefaultSharedPreferences(getActivity())
+                                                                      .getBoolean(getString(R.string.key_display_negative_signum_in_splits),
+                                                                                  false);
+
         AccountType.ASSET.displayBalance(mStartAmountLabel,
-                                         mOriginAmount);
+                                         mOriginAmount,
+                                         shallDisplayNegativeSignumInSplits);
 
         String fromCurrencyCode = mOriginAmount.getCommodity().getCurrencyCode();
         mFromCurrencyLabel.setText(fromCurrencyCode);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
@@ -35,6 +35,7 @@ import android.widget.RadioButton;
 import android.widget.TextView;
 
 import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.adapter.CommoditiesDbAdapter;
 import org.gnucash.android.db.adapter.PricesDbAdapter;
 import org.gnucash.android.model.Commodity;
@@ -97,7 +98,11 @@ public class TransferFundsDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_transfer_funds, container, false);
         ButterKnife.bind(this, view);
 
-        TransactionsActivity.displayBalance(mStartAmountLabel, mOriginAmount);
+        TransactionsActivity.displayBalance(mStartAmountLabel,
+                                            mOriginAmount,
+                                            // TODO TW C 2020-03-05 : A vérifier
+                                            null);
+
         String fromCurrencyCode = mOriginAmount.getCommodity().getCurrencyCode();
         mFromCurrencyLabel.setText(fromCurrencyCode);
         mToCurrencyLabel.setText(mTargetCommodity.getCurrencyCode());

--- a/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/dialog/TransferFundsDialogFragment.java
@@ -35,14 +35,13 @@ import android.widget.RadioButton;
 import android.widget.TextView;
 
 import org.gnucash.android.R;
-import org.gnucash.android.app.GnuCashApplication;
 import org.gnucash.android.db.adapter.CommoditiesDbAdapter;
 import org.gnucash.android.db.adapter.PricesDbAdapter;
+import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Commodity;
 import org.gnucash.android.model.Money;
 import org.gnucash.android.model.Price;
 import org.gnucash.android.ui.transaction.OnTransferFundsListener;
-import org.gnucash.android.ui.transaction.TransactionsActivity;
 import org.gnucash.android.util.AmountParser;
 
 import java.math.BigDecimal;
@@ -98,10 +97,9 @@ public class TransferFundsDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_transfer_funds, container, false);
         ButterKnife.bind(this, view);
 
-        TransactionsActivity.displayBalance(mStartAmountLabel,
-                                            mOriginAmount,
-                                            // TODO TW C 2020-03-05 : A vérifier
-                                            null);
+        // TODO TW C 2020-03-05 : A vérifier
+        AccountType.ASSET.displayBalance(mStartAmountLabel,
+                                         mOriginAmount);
 
         String fromCurrencyCode = mOriginAmount.getCommodity().getCurrencyCode();
         mFromCurrencyLabel.setText(fromCurrencyCode);

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -40,10 +40,13 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
     private final WeakReference<TextView> accountBalanceTextViewReference;
     private final AccountsDbAdapter       accountsDbAdapter;
     private       String                  mAccountUID;
+    private       boolean                 mShallDisplayNegativeSignumInSplits;
 
-    public AccountBalanceTask(TextView balanceTextView){
+    public AccountBalanceTask(TextView balanceTextView,
+                              boolean shallDisplayNegativeSignumInSplits) {
         accountBalanceTextViewReference = new WeakReference<>(balanceTextView);
         accountsDbAdapter = AccountsDbAdapter.getInstance();
+        mShallDisplayNegativeSignumInSplits = shallDisplayNegativeSignumInSplits;
     }
 
     @Override
@@ -78,8 +81,10 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
                 final AccountType accountType = accountsDbAdapter.getAccountType(mAccountUID);
 
+                // Get Preference about showing signum in Splits
                 accountType.displayBalance(balanceTextView,
-                                           balance);
+                                           balance,
+                                           mShallDisplayNegativeSignumInSplits);
             }
         }
     }

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -38,7 +38,8 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
     public static final String LOG_TAG = AccountBalanceTask.class.getName();
 
     private final WeakReference<TextView> accountBalanceTextViewReference;
-    private final AccountsDbAdapter accountsDbAdapter;
+    private final AccountsDbAdapter       accountsDbAdapter;
+    private       String                  mAccountUID;
 
     public AccountBalanceTask(TextView balanceTextView){
         accountBalanceTextViewReference = new WeakReference<>(balanceTextView);
@@ -55,7 +56,10 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
         Money balance = Money.getZeroInstance();
         try {
-            balance = accountsDbAdapter.getAccountBalance(params[0], -1, -1);
+            mAccountUID = params[0];
+            balance = accountsDbAdapter.getAccountBalance(mAccountUID,
+                                                          -1,
+                                                          -1);
         } catch (Exception ex) {
             Log.e(LOG_TAG, "Error computing account balance ", ex);
             Crashlytics.logException(ex);
@@ -65,10 +69,16 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
     @Override
     protected void onPostExecute(Money balance) {
-        if (accountBalanceTextViewReference.get() != null && balance != null){
+
+        if (accountBalanceTextViewReference.get() != null && balance != null) {
+
             final TextView balanceTextView = accountBalanceTextViewReference.get();
-            if (balanceTextView != null){
-                TransactionsActivity.displayBalance(balanceTextView, balance);
+
+            if (balanceTextView != null) {
+
+                TransactionsActivity.displayBalance(balanceTextView,
+                                                    balance,
+                                                    accountsDbAdapter.getAccountType(mAccountUID));
             }
         }
     }

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -24,8 +24,8 @@ import android.widget.TextView;
 import com.crashlytics.android.Crashlytics;
 
 import org.gnucash.android.db.adapter.AccountsDbAdapter;
+import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.Money;
-import org.gnucash.android.ui.transaction.TransactionsActivity;
 
 import java.lang.ref.WeakReference;
 
@@ -76,9 +76,10 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
             if (balanceTextView != null) {
 
-                TransactionsActivity.displayBalance(balanceTextView,
-                                                    balance,
-                                                    accountsDbAdapter.getAccountType(mAccountUID));
+                final AccountType accountType = accountsDbAdapter.getAccountType(mAccountUID);
+
+                accountType.displayBalance(balanceTextView,
+                                           balance);
             }
         }
     }

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountBalanceTask.java
@@ -40,13 +40,10 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
     private final WeakReference<TextView> accountBalanceTextViewReference;
     private final AccountsDbAdapter       accountsDbAdapter;
     private       String                  mAccountUID;
-    private       boolean                 mShallDisplayNegativeSignumInSplits;
 
-    public AccountBalanceTask(TextView balanceTextView,
-                              boolean shallDisplayNegativeSignumInSplits) {
+    public AccountBalanceTask(TextView balanceTextView) {
         accountBalanceTextViewReference = new WeakReference<>(balanceTextView);
         accountsDbAdapter = AccountsDbAdapter.getInstance();
-        mShallDisplayNegativeSignumInSplits = shallDisplayNegativeSignumInSplits;
     }
 
     @Override
@@ -83,8 +80,7 @@ public class AccountBalanceTask extends AsyncTask<String, Void, Money> {
 
                 // Get Preference about showing signum in Splits
                 accountType.displayBalance(balanceTextView,
-                                           balance,
-                                           mShallDisplayNegativeSignumInSplits);
+                                           balance);
             }
         }
     }

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountTypeUtils.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountTypeUtils.java
@@ -41,12 +41,15 @@ public class AccountTypeUtils {
                 label = context.getString(R.string.label_deposit); // DEBIT
                 break;
 
-            case CREDIT:
+            case ASSET:
                 // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_increase); // DEBIT
+                break;
+
+            case CREDIT:
                 label = context.getString(R.string.label_payment); // DEBIT
                 break;
 
-            case ASSET:
             case EQUITY:
             case LIABILITY:
                 // #876 Change according to GnuCash on Windows
@@ -115,12 +118,15 @@ public class AccountTypeUtils {
                 label = context.getString(R.string.label_withdrawal); // CREDIT
                 break;
 
-            case CREDIT:
+            case ASSET:
                 // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_decrease); // CREDIT
+                break;
+
+            case CREDIT:
                 label = context.getString(R.string.label_charge); // CREDIT
                 break;
 
-            case ASSET:
             case EQUITY:
             case LIABILITY:
                 // #876 Change according to GnuCash on Windows

--- a/app/src/main/java/org/gnucash/android/ui/util/AccountTypeUtils.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/AccountTypeUtils.java
@@ -1,0 +1,164 @@
+package org.gnucash.android.ui.util;
+
+import android.content.Context;
+
+import org.gnucash.android.R;
+import org.gnucash.android.app.GnuCashApplication;
+import org.gnucash.android.db.DatabaseSchema;
+import org.gnucash.android.model.AccountType;
+
+/**
+ * Utilities for AccountType UI
+ *
+ * @author JeanGarf
+ */
+public class AccountTypeUtils {
+
+    /**
+     * Get the debit label customized for the account type
+     *
+     * @param accountType
+     *          Account Type
+     *
+     * @return
+     *          The debit label customized for the account type
+     *
+     * @author JeanGarf
+     */
+    public static String getLabelDebit(final AccountType accountType) {
+
+        final String label;
+        
+        Context context = GnuCashApplication.getAppContext().getApplicationContext();
+
+        switch (accountType) {
+            
+            case CASH:
+                label = context.getString(R.string.label_receive); // DEBIT
+                break;
+
+            case BANK:
+                label = context.getString(R.string.label_deposit); // DEBIT
+                break;
+
+            case CREDIT:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_payment); // DEBIT
+                break;
+
+            case ASSET:
+            case EQUITY:
+            case LIABILITY:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_decrease); // DEBIT
+                break;
+
+            case INCOME:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_charge); // DEBIT
+                break;
+
+            case EXPENSE:
+                label = context.getString(R.string.label_expense); // DEBIT
+                break;
+
+            case PAYABLE:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_payment); // DEBIT
+                break;
+
+            case RECEIVABLE:
+                label = context.getString(R.string.label_invoice); // DEBIT
+                break;
+
+            case STOCK:
+            case MUTUAL:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_buy); // DEBIT
+                break;
+
+            case CURRENCY:
+            case ROOT:
+            default:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_debit); // DEBIT
+                break;
+        }
+
+        return label;
+    }
+
+    /**
+     * Get the credit label customized for the account type
+     *
+     * @param accountType
+     *          Account Type
+     *
+     * @return
+     *          The credit label customized for the account type
+     *
+     * @author JeanGarf
+     */
+    public static String getLabelCredit(final AccountType accountType) {
+
+        final String label;
+
+        Context context = GnuCashApplication.getAppContext().getApplicationContext();
+
+        switch (accountType) {
+
+            case CASH:
+                label = context.getString(R.string.label_spend); // CREDIT
+                break;
+
+            case BANK:
+                label = context.getString(R.string.label_withdrawal); // CREDIT
+                break;
+
+            case CREDIT:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_charge); // CREDIT
+                break;
+
+            case ASSET:
+            case EQUITY:
+            case LIABILITY:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_increase); // CREDIT
+                break;
+
+            case INCOME:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_income); // CREDIT
+                break;
+
+            case EXPENSE:
+                label = context.getString(R.string.label_rebate); // CREDIT
+                break;
+
+            case PAYABLE:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_bill); // CREDIT
+                break;
+
+            case RECEIVABLE:
+                label = context.getString(R.string.label_payment); // CREDIT
+                break;
+
+            case STOCK:
+            case MUTUAL:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_sell); // CREDIT
+                break;
+
+            case CURRENCY:
+            case ROOT:
+            default:
+                // #876 Change according to GnuCash on Windows
+                label = context.getString(R.string.label_credit); // CREDIT
+                break;
+        }
+
+        return label;
+    }
+}

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -33,14 +33,13 @@ import java.util.List;
 
 /**
  * A special type of {@link android.widget.ToggleButton} which displays the appropriate DEBIT/CREDIT labels for the
- * linked account type
+ * linked account type and update the color of the amount and currency fields as well
  *
  * checked means CREDIT
  * unchecked means DEBIT
  *
  * @author Ngewi Fet <ngewif@gmail.com>
  */
-// TODO TW m 2020-03-03 : Should be named SplitTypeToggleButton (or SplitTypeSwitch) instead of TransactionTypeSwitch
 public class TransactionTypeSwitch extends SwitchCompat {
 
     private AccountType mAccountType = AccountType.EXPENSE;
@@ -234,6 +233,21 @@ public class TransactionTypeSwitch extends SwitchCompat {
                );
 
         //
+        // Change signum if needed
+        //
+
+//        BigDecimal amount = mAmountEditText.getValue();
+//
+//        if (amount != null) {
+//            if ((isCredit && amount.signum() > 0) //we switched to debit but the amount is +ve
+//                || (!isCredit && amount.signum() < 0)) { //credit but amount is -ve
+//
+//                mAmountEditText.setValue(amount.negate());
+//            }
+//
+//        }
+
+        //
         // Set text color of views
         //
 
@@ -273,21 +287,6 @@ public class TransactionTypeSwitch extends SwitchCompat {
             //
 
             setSwitchTextAndColor(isCredit);
-
-            //
-            // Change signum if needed
-            //
-
-            BigDecimal amount = mAmountEditText.getValue();
-
-            if (amount != null) {
-                if ((isCredit && amount.signum() > 0) //we switched to debit but the amount is +ve
-                    || (!isCredit && amount.signum() < 0)) { //credit but amount is -ve
-
-                    mAmountEditText.setValue(amount.negate());
-                }
-
-            }
 
             //
             // Call other listeners

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -40,7 +40,7 @@ import java.util.List;
  *
  * @author Ngewi Fet <ngewif@gmail.com>
  */
-// TODO TW C 2020-03-03 : A renommer SplitTypeSwitch (AC)
+// TODO TW m 2020-03-03 : Should be named SplitTypeToggleButton (or SplitTypeSwitch) instead of TransactionTypeSwitch
 public class TransactionTypeSwitch extends SwitchCompat {
 
     private AccountType mAccountType = AccountType.EXPENSE;

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -17,7 +17,7 @@
 package org.gnucash.android.ui.util.widget;
 
 import android.content.Context;
-import android.support.v4.content.ContextCompat;
+import android.support.annotation.ColorInt;
 import android.support.v7.widget.SwitchCompat;
 import android.util.AttributeSet;
 import android.widget.CompoundButton;
@@ -234,29 +234,11 @@ public class TransactionTypeSwitch extends SwitchCompat {
                );
 
         //
-        // Set text color
+        // Set text color of views
         //
 
-        // TODO TW C 2020-03-02 : A renommer et commenter
-        if ((mAccountType.isResultAccount() && !isCredit) || (!mAccountType.isResultAccount() && isCredit)) {
-            // CREDIT
-
-            // RED
-            int red = ContextCompat.getColor(getContext(),
-                                             R.color.debit_red);
-            setAllTextsColor(red);
-
-        } else {
-            // DEBIT
-
-            // GREEN
-            int green = ContextCompat.getColor(getContext(),
-                                               R.color.credit_green);
-            setAllTextsColor(green);
-        }
-    }
-
-    private void setAllTextsColor(final int color) {
+        @ColorInt final int color = AccountType.getAmountColor(isCredit,
+                                                               getAccountType());
 
         TransactionTypeSwitch.this.setTextColor(color);
         mAmountEditText.setTextColor(color);

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -23,11 +23,10 @@ import android.util.AttributeSet;
 import android.widget.CompoundButton;
 import android.widget.TextView;
 
-import org.gnucash.android.R;
 import org.gnucash.android.model.AccountType;
 import org.gnucash.android.model.TransactionType;
+import org.gnucash.android.ui.util.AccountTypeUtils;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -99,67 +98,18 @@ public class TransactionTypeSwitch extends SwitchCompat {
 
         mAccountType = accountType;
 
-        Context context = getContext().getApplicationContext();
+        //
+        // Set switch button text
+        //
 
-        switch (mAccountType) {
-            case CASH:
-                setTextOff(context.getString(R.string.label_receive)); // DEBIT
-                setTextOn(context.getString(R.string.label_spend)); // CREDIT
-                break;
-            case BANK:
-                setTextOff(context.getString(R.string.label_deposit)); // DEBIT
-                setTextOn(context.getString(R.string.label_withdrawal)); // CREDIT
-                break;
-            case CREDIT:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_payment)); // DEBIT
-                setTextOn(context.getString(R.string.label_charge)); // CREDIT
-                break;
-            case ASSET:
-            case EQUITY:
-            case LIABILITY:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_decrease)); // DEBIT
-                setTextOn(context.getString(R.string.label_increase)); // CREDIT
-                break;
-            case INCOME:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_charge)); // DEBIT
-                setTextOn(context.getString(R.string.label_income)); // CREDIT
-                break;
-            case EXPENSE:
-                setTextOff(context.getString(R.string.label_expense)); // DEBIT
-                setTextOn(context.getString(R.string.label_rebate)); // CREDIT
-                break;
-            case PAYABLE:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_payment)); // DEBIT
-                setTextOn(context.getString(R.string.label_bill)); // CREDIT
-                break;
-            case RECEIVABLE:
-                setTextOff(context.getString(R.string.label_invoice)); // DEBIT
-                setTextOn(context.getString(R.string.label_payment)); // CREDIT
-                break;
-            case STOCK:
-            case MUTUAL:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_buy)); // DEBIT
-                setTextOn(context.getString(R.string.label_sell)); // CREDIT
-                break;
-            case CURRENCY:
-            case ROOT:
-            default:
-                // #876 Change according to GnuCash on Windows
-                setTextOff(context.getString(R.string.label_debit)); // DEBIT
-                setTextOn(context.getString(R.string.label_credit)); // CREDIT
-                break;
-        }
+        setTextOff(AccountTypeUtils.getLabelDebit(mAccountType)); // DEBIT
+        setTextOn(AccountTypeUtils.getLabelCredit(mAccountType)); // CREDIT
 
         //
         // Set switch text and color
         //
 
-        setSwitchTextAndColor(isChecked());
+        setWidgetTextColor(isChecked());
 
         invalidate();
     }
@@ -221,7 +171,15 @@ public class TransactionTypeSwitch extends SwitchCompat {
                : TransactionType.DEBIT;
     }
 
-    private void setSwitchTextAndColor(final boolean isCredit) {
+    /**
+     * Set the text color of the 3 views of the widget
+     * according to is a Credit amount
+     * and the Account type
+     *
+     * @param isCredit
+     *      true if amount is negative
+     */
+    private void setWidgetTextColor(final boolean isCredit) {
 
         //
         // Set switch text
@@ -286,7 +244,7 @@ public class TransactionTypeSwitch extends SwitchCompat {
             // Set switch text and color
             //
 
-            setSwitchTextAndColor(isCredit);
+            setWidgetTextColor(isCredit);
 
             //
             // Call other listeners

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -237,8 +237,7 @@ public class TransactionTypeSwitch extends SwitchCompat {
         // Set text color of views
         //
 
-        @ColorInt final int color = AccountType.getAmountColor(isCredit,
-                                                               getAccountType());
+        @ColorInt final int color = getAccountType().getAmountColor(isCredit);
 
         TransactionTypeSwitch.this.setTextColor(color);
         mAmountEditText.setTextColor(color);

--- a/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/TransactionTypeSwitch.java
@@ -211,7 +211,10 @@ public class TransactionTypeSwitch extends SwitchCompat {
 
         @ColorInt final int color = getAccountType().getAmountColor(isCredit);
 
+        // Set switch color
         TransactionTypeSwitch.this.setTextColor(color);
+
+        // Set Currency color
         mAmountEditText.setTextColor(color);
         mCurrencyTextView.setTextColor(color);
     }

--- a/app/src/main/java/org/gnucash/android/util/BookUtils.java
+++ b/app/src/main/java/org/gnucash/android/util/BookUtils.java
@@ -25,7 +25,9 @@ public class BookUtils {
      * @param bookUID GUID of the book to be loaded
      */
     public static void loadBook(@NonNull String bookUID){
+
         activateBook(bookUID);
+
         AccountsActivity.start(GnuCashApplication.getAppContext());
     }
 }

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -25,6 +25,7 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:background="?attr/colorPrimary"
@@ -34,10 +35,12 @@
             android:gravity="bottom"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light" >
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
+
                 <TextView android:id="@+id/trn_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -64,94 +67,111 @@
                     android:textColor="@android:color/white"
                     tools:text="Expenses:Computer"/>
             </LinearLayout>
+
         </android.support.v7.widget.Toolbar>
 
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent">
-        <TableLayout android:id="@+id/fragment_transaction_details"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/dialog_padding"
-            android:layout_marginTop="20dp"
-            android:stretchColumns="1"
-            android:orientation="vertical" >
 
-            <TableRow android:layout_width="match_parent"
+            <TableLayout
+                android:id="@+id/fragment_transaction_details"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:weightSum="5"
-                android:paddingTop="5dp"
-                android:paddingBottom="5dp"
-                android:layout_marginLeft="6dp">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_weight="2"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_vertical|right"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:text="@string/account_balance"
-                    android:textColor="@android:color/black" />
-
-                <TextView
-                    android:id="@+id/balance_debit"
-                    android:layout_width="0dp"
-                    android:layout_weight="1.5"
-                    android:layout_height="wrap_content"
-                    android:gravity="right"
-                    android:layout_gravity="center"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    tools:text="$ 2000"
-                    android:textColor="@android:color/black" />
-
-                <TextView
-                    android:id="@+id/balance_credit"
-                    android:layout_width="0dp"
-                    android:layout_weight="1.5"
-                    android:layout_height="wrap_content"
-                    android:gravity="right"
-                    android:layout_gravity="center"
-                    android:textSize="16sp"
-                    android:textStyle="bold"
-                    tools:text="$ 2000"
-                    android:textColor="@android:color/black" />
-            </TableRow>
-
-            <TableRow android:id="@+id/row_time_and_date"
+                android:padding="@dimen/dialog_padding"
                 android:layout_marginTop="20dp"
-                style="@style/FormRow" >
+                android:stretchColumns="1"
+                android:orientation="vertical">
 
-                <ImageView style="@style/FormIcon"
-                    android:src="@drawable/ic_action_time"/>
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:weightSum="5"
+                    android:paddingTop="5dp"
+                    android:paddingBottom="5dp"
+                    android:layout_marginLeft="6dp">
 
-                <TextView android:id="@+id/trn_time_and_date"
-                    style="@style/TransactionInfo" />
-            </TableRow>
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_weight="2"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical|right"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:text="@string/account_balance"
+                        android:textColor="@android:color/black" />
 
-            <TableRow android:id="@+id/row_trn_notes"
-                style="@style/FormRow">
-                <ImageView style="@style/FormIcon"
-                    android:src="@drawable/ic_action_sort_by_size"/>
+                    <TextView
+                        android:id="@+id/balance_debit"
+                        android:layout_width="0dp"
+                        android:layout_weight="1.5"
+                        android:layout_height="wrap_content"
+                        android:gravity="right"
+                        android:layout_gravity="center"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        tools:text="$ 2000"
+                        android:textColor="@android:color/black" />
 
-                <TextView android:id="@+id/trn_notes"
-                    style="@style/TransactionInfo" />
-            </TableRow>
+                    <TextView
+                        android:id="@+id/balance_credit"
+                        android:layout_width="0dp"
+                        android:layout_weight="1.5"
+                        android:layout_height="wrap_content"
+                        android:gravity="right"
+                        android:layout_gravity="center"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        tools:text="$ 2000"
+                        android:textColor="@android:color/black" />
+                </TableRow>
 
-            <TableRow android:id="@+id/row_trn_recurrence"
-                style="@style/FormRow">
+                <TableRow
+                    android:id="@+id/row_time_and_date"
+                    android:layout_marginTop="20dp"
+                    style="@style/FormRow">
 
-                <ImageView style="@style/FormIcon"
-                    android:src="@drawable/ic_action_rotate_right"/>
+                    <ImageView
+                        style="@style/FormIcon"
+                        android:src="@drawable/ic_action_time" />
 
-                <TextView android:id="@+id/trn_recurrence"
-                    style="@style/TransactionInfo" />
-            </TableRow>
+                    <TextView
+                        android:id="@+id/trn_time_and_date"
+                        style="@style/TransactionInfo" />
+                </TableRow>
 
-        </TableLayout>
+                <TableRow
+                    android:id="@+id/row_trn_notes"
+                    style="@style/FormRow">
+
+                    <ImageView
+                        style="@style/FormIcon"
+                        android:src="@drawable/ic_action_sort_by_size" />
+
+                    <TextView
+                        android:id="@+id/trn_notes"
+                        style="@style/TransactionInfo" />
+                </TableRow>
+
+                <TableRow
+                    android:id="@+id/row_trn_recurrence"
+                    style="@style/FormRow">
+
+                    <ImageView
+                        style="@style/FormIcon"
+                        android:src="@drawable/ic_action_rotate_right" />
+
+                    <TextView
+                        android:id="@+id/trn_recurrence"
+                        style="@style/TransactionInfo" />
+                </TableRow>
+
+            </TableLayout>
+
         </ScrollView>
+
     </LinearLayout>
+
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_edit_transaction"
         android:layout_height="40dp"

--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -61,7 +61,7 @@
                     android:layout_marginLeft="8dp"
                     android:layout_marginEnd="8dp"
                     android:layout_marginRight="8dp"
-                    android:maxLines="1"
+                    android:singleLine="true"
                     android:ellipsize="start"
                     android:textStyle="italic"
                     android:textColor="@android:color/white"
@@ -82,6 +82,22 @@
                 android:layout_marginTop="20dp"
                 android:stretchColumns="1"
                 android:orientation="vertical">
+
+                <TableRow
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="20dp"
+                    android:paddingBottom="20dp"
+                    >
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_span="3"
+                        android:background="@color/theme_accent"
+                        />
+
+                </TableRow>
 
                 <TableRow
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_transaction_form.xml
+++ b/app/src/main/res/layout/fragment_transaction_form.xml
@@ -75,12 +75,6 @@
                     android:textIsSelectable="true"
                     gnucash:keyboardKeysLayout="@xml/calculator_keyboard"/>
 
-                <ImageView android:id="@+id/btn_split_editor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:contentDescription="Open split editor"
-                    android:src="@drawable/content_split_holo_light" />
-
                 <org.gnucash.android.ui.util.widget.TransactionTypeSwitch
                     android:id="@+id/input_transaction_type"
                     android:layout_width="0dp"
@@ -92,6 +86,12 @@
                     android:textColor="@color/debit_red"
                     android:textSize="14sp"
                     android:checked="true"/>
+
+                <ImageView android:id="@+id/btn_split_editor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="Open split editor"
+                    android:src="@drawable/content_split_holo_light" />
 
             </TableRow>
             <View style="@style/Divider" />

--- a/app/src/main/res/layout/item_split_entry.xml
+++ b/app/src/main/res/layout/item_split_entry.xml
@@ -20,10 +20,12 @@ limitations under the License.
         android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:orientation="vertical">
+
     <LinearLayout
             android:layout_width="match_parent"
             android:minHeight="40dp"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
         <TextView
                 android:id="@+id/split_currency_symbol"
@@ -67,19 +69,26 @@ limitations under the License.
         <ImageView
             android:id="@+id/btn_remove_split"
             android:layout_width="48dp"
-            android:layout_height="48dp"
+            android:layout_height="match_parent"
             android:background="?attr/selectableItemBackgroundBorderless"
-            android:paddingTop="6dp"
+            android:paddingTop="0dp"
             android:paddingRight="6dp"
             android:paddingLeft="22dp"
-            android:paddingBottom="22dp"
+            android:paddingBottom="0dp"
             android:src="@drawable/ic_close_black_24dp"
             tools:ignore="ContentDescription" />
+
     </LinearLayout>
+
+    <Spinner
+        android:id="@+id/input_accounts_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
 
     <android.support.design.widget.TextInputLayout
         android:id="@+id/name_text_input_layout"
         android:layout_width="match_parent"
+        android:layout_marginTop="6dp"
         android:layout_marginLeft="7dp"
         android:layout_height="wrap_content">
         <EditText android:id="@+id/input_split_memo"
@@ -92,11 +101,6 @@ limitations under the License.
             android:background="@android:color/transparent"
             android:gravity="top" />
     </android.support.design.widget.TextInputLayout>
-
-    <Spinner
-            android:id="@+id/input_accounts_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
 
     <!-- Only serves to store the split UID for background processing. Not relevant to user-->
     <TextView android:id="@+id/split_uid"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -446,4 +446,6 @@
   <string name="label_select_destination_after_export">Sélectionnez la destination une fois l\'exportation terminée</string>
   <string name="label_dropbox_export_destination">Exporter dans le dossier \'/Apps/GnuCash Android/\' sur Dropbox</string>
   <string name="title_section_preferences">Préférences</string>
+  <string name="title_display_negative_signum_in_splits">Afficher le signe - dans les transactions splittées</string>
+  <string name="summary_display_negative_signum_in_splits">Autoriser l\'affichage du signe - même lorsque le bouton Débit/Crédit est affiché</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -109,7 +109,7 @@
   <string name="summary_default_export_email">Email par défaut pour les exports. Vous pourrez toujours le changer lors de votre prochain export.</string>
   <string name="summary_use_double_entry">Toutes les transactions seront un transfert d’un compte à un autre</string>
   <string name="title_use_double_entry">Activer la Double entrée</string>
-  <string name="account_balance">Solde à la date indiquée ci-dessous</string>
+  <string name="account_balance">Solde du Compte à la date indiquée ci-dessous</string>
   <string name="toast_no_account_name_entered">Entrer un nom de compte pour créer un compte</string>
   <string name="label_account_currency">Monnaie</string>
   <string name="label_parent_account">Compte parent</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,7 +95,7 @@
   <string name="title_transaction_preferences">Préférences des transactions</string>
   <string name="title_account_preferences">Préférences du compte</string>
   <string name="title_default_transaction_type">Type de transaction par défaut</string>
-  <string name="summary_default_transaction_type">Le type de transaction à utiliser par défaut, CRÉDIT ou DÉBIT</string>
+  <string name="summary_default_transaction_type">CRÉDIT</string>
   <string-array name="transaction_types">
     <item>CRÉDIT</item>
     <item>DÉBIT</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -452,4 +452,5 @@
   <string name="title_section_preferences">Préférences</string>
   <string name="title_display_negative_signum_in_splits">Afficher le signe - dans les transactions splittées</string>
   <string name="summary_display_negative_signum_in_splits">Autoriser l\'affichage du signe - même lorsque le bouton Débit/Crédit est affiché</string>
+  <string name="toast_must_be_on_account_page_to_change_book">Vous devez être sur la page des Comptes pour pouvoir changer de Comptabilité</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -109,7 +109,7 @@
   <string name="summary_default_export_email">Email par défaut pour les exports. Vous pourrez toujours le changer lors de votre prochain export.</string>
   <string name="summary_use_double_entry">Toutes les transactions seront un transfert d’un compte à un autre</string>
   <string name="title_use_double_entry">Activer la Double entrée</string>
-  <string name="account_balance">Solde</string>
+  <string name="account_balance">Solde à la date indiquée ci-dessous</string>
   <string name="toast_no_account_name_entered">Entrer un nom de compte pour créer un compte</string>
   <string name="label_account_currency">Monnaie</string>
   <string name="label_parent_account">Compte parent</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,10 +95,14 @@
   <string name="title_transaction_preferences">Préférences des transactions</string>
   <string name="title_account_preferences">Préférences du compte</string>
   <string name="title_default_transaction_type">Type de transaction par défaut</string>
-  <string name="summary_default_transaction_type">CRÉDIT</string>
+  <string name="summary_default_transaction_type">@string/label_credit</string>
+  <string name="label_use_account_usual_balance_expense_mode">Utiliser le Solde habituel du Compte (sauf pour les Actifs)</string>
+  <string name="label_use_account_usual_balance_income_mode">Utiliser le Solde habituel du Compte</string>
   <string-array name="transaction_types">
-    <item>CRÉDIT</item>
-    <item>DÉBIT</item>
+  <item>@string/label_use_account_usual_balance_expense_mode</item>
+  <item>@string/label_use_account_usual_balance_income_mode</item>
+    <item>@string/label_debit</item>
+    <item>@string/label_credit</item>
   </string-array>
   <string name="msg_delete_all_transactions_confirmation">Êtes vous sûre de vouloir supprimer TOUTES les transactions ?</string>
   <string name="msg_delete_transaction_confirmation">Êtes vous sûre de vouloir supprimer cette transaction ?</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,8 +17,8 @@
 <resources>
     <color name="debit_red">#c11b17</color>
     <color name="credit_green">#4cc552</color>
-    <color name="debit_expense_income">#FF9800</color>
-    <color name="credit_expense_income">#00BCD4</color>
+    <color name="debit_expense_income">#F4511E</color>
+    <color name="credit_expense_income">#00897B</color>
     <color name="light_gray">#FFAAAAAA</color>
     <color name="transparent">#00000000</color>
     <color name="abs__holo_blue_light">#ff33b5e5</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,8 +15,8 @@
  limitations under the License.
 -->
 <resources>
-    <color name="debit_equity">#F4511E</color>
-    <color name="credit_equity">#00897B</color>
+    <color name="debit_equity">#8E24AA</color>
+    <color name="credit_equity">#1E88E5</color>
     <color name="debit_red">#c11b17</color>
     <color name="credit_green">#4cc552</color>
     <color name="debit_expense_income">#F4511E</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,8 @@
 <resources>
     <color name="debit_red">#c11b17</color>
     <color name="credit_green">#4cc552</color>
+    <color name="debit_expense_income">#FF9800</color>
+    <color name="credit_expense_income">#00BCD4</color>
     <color name="light_gray">#FFAAAAAA</color>
     <color name="transparent">#00000000</color>
     <color name="abs__holo_blue_light">#ff33b5e5</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,8 @@
  limitations under the License.
 -->
 <resources>
+    <color name="debit_equity">#F4511E</color>
+    <color name="credit_equity">#00897B</color>
     <color name="debit_red">#c11b17</color>
     <color name="credit_green">#4cc552</color>
     <color name="debit_expense_income">#F4511E</color>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -6,7 +6,7 @@
     <string name="key_enable_passcode" translatable="false">enable_passcode</string>
     <string name="key_change_passcode" translatable="false">change_passcode</string>
     <string name="key_about_gnucash" translatable="false">about_gnucash</string>
-    <string name="key_default_transaction_type_switch" translatable="false">default_transaction_type_switch</string>
+    <string name="key_default_transaction_type" translatable="false">default_transaction_type</string>
     <string name="key_export_all_transactions" translatable="false">export_all_transactions</string>
     <string name="key_delete_transactions_after_export" translatable="false">delete_transactions_after_export</string>
     <string name="key_default_export_email" translatable="false">export_email_target</string>
@@ -37,9 +37,11 @@
     <string name="key_prefs_header_general">prefs_header_general</string>
     <string name="key_dropbox_access_token">dropbox_access_token</string>
     <string name="key_backup_location">backup_location</string>
-    <string-array name="key_transaction_type_values" translatable="false">
-        <item>CREDIT</item>
-        <item>DEBIT</item>
+    <string-array name="key_transaction_types" translatable="false">
+        <item>KEY_USE_NORMAL_BALANCE_EXPENSE</item>
+        <item>KEY_USE_NORMAL_BALANCE_INCOME</item>
+        <item>KEY_DEBIT</item>
+        <item>KEY_CREDIT</item>
     </string-array>
     <string-array name="key_account_type_entries" translatable="false">
         <item>CASH</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -33,6 +33,7 @@
     <string name="key_use_account_color" translatable="false">use_account_color</string>
     <string name="key_last_export_destination">last_export_destination</string>
     <string name="key_use_compact_list">use_compact_list</string>
+    <string name="key_display_negative_signum_in_splits" translatable="false">key_display_negative_signum_in_splits</string>
     <string name="key_prefs_header_general">prefs_header_general</string>
     <string name="key_dropbox_access_token">dropbox_access_token</string>
     <string name="key_backup_location">backup_location</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -6,7 +6,7 @@
     <string name="key_enable_passcode" translatable="false">enable_passcode</string>
     <string name="key_change_passcode" translatable="false">change_passcode</string>
     <string name="key_about_gnucash" translatable="false">about_gnucash</string>
-    <string name="key_default_transaction_type" translatable="false">default_transaction_type</string>
+    <string name="key_default_transaction_type_switch" translatable="false">default_transaction_type_switch</string>
     <string name="key_export_all_transactions" translatable="false">export_all_transactions</string>
     <string name="key_delete_transactions_after_export" translatable="false">delete_transactions_after_export</string>
     <string name="key_default_export_email" translatable="false">export_email_target</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -439,6 +439,7 @@
         <item>INCOME</item>
     </string-array>
 
+    <string name="toast_must_be_on_account_page_to_change_book">You must be on the Account Page to change Book</string>
     <string name="toast_connected_to_google_drive">Connected to Google Drive</string>
     <string name="toast_unable_to_connect_to_google_drive">Unable to connect to Google Drive</string>
     <string name="toast_enter_amount_to_split">Please enter an amount to split</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
 	<string name="summary_default_export_email">The default email address to send exports to. You can still change this when you export.</string>
     <string name="summary_use_double_entry">All transactions will be a transfer from one account to another</string>
 	<string name="title_use_double_entry">Activate Double Entry</string>
-	<string name="account_balance">Balance at date below</string>
+	<string name="account_balance">Account Balance at Date below</string>
 	<string name="toast_no_account_name_entered">Enter an account name to create an account</string>
 	<string name="label_account_currency">Currency</string>
 	<string name="label_parent_account">Parent account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,10 +95,14 @@
 	<string name="title_transaction_preferences">Transaction Preferences</string>
 	<string name="title_account_preferences">Account Preferences</string>
 	<string name="title_default_transaction_type">Default Transaction Type</string>
-	<string name="summary_default_transaction_type">CREDIT</string>
+	<string name="summary_default_transaction_type">@string/label_credit</string>
+    <string name="label_use_account_usual_balance_expense_mode">Use Account usual Balance (Exept for Assets)</string>
+    <string name="label_use_account_usual_balance_income_mode">Use Account usual Balance</string>
 	<string-array name="transaction_types">
-		<item>CREDIT</item>
-		<item>DEBIT</item>
+        <item>@string/label_use_account_usual_balance_expense_mode</item>
+        <item>@string/label_use_account_usual_balance_income_mode</item>
+        <item>@string/label_debit</item>
+        <item>@string/label_credit</item>
 	</string-array>
 	<string name="msg_delete_all_transactions_confirmation">Are you sure you want to delete ALL transactions?</string>
 	<string name="msg_delete_transaction_confirmation">Are you sure you want to delete this transaction?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
 	<string name="title_transaction_preferences">Transaction Preferences</string>
 	<string name="title_account_preferences">Account Preferences</string>
 	<string name="title_default_transaction_type">Default Transaction Type</string>
-	<string name="summary_default_transaction_type">The type of transaction to use by default, CREDIT or DEBIT</string>
+	<string name="summary_default_transaction_type">CREDIT</string>
 	<string-array name="transaction_types">
 		<item>CREDIT</item>
 		<item>DEBIT</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,6 +370,8 @@
     <string name="title_budgets">Budgets</string>
     <string name="title_use_compact_list">Enable compact view</string>
     <string name="summary_use_compact_list">Enable to always use compact view for transactions list</string>
+    <string name="title_display_negative_signum_in_splits">Display negative signum in splits</string>
+    <string name="summary_display_negative_signum_in_splits">Enable to display negative signum amount even when debit/credit toggle button is displayed</string>
     <string name="error_invalid_exchange_rate">Invalid exchange rate</string>
     <string name="sample_exchange_rate">e.g. 1 %1$s = x.xx %2$s</string>
     <string name="error_invalid_amount">Invalid amount</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,7 +109,7 @@
 	<string name="summary_default_export_email">The default email address to send exports to. You can still change this when you export.</string>
     <string name="summary_use_double_entry">All transactions will be a transfer from one account to another</string>
 	<string name="title_use_double_entry">Activate Double Entry</string>
-	<string name="account_balance">Balance</string>
+	<string name="account_balance">Balance at date below</string>
 	<string name="toast_no_account_name_entered">Enter an account name to create an account</string>
 	<string name="label_account_currency">Currency</string>
 	<string name="label_parent_account">Parent account</string>

--- a/app/src/main/res/xml/fragment_general_preferences.xml
+++ b/app/src/main/res/xml/fragment_general_preferences.xml
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
     <PreferenceCategory android:title="@string/title_passcode_preferences">
+
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:key="@string/key_display_negative_signum_in_splits"
+            android:title="@string/title_display_negative_signum_in_splits"
+            android:summary="@string/summary_display_negative_signum_in_splits"
+            />
+
         <CheckBoxPreference android:key="@string/key_enable_passcode"
             android:title="@string/title_enable_passcode"/>
+
         <Preference android:key="@string/key_change_passcode"
             android:title="@string/title_change_passcode"
             android:dependency="@string/key_enable_passcode" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/title_report_prefs">
+
         <CheckBoxPreference android:key="@string/key_use_account_color"
             android:title="@string/title_use_account_color"
             android:summary="@string/summary_use_account_color" />
-    </PreferenceCategory>
 
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/fragment_general_preferences.xml
+++ b/app/src/main/res/xml/fragment_general_preferences.xml
@@ -3,12 +3,6 @@
 
     <PreferenceCategory android:title="@string/title_passcode_preferences">
 
-        <android.support.v7.preference.SwitchPreferenceCompat
-            android:key="@string/key_display_negative_signum_in_splits"
-            android:title="@string/title_display_negative_signum_in_splits"
-            android:summary="@string/summary_display_negative_signum_in_splits"
-            />
-
         <CheckBoxPreference android:key="@string/key_enable_passcode"
             android:title="@string/title_enable_passcode"/>
 

--- a/app/src/main/res/xml/fragment_transaction_preferences.xml
+++ b/app/src/main/res/xml/fragment_transaction_preferences.xml
@@ -15,16 +15,18 @@
  limitations under the License.
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <ListPreference android:title="@string/title_default_transaction_type"
-        android:entryValues="@array/key_transaction_type_values"
-        android:entries="@array/transaction_types"
-        android:key="@string/key_default_transaction_type"
-        android:summary="@string/summary_default_transaction_type"/>
 
-    <android.support.v7.preference.SwitchPreferenceCompat android:summary="@string/summary_use_double_entry"
-                                                          android:key="@string/key_use_double_entry"
-                                                          android:defaultValue="true"
-                                                          android:title="@string/title_use_double_entry"/>
+    <android.support.v7.preference.SwitchPreferenceCompat
+        android:key="@string/key_default_transaction_type_switch"
+        android:title="@string/title_display_negative_signum_in_splits"
+        android:summary="@string/title_display_negative_signum_in_splits"
+        />
+
+    <android.support.v7.preference.SwitchPreferenceCompat
+        android:key="@string/key_use_double_entry"
+        android:title="@string/title_use_double_entry"
+        android:summary="@string/summary_use_double_entry"
+        android:defaultValue="true" />
 
     <android.support.v7.preference.SwitchPreferenceCompat
         android:summary="@string/summary_use_compact_list"
@@ -32,10 +34,17 @@
         android:dependency="@string/key_use_double_entry"
         android:title="@string/title_use_compact_list"/>
 
+    <android.support.v7.preference.SwitchPreferenceCompat
+        android:key="@string/key_display_negative_signum_in_splits"
+        android:title="@string/title_display_negative_signum_in_splits"
+        android:summary="@string/summary_display_negative_signum_in_splits"
+        android:defaultValue="false" />
+
     <android.support.v7.preference.SwitchPreferenceCompat android:summary="@string/summary_save_opening_balances"
         android:key="@string/key_save_opening_balances"
         android:defaultValue="false"
         android:title="@string/title_save_opening_balances" />
+
     <Preference android:key="@string/key_delete_all_transactions"
         android:summary="@string/summary_delete_all_transactions"
         android:title="@string/title_delete_all_transactions" />

--- a/app/src/main/res/xml/fragment_transaction_preferences.xml
+++ b/app/src/main/res/xml/fragment_transaction_preferences.xml
@@ -18,8 +18,8 @@
 
     <android.support.v7.preference.SwitchPreferenceCompat
         android:key="@string/key_default_transaction_type_switch"
-        android:title="@string/title_display_negative_signum_in_splits"
-        android:summary="@string/title_display_negative_signum_in_splits"
+        android:title="@string/title_default_transaction_type"
+        android:summary="@string/summary_default_transaction_type"
         />
 
     <android.support.v7.preference.SwitchPreferenceCompat

--- a/app/src/main/res/xml/fragment_transaction_preferences.xml
+++ b/app/src/main/res/xml/fragment_transaction_preferences.xml
@@ -16,10 +16,12 @@
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <android.support.v7.preference.SwitchPreferenceCompat
-        android:key="@string/key_default_transaction_type_switch"
+    <ListPreference
+        android:key="@string/key_default_transaction_type"
         android:title="@string/title_default_transaction_type"
         android:summary="@string/summary_default_transaction_type"
+        android:entryValues="@array/key_transaction_types"
+        android:entries="@array/transaction_types"
         />
 
     <android.support.v7.preference.SwitchPreferenceCompat


### PR DESCRIPTION
Hi,

This is one of my main contribution to GnucashAndroid.

It corrects #876, but also lots of other errors like 
- Avoid crashing when changing book while in a transaction list by displaying a toast message
- Remove changes made in #586 
- Factorize balance display
- Use distinct colors for INCOME/EXPENSE and others balance
- Add Preference to not display negative signum in transaction form (which may be confusing for debts)
- Invert Memo and Account Spinner
- In Transaction form, select amount first
- Correct ASSET switch button labels like in GnuCash PC
- Enhance Transaction Detail
- Reports (balance...)
...

You can see all my contributions together on the following branch : 
https://github.com/JeanGarf/gnucash-android/tree/tw_develop

See you,
