### PR TITLE
Fix #892 - Favourite Accounts not showing up Dynamically

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -157,16 +157,16 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
             if (currentFragment == null) {
                 switch (i) {
                     case INDEX_RECENT_ACCOUNTS_FRAGMENT:
-                        currentFragment = AccountsListFragment.newInstance(AccountsListFragment.DisplayMode.RECENT);
+                        currentFragment = AccountsListFragment.newInstance(this, AccountsListFragment.DisplayMode.RECENT);
                         break;
 
                     case INDEX_FAVORITE_ACCOUNTS_FRAGMENT:
-                        currentFragment = AccountsListFragment.newInstance(AccountsListFragment.DisplayMode.FAVORITES);
+                        currentFragment = AccountsListFragment.newInstance(this, AccountsListFragment.DisplayMode.FAVORITES);
                         break;
 
                     case INDEX_TOP_LEVEL_ACCOUNTS_FRAGMENT:
                     default:
-                        currentFragment = AccountsListFragment.newInstance(AccountsListFragment.DisplayMode.TOP_LEVEL);
+                        currentFragment = AccountsListFragment.newInstance(this, AccountsListFragment.DisplayMode.TOP_LEVEL);
                         break;
                 }
                 mFragmentPageReferenceMap.put(i, currentFragment);
@@ -198,6 +198,11 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
         @Override
         public int getCount() {
             return DEFAULT_NUM_PAGES;
+        }
+
+        @Override
+        public int getItemPosition(Object object){
+            return POSITION_NONE;
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -25,9 +25,9 @@ import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
@@ -85,6 +85,7 @@ public class AccountsListFragment extends Fragment implements
     AccountRecyclerAdapter mAccountRecyclerAdapter;
     @BindView(R.id.account_recycler_view)  EmptyRecyclerView mRecyclerView;
     @BindView(R.id.empty_view) TextView mEmptyTextView;
+    private FragmentPagerAdapter accountViewPagerAdapter;
 
     /**
      * Describes the kinds of accounts that should be loaded in the accounts list.
@@ -135,9 +136,10 @@ public class AccountsListFragment extends Fragment implements
      */
     private android.support.v7.widget.SearchView mSearchView;
 
-    public static AccountsListFragment newInstance(DisplayMode displayMode){
+    public static AccountsListFragment newInstance(FragmentPagerAdapter accountViewPagerAdapter, DisplayMode displayMode){
         AccountsListFragment fragment = new AccountsListFragment();
         fragment.mDisplayMode = displayMode;
+        fragment.accountViewPagerAdapter = accountViewPagerAdapter;
         return fragment;
     }
 
@@ -557,6 +559,8 @@ public class AccountsListFragment extends Fragment implements
                     holder.favoriteStatus.setImageResource(drawableResource);
                     if (mDisplayMode == DisplayMode.FAVORITES)
                         refresh();
+
+                    accountViewPagerAdapter.notifyDataSetChanged();
                 }
             });
 


### PR DESCRIPTION
I noticed that when favorite status button was being clicked, The viewpager was not getting updated. That's why the favorite tab was not adding accounts instantly.

So I called accountViewPagerAdapter.notifyDataSetChanged(); in onClick of Favorite Status Button so that every time button is clicked, every fragment gets updated with new data.