### PR TITLE
Fix #851 - Create Sub-accounts screen should have default currency same as parent, not app-default currency

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountFormFragment.java
@@ -430,6 +430,7 @@ public class AccountFormFragment extends Fragment {
             setAccountTypeSelection(parentAccountType);
             loadParentAccountList(parentAccountType);
             setParentAccountSelection(mAccountsDbAdapter.getID(mParentAccountUID));
+            setSelectedCurrency(mAccountsDbAdapter.getCurrencyCode(mParentAccountUID));
         }
 
     }


### PR DESCRIPTION
This is more like a feature rather than a fix. When creating a sub-account, It'll be helpful for the users if the default currency was the same as Parent's currency.